### PR TITLE
feat: Add LND wallet support to Python MCP

### DIFF
--- a/python/lightning-enable-mcp/README.md
+++ b/python/lightning-enable-mcp/README.md
@@ -114,6 +114,22 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
 }
 ```
 
+**Using LND:**
+```json
+{
+  "mcpServers": {
+    "lightning-enable": {
+      "command": "uvx",
+      "args": ["lightning-enable-mcp"],
+      "env": {
+        "LND_REST_HOST": "localhost:8080",
+        "LND_MACAROON_HEX": "your-admin-macaroon-in-hex"
+      }
+    }
+  }
+}
+```
+
 **Using NWC:**
 ```json
 {

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/lnd_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/lnd_wallet.py
@@ -1,0 +1,518 @@
+"""
+LND Wallet Client
+
+Implements Lightning wallet operations via LND's REST API.
+Connects directly to user's own Lightning node - ALWAYS returns preimage.
+
+This is the recommended wallet for L402 because:
+1. User controls their own node
+2. LND always returns preimage for payments
+3. Direct node access = lowest latency
+
+Configuration (environment variables or config file):
+- LND_REST_HOST: LND REST API host (e.g., "localhost:8080" or "127.0.0.1:8080")
+- LND_MACAROON_HEX: Admin macaroon in hex format (required for payments)
+- LND_SKIP_TLS_VERIFY: Set to "true" to skip TLS verification (dev only)
+
+To get your macaroon in hex format:
+- Linux/Mac: xxd -ps -c 1000 ~/.lnd/data/chain/bitcoin/mainnet/admin.macaroon
+- Windows PowerShell: [System.BitConverter]::ToString(
+      [System.IO.File]::ReadAllBytes("$env:USERPROFILE\\AppData\\Local\\Lnd\\data\\chain\\bitcoin\\mainnet\\admin.macaroon")
+  ) -replace '-',''
+"""
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore
+
+logger = logging.getLogger("lightning-enable-mcp.lnd")
+
+
+class LndError(Exception):
+    """Exception for LND-related errors."""
+    pass
+
+
+class LndPaymentError(LndError):
+    """Exception for payment failures."""
+    pass
+
+
+@dataclass
+class LndConfig:
+    """LND connection configuration."""
+    rest_host: str
+    macaroon_hex: str
+    skip_tls_verify: bool = False
+
+
+@dataclass
+class LndOnChainResult:
+    """On-chain payment result from LND."""
+    success: bool
+    payment_id: str | None = None
+    txid: str | None = None
+    state: str | None = None
+    amount_sats: int | None = None
+    fee_sats: int | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+    @classmethod
+    def succeeded(
+        cls,
+        payment_id: str,
+        state: str,
+        amount_sats: int,
+        fee_sats: int = 0,
+        txid: str | None = None,
+    ) -> "LndOnChainResult":
+        return cls(
+            success=True,
+            payment_id=payment_id,
+            txid=txid,
+            state=state,
+            amount_sats=amount_sats,
+            fee_sats=fee_sats,
+        )
+
+    @classmethod
+    def failed(cls, code: str, message: str) -> "LndOnChainResult":
+        return cls(success=False, error_code=code, error_message=message)
+
+
+class LndWallet:
+    """
+    LND wallet client for Lightning payments via LND REST API.
+
+    Provides the same core interface as NWCWallet, StrikeWallet, and OpenNodeWallet.
+    LND always returns the preimage for outgoing payments, making it ideal for L402.
+
+    LND REST API notes:
+    - Numbers are returned as strings in JSON (e.g., "1000" not 1000)
+    - Preimage and r_hash are returned as base64, must convert to hex
+    - Auth via Grpc-Metadata-macaroon header with hex-encoded macaroon
+    """
+
+    def __init__(
+        self,
+        rest_host: str,
+        macaroon_hex: str,
+        skip_tls_verify: bool = False,
+    ) -> None:
+        """
+        Initialize LND wallet.
+
+        Args:
+            rest_host: LND REST API host (e.g., "localhost:8080")
+            macaroon_hex: Admin macaroon in hex format
+            skip_tls_verify: Skip TLS certificate verification (dev only)
+        """
+        if httpx is None:
+            raise ImportError(
+                "httpx is required for LndWallet. Install with: pip install httpx"
+            )
+
+        self.config = LndConfig(
+            rest_host=rest_host,
+            macaroon_hex=macaroon_hex,
+            skip_tls_verify=skip_tls_verify,
+        )
+        self._client: httpx.AsyncClient | None = None
+        self._connected = False
+
+    @property
+    def is_configured(self) -> bool:
+        """Whether the wallet has valid configuration."""
+        return bool(self.config.rest_host) and bool(self.config.macaroon_hex)
+
+    @property
+    def provider_name(self) -> str:
+        """Return the provider name."""
+        return "LND"
+
+    async def connect(self) -> None:
+        """Initialize the HTTP client and verify connection."""
+        if self._connected:
+            return
+
+        # Determine base URL - add scheme if not present
+        host = self.config.rest_host
+        if not host.startswith("https://") and not host.startswith("http://"):
+            host = f"https://{host}"
+
+        base_url = f"{host}/v1/"
+
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            headers={
+                "Grpc-Metadata-macaroon": self.config.macaroon_hex,
+                "Content-Type": "application/json",
+            },
+            timeout=60.0,
+            verify=not self.config.skip_tls_verify,
+        )
+
+        self._connected = True
+        logger.info(f"LND wallet connected to {self.config.rest_host}")
+
+    async def disconnect(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            await self._client.aclose()
+        self._connected = False
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        json_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Make an API request to LND REST API.
+
+        Args:
+            method: HTTP method (GET, POST)
+            path: API path (relative to /v1/)
+            json_data: Request body data
+
+        Returns:
+            Response data dict
+
+        Raises:
+            LndError: If the request fails
+        """
+        if not self._connected or not self._client:
+            await self.connect()
+
+        try:
+            response = await self._client.request(
+                method=method,
+                url=path,
+                json=json_data,
+            )
+
+            if response.status_code >= 400:
+                error_text = response.text
+                raise LndError(f"LND API error ({response.status_code}): {error_text}")
+
+            if response.status_code == 204:
+                return {}
+
+            return response.json()
+
+        except httpx.RequestError as e:
+            raise LndError(f"Failed to connect to LND: {e!s}") from e
+
+    async def pay_invoice(self, bolt11: str, amount_sats: int | None = None) -> str:
+        """
+        Pay a Lightning invoice via LND.
+
+        LND ALWAYS returns the preimage - this is why it's ideal for L402.
+
+        POST /v1/channels/transactions
+        Request: {"payment_request": bolt11}
+        Response: {"payment_preimage": "<base64>", "payment_error": "", "payment_hash": "<base64>"}
+
+        Args:
+            bolt11: BOLT11 invoice string
+            amount_sats: Unused - LND uses the invoice amount
+
+        Returns:
+            Payment preimage as hex string
+
+        Raises:
+            LndPaymentError: If payment fails
+        """
+        if not self.is_configured:
+            raise LndPaymentError(
+                "LND not configured. Set LND_REST_HOST and LND_MACAROON_HEX environment variables."
+            )
+
+        logger.info(f"Paying invoice via LND: {bolt11[:30]}...")
+
+        try:
+            request_body = {"payment_request": bolt11}
+            result = await self._request("POST", "channels/transactions", request_body)
+
+            # Check for payment error
+            payment_error = result.get("payment_error")
+            if payment_error:
+                logger.error(f"LND payment error: {payment_error}")
+                raise LndPaymentError(f"Payment failed: {payment_error}")
+
+            # LND returns preimage as base64 - convert to hex
+            payment_preimage_b64 = result.get("payment_preimage")
+            if payment_preimage_b64:
+                preimage_bytes = base64.b64decode(payment_preimage_b64)
+                preimage_hex = preimage_bytes.hex()
+                logger.info(f"LND payment succeeded! Preimage: {preimage_hex[:16]}...")
+                return preimage_hex
+
+            raise LndPaymentError("Payment succeeded but no preimage returned")
+
+        except LndError:
+            raise
+        except Exception as e:
+            raise LndPaymentError(f"Payment failed: {e!s}") from e
+
+    async def get_balance(self) -> int:
+        """
+        Get wallet Lightning channel balance in satoshis.
+
+        GET /v1/balance/channels
+        Response: {"local_balance": {"sat": "12345", "msat": "12345000"}, ...}
+
+        Note: LND returns numbers as strings.
+
+        Returns:
+            Balance in satoshis
+        """
+        if not self.is_configured:
+            raise LndError("LND not configured")
+
+        try:
+            result = await self._request("GET", "balance/channels")
+
+            # local_balance.sat is spendable Lightning balance
+            # LND returns numbers as strings
+            local_balance = result.get("local_balance", {})
+            balance_str = local_balance.get("sat", "0")
+            balance_sats = int(balance_str)
+
+            logger.info(f"LND balance: {balance_sats} sats")
+            return balance_sats
+
+        except LndError:
+            raise
+        except Exception as e:
+            raise LndError(f"Failed to get LND balance: {e!s}") from e
+
+    async def create_invoice(
+        self,
+        amount_sats: int,
+        memo: str | None = None,
+        expiry_secs: int = 3600,
+    ) -> dict[str, Any]:
+        """
+        Create a Lightning invoice via LND.
+
+        POST /v1/invoices
+        Request: {"value": sats, "memo": "...", "expiry": secs}
+        Response: {"r_hash": "<base64>", "payment_request": "lnbc..."}
+
+        Args:
+            amount_sats: Amount in satoshis
+            memo: Optional invoice memo/description
+            expiry_secs: Invoice expiry in seconds (default 3600)
+
+        Returns:
+            Dict with invoice_id (r_hash hex), bolt11 (payment_request), amount_sats, expires_at
+        """
+        if not self.is_configured:
+            raise LndError(
+                "LND not configured. Set LND_REST_HOST and LND_MACAROON_HEX environment variables."
+            )
+
+        logger.info(f"Creating LND invoice for {amount_sats} sats...")
+
+        request_body: dict[str, Any] = {
+            "value": str(amount_sats),
+            "memo": memo or "Lightning payment",
+            "expiry": str(expiry_secs),
+        }
+
+        result = await self._request("POST", "invoices", request_body)
+
+        payment_request = result.get("payment_request")
+        if not payment_request:
+            raise LndError("No invoice returned from LND")
+
+        # Convert r_hash from base64 to hex for invoice ID
+        r_hash_b64 = result.get("r_hash", "")
+        invoice_id = ""
+        if r_hash_b64:
+            r_hash_bytes = base64.b64decode(r_hash_b64)
+            invoice_id = r_hash_bytes.hex()
+
+        logger.info(f"LND invoice created: {invoice_id[:16]}...")
+
+        return {
+            "invoice_id": invoice_id,
+            "bolt11": payment_request,
+            "amount_sats": amount_sats,
+            "expires_at": datetime.now(timezone.utc).timestamp() + expiry_secs,
+        }
+
+    async def get_invoice_status(self, invoice_id: str) -> dict[str, Any]:
+        """
+        Check the status of an invoice.
+
+        GET /v1/invoice/{r_hash_hex}
+        Response: {"state": "OPEN|SETTLED|CANCELED", "value": "1000", "settle_date": "1234567890"}
+
+        Args:
+            invoice_id: Invoice ID (r_hash in hex)
+
+        Returns:
+            Dict with id, state (PENDING/PAID/CANCELLED), amount_sats, settled_at
+        """
+        if not self.is_configured:
+            raise LndError("LND not configured")
+
+        result = await self._request("GET", f"invoice/{invoice_id}")
+
+        # Map LND states to standard states
+        lnd_state = (result.get("state") or "UNKNOWN").upper()
+        state_map = {
+            "OPEN": "PENDING",
+            "SETTLED": "PAID",
+            "CANCELED": "CANCELLED",
+            "ACCEPTED": "PENDING",
+        }
+        state = state_map.get(lnd_state, lnd_state)
+
+        # Parse amount (LND returns as string)
+        value_str = result.get("value", "0")
+        amount_sats = int(value_str) if value_str else 0
+
+        # Parse settle date (LND returns as string unix timestamp)
+        settled_at = None
+        settle_date_str = result.get("settle_date")
+        if settle_date_str:
+            settle_ts = int(settle_date_str)
+            if settle_ts > 0:
+                settled_at = datetime.fromtimestamp(settle_ts, tz=timezone.utc).isoformat()
+
+        return {
+            "id": invoice_id,
+            "state": state,
+            "is_paid": state == "PAID",
+            "is_pending": state == "PENDING",
+            "amount_sats": amount_sats,
+            "settled_at": settled_at,
+        }
+
+    async def send_onchain(self, address: str, amount_sats: int) -> LndOnChainResult:
+        """
+        Send an on-chain Bitcoin payment via LND.
+
+        POST /v1/transactions
+        Request: {"addr": address, "amount": sats, "target_conf": 6}
+        Response: {"txid": "..."}
+
+        Args:
+            address: Bitcoin address (e.g., bc1q...)
+            amount_sats: Amount in satoshis
+
+        Returns:
+            LndOnChainResult with payment details
+        """
+        if not self.is_configured:
+            return LndOnChainResult.failed("NOT_CONFIGURED", "LND not configured")
+
+        if not address:
+            return LndOnChainResult.failed("INVALID_ADDRESS", "Bitcoin address is required")
+
+        if amount_sats <= 0:
+            return LndOnChainResult.failed("INVALID_AMOUNT", "Amount must be positive")
+
+        try:
+            logger.info(f"LND sending {amount_sats} sats on-chain to {address}...")
+
+            request_body = {
+                "addr": address,
+                "amount": str(amount_sats),
+                "target_conf": 6,  # Target 6 confirmations (~1 hour)
+            }
+
+            result = await self._request("POST", "transactions", request_body)
+            txid = result.get("txid", "")
+
+            logger.info(f"LND on-chain tx sent: {txid}")
+
+            return LndOnChainResult.succeeded(
+                payment_id=txid or "",
+                txid=txid,
+                state="PENDING",
+                amount_sats=amount_sats,
+                fee_sats=0,  # Fee will be in the tx details
+            )
+
+        except LndError as e:
+            return LndOnChainResult.failed("API_ERROR", str(e))
+        except Exception as e:
+            return LndOnChainResult.failed("EXCEPTION", str(e))
+
+    async def get_all_balances(self) -> dict[str, Any]:
+        """
+        Get all balances - LND is BTC-only (Lightning channels).
+
+        Returns a dict with success, balances list, etc. matching the
+        pattern used by StrikeWallet.get_all_balances().
+        """
+        try:
+            balance_sats = await self.get_balance()
+            balance_btc = Decimal(balance_sats) / Decimal("100000000")
+
+            return {
+                "success": True,
+                "balances": [
+                    {
+                        "currency": "BTC",
+                        "available": float(balance_btc),
+                        "total": float(balance_btc),
+                        "pending": 0,
+                        "formatted": f"{balance_btc:.8f} BTC ({balance_sats:,} sats)",
+                    }
+                ],
+                "provider": "LND",
+                "message": f"Retrieved BTC balance from LND node ({balance_sats:,} sats)",
+            }
+
+        except Exception as e:
+            return {
+                "success": False,
+                "error_code": "ERROR",
+                "error_message": str(e),
+            }
+
+    async def get_info(self) -> dict[str, Any]:
+        """
+        Get wallet/node info.
+
+        Returns:
+            Dict with node info
+        """
+        try:
+            result = await self._request("GET", "getinfo")
+            return {
+                "type": "lnd",
+                "alias": result.get("alias"),
+                "identity_pubkey": result.get("identity_pubkey"),
+                "num_active_channels": result.get("num_active_channels"),
+                "num_peers": result.get("num_peers"),
+                "block_height": result.get("block_height"),
+                "synced_to_chain": result.get("synced_to_chain"),
+                "version": result.get("version"),
+                "status": "connected",
+                "preimage_support": True,
+                "l402_compatible": True,
+            }
+        except Exception:
+            return {
+                "type": "lnd",
+                "status": "connected" if self._connected else "disconnected",
+                "preimage_support": True,
+                "l402_compatible": True,
+                "note": "LND always returns preimage. L402 fully supported.",
+            }

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/lnd_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/lnd_wallet.py
@@ -22,7 +22,6 @@ To get your macaroon in hex format:
 """
 
 import base64
-import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -20,6 +20,7 @@ from mcp.types import (
 from .budget import BudgetManager
 from .budget_service import BudgetService, get_budget_service
 from .l402_client import L402Client
+from .lnd_wallet import LndWallet
 from .lightning_enable_api import LightningEnableApiClient
 from .nwc_wallet import NWCWallet, NWCConfig
 from .opennode_wallet import OpenNodeWallet
@@ -54,7 +55,7 @@ class LightningEnableServer:
 
     def __init__(self) -> None:
         self.server = Server("lightning-enable")
-        self.wallet: NWCWallet | OpenNodeWallet | StrikeWallet | None = None
+        self.wallet: LndWallet | NWCWallet | OpenNodeWallet | StrikeWallet | None = None
         self.strike_wallet: StrikeWallet | None = None  # For Strike-specific features
         self.l402_client: L402Client | None = None
         self.budget_manager: BudgetManager | None = None
@@ -448,8 +449,9 @@ class LightningEnableServer:
                     return [
                         TextContent(
                             type="text",
-                            text="Error: NWC wallet not configured. "
-                            "Set NWC_CONNECTION_STRING environment variable.",
+                            text="Error: No wallet configured. "
+                            "Set LND_REST_HOST+LND_MACAROON_HEX, NWC_CONNECTION_STRING, "
+                            "STRIKE_API_KEY, or OPENNODE_API_KEY environment variable.",
                         )
                     ]
 
@@ -538,10 +540,14 @@ class LightningEnableServer:
                     )
 
                 elif name == "send_onchain":
+                    # send_onchain supports Strike and LND wallets
+                    onchain_wallet = self.strike_wallet
+                    if onchain_wallet is None and isinstance(self.wallet, LndWallet):
+                        onchain_wallet = self.wallet
                     result = await send_onchain(
                         address=arguments.get("address", ""),
                         amount_sats=arguments.get("amount_sats", 0),
-                        wallet=self.strike_wallet,
+                        wallet=onchain_wallet,
                         budget_service=self.budget_service,
                     )
 
@@ -593,38 +599,97 @@ class LightningEnableServer:
         """Initialize wallet, L402 client, and budget manager.
 
         Supports wallet backends (in priority order for L402):
-        1. NWC (Nostr Wallet Connect) - Set NWC_CONNECTION_STRING (returns preimage - best for L402)
-        2. Strike - Set STRIKE_API_KEY (returns preimage via lightning.preImage - L402 works)
-        3. OpenNode - Set OPENNODE_API_KEY (does NOT return preimage - L402 will NOT work)
+        1. LND - Set LND_REST_HOST + LND_MACAROON_HEX (direct node, always returns preimage)
+        2. NWC (Nostr Wallet Connect) - Set NWC_CONNECTION_STRING (returns preimage - best for L402)
+        3. Strike - Set STRIKE_API_KEY (returns preimage via lightning.preImage - L402 works)
+        4. OpenNode - Set OPENNODE_API_KEY (does NOT return preimage - L402 will NOT work)
 
-        For L402 support, use NWC or Strike. OpenNode is for general payments only.
+        For L402 support, use LND, NWC, or Strike. OpenNode is for general payments only.
         """
-        nwc_connection = os.getenv("NWC_CONNECTION_STRING")
-        opennode_api_key = os.getenv("OPENNODE_API_KEY")
-        strike_api_key = os.getenv("STRIKE_API_KEY")
+        from .config import get_config_service
+
+        config_service = get_config_service()
+        wallet_config = config_service.configuration.wallets
+
+        # Read env vars with config file fallback (matching .NET behavior)
+        def _get_env_or_config(env_var: str, config_value: str | None) -> str | None:
+            """Get value from env var, falling back to config file."""
+            value = os.getenv(env_var)
+            if not value or value.startswith("${"):
+                return config_value
+            return value
+
+        lnd_rest_host = _get_env_or_config("LND_REST_HOST", wallet_config.lnd_rest_host)
+        lnd_macaroon_hex = _get_env_or_config("LND_MACAROON_HEX", wallet_config.lnd_macaroon_hex)
+        nwc_connection = _get_env_or_config("NWC_CONNECTION_STRING", wallet_config.nwc_connection_string)
+        strike_api_key = _get_env_or_config("STRIKE_API_KEY", wallet_config.strike_api_key)
+        opennode_api_key = _get_env_or_config("OPENNODE_API_KEY", wallet_config.opennode_api_key)
+
+        lnd_skip_tls_verify = os.getenv("LND_SKIP_TLS_VERIFY", "").lower() == "true"
 
         # Always initialize API client (for producer tools, independent of wallet)
         self.api_client = LightningEnableApiClient()
         if self.api_client.is_configured:
             logger.info("Lightning Enable API client configured - producer tools available")
 
-        if not nwc_connection and not opennode_api_key and not strike_api_key:
+        has_lnd = bool(lnd_rest_host and lnd_macaroon_hex)
+        has_nwc = bool(nwc_connection)
+        has_strike = bool(strike_api_key)
+        has_opennode = bool(opennode_api_key)
+
+        if not has_lnd and not has_nwc and not has_strike and not has_opennode:
             logger.warning(
-                "No wallet configured. Set NWC_CONNECTION_STRING, OPENNODE_API_KEY, or STRIKE_API_KEY"
+                "No wallet configured. Set LND_REST_HOST+LND_MACAROON_HEX, "
+                "NWC_CONNECTION_STRING, STRIKE_API_KEY, or OPENNODE_API_KEY"
             )
             return
 
         try:
-            # Initialize wallet - priority: NWC > OpenNode > Strike (for L402 compatibility)
-            if nwc_connection:
+            # Determine wallet priority
+            # Default: LND > NWC > Strike > OpenNode
+            # Can be overridden via WALLET_PRIORITY env var or config
+            wallet_priority = os.getenv("WALLET_PRIORITY", "").lower() or (wallet_config.priority or "").lower()
+
+            if wallet_priority == "lnd" and has_lnd:
+                selected = "lnd"
+            elif wallet_priority == "nwc" and has_nwc:
+                selected = "nwc"
+            elif wallet_priority == "strike" and has_strike:
+                selected = "strike"
+            elif wallet_priority == "opennode" and has_opennode:
+                selected = "opennode"
+            elif has_lnd:
+                selected = "lnd"
+            elif has_nwc:
+                selected = "nwc"
+            elif has_strike:
+                selected = "strike"
+            elif has_opennode:
+                selected = "opennode"
+            else:
+                selected = None
+
+            # Initialize wallet based on priority
+            if selected == "lnd":
+                logger.info("Initializing LND wallet (L402 compatible, direct node)...")
+                self.wallet = LndWallet(
+                    rest_host=lnd_rest_host,
+                    macaroon_hex=lnd_macaroon_hex,
+                    skip_tls_verify=lnd_skip_tls_verify,
+                )
+                await self.wallet.connect()
+                logger.info("LND wallet connected - preimage always available")
+            elif selected == "nwc":
                 logger.info("Initializing NWC wallet (L402 compatible)...")
                 self._nwc_config = NWCConfig.from_uri(nwc_connection)
                 self.wallet = NWCWallet(nwc_connection)
                 await self.wallet.connect()
                 logger.info("NWC wallet connected - preimage support available")
-            elif opennode_api_key:
+            elif selected == "opennode":
                 logger.info("Initializing OpenNode wallet...")
                 environment = os.getenv("OPENNODE_ENVIRONMENT", "production")
+                if not environment or environment.startswith("${"):
+                    environment = wallet_config.opennode_environment or "production"
                 self.wallet = OpenNodeWallet(
                     api_key=opennode_api_key,
                     environment=environment,
@@ -632,14 +697,14 @@ class LightningEnableServer:
                 await self.wallet.connect()
                 logger.info(f"OpenNode wallet connected ({environment})")
                 logger.warning("OpenNode may not return preimage - L402 may not work")
-            elif strike_api_key:
+            elif selected == "strike":
                 logger.info("Initializing Strike wallet...")
                 self.wallet = StrikeWallet(api_key=strike_api_key)
                 await self.wallet.connect()
                 logger.info("Strike wallet connected - preimage support available via lightning.preImage")
 
             # Also initialize Strike for Strike-specific features if available
-            if strike_api_key and not isinstance(self.wallet, StrikeWallet):
+            if has_strike and not isinstance(self.wallet, StrikeWallet):
                 logger.info("Initializing Strike wallet for multi-currency features...")
                 self.strike_wallet = StrikeWallet(api_key=strike_api_key)
                 await self.strike_wallet.connect()

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/check_invoice_status.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/check_invoice_status.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
+    from ..lnd_wallet import LndWallet
     from ..nwc_wallet import NWCWallet
     from ..opennode_wallet import OpenNodeWallet
     from ..strike_wallet import StrikeWallet
@@ -18,7 +19,7 @@ logger = logging.getLogger("lightning-enable-mcp.tools.check_invoice_status")
 
 async def check_invoice_status(
     invoice_id: str,
-    wallet: "Union[NWCWallet, OpenNodeWallet, StrikeWallet, None]" = None,
+    wallet: "Union[LndWallet, NWCWallet, OpenNodeWallet, StrikeWallet, None]" = None,
 ) -> str:
     """
     Check if a Lightning invoice has been paid.
@@ -46,9 +47,35 @@ async def check_invoice_status(
         })
 
     try:
+        from ..lnd_wallet import LndWallet
         from ..strike_wallet import StrikeWallet
 
-        if isinstance(wallet, StrikeWallet):
+        if isinstance(wallet, LndWallet):
+            # Use LND REST API to check invoice status
+            status = await wallet.get_invoice_status(invoice_id.strip())
+
+            if status["is_paid"]:
+                message = f"Invoice {invoice_id} has been PAID!"
+            elif status["is_pending"]:
+                message = f"Invoice {invoice_id} is still pending payment."
+            else:
+                message = f"Invoice {invoice_id} status: {status['state']}"
+
+            return json.dumps({
+                "success": True,
+                "provider": "LND",
+                "invoice": {
+                    "id": status["id"],
+                    "state": status["state"],
+                    "isPaid": status["is_paid"],
+                    "isPending": status["is_pending"],
+                    "amountSats": status["amount_sats"],
+                    "settledAt": status.get("settled_at"),
+                },
+                "message": message,
+            }, indent=2)
+
+        elif isinstance(wallet, StrikeWallet):
             # Use Strike API to check invoice status
             payment = await wallet._request("GET", f"/invoices/{invoice_id}")
             state = payment.get("state", "UNKNOWN")

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/check_invoice_status.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/check_invoice_status.py
@@ -43,7 +43,7 @@ async def check_invoice_status(
     if not wallet:
         return json.dumps({
             "success": False,
-            "error": "Wallet not configured. Set STRIKE_API_KEY, OPENNODE_API_KEY, or NWC_CONNECTION_STRING environment variable."
+            "error": "Wallet not configured. Set LND_REST_HOST+LND_MACAROON_HEX, STRIKE_API_KEY, OPENNODE_API_KEY, or NWC_CONNECTION_STRING environment variable."
         })
 
     try:
@@ -111,7 +111,7 @@ async def check_invoice_status(
             return json.dumps({
                 "success": False,
                 "error": f"Invoice status check is not supported with {provider_name} wallet.",
-                "hint": "Use Strike wallet (set STRIKE_API_KEY) for invoice status checking."
+                "hint": "Use LND (set LND_REST_HOST+LND_MACAROON_HEX) or Strike (set STRIKE_API_KEY) for invoice status checking."
             })
 
     except Exception as e:

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/create_invoice.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/create_invoice.py
@@ -48,7 +48,7 @@ async def create_invoice(
     if not wallet:
         return json.dumps({
             "success": False,
-            "error": "Wallet not configured. Set STRIKE_API_KEY, OPENNODE_API_KEY, or NWC_CONNECTION_STRING environment variable."
+            "error": "Wallet not configured. Set LND_REST_HOST+LND_MACAROON_HEX, STRIKE_API_KEY, OPENNODE_API_KEY, or NWC_CONNECTION_STRING environment variable."
         })
 
     try:

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/create_invoice.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/create_invoice.py
@@ -10,6 +10,7 @@ import logging
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
+    from ..lnd_wallet import LndWallet
     from ..nwc_wallet import NWCWallet
     from ..opennode_wallet import OpenNodeWallet
     from ..strike_wallet import StrikeWallet
@@ -21,7 +22,7 @@ async def create_invoice(
     amount_sats: int,
     memo: str | None = None,
     expiry_secs: int = 3600,
-    wallet: "Union[NWCWallet, OpenNodeWallet, StrikeWallet, None]" = None,
+    wallet: "Union[LndWallet, NWCWallet, OpenNodeWallet, StrikeWallet, None]" = None,
 ) -> str:
     """
     Create a Lightning invoice to receive a payment.
@@ -51,10 +52,30 @@ async def create_invoice(
         })
 
     try:
+        from ..lnd_wallet import LndWallet
         from ..strike_wallet import StrikeWallet
         from ..opennode_wallet import OpenNodeWallet
 
-        if isinstance(wallet, StrikeWallet):
+        if isinstance(wallet, LndWallet):
+            # Create invoice via LND REST API
+            inv_result = await wallet.create_invoice(
+                amount_sats=amount_sats,
+                memo=memo,
+                expiry_secs=expiry_secs,
+            )
+
+            return json.dumps({
+                "success": True,
+                "provider": "LND",
+                "invoice": {
+                    "id": inv_result["invoice_id"],
+                    "bolt11": inv_result["bolt11"],
+                    "amountSats": inv_result["amount_sats"],
+                },
+                "message": f"Invoice created for {amount_sats} sats. Share the bolt11 string with the payer."
+            }, indent=2)
+
+        elif isinstance(wallet, StrikeWallet):
             # Create invoice via Strike API
             from decimal import Decimal
             amount_btc = Decimal(amount_sats) / Decimal("100000000")

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
@@ -96,6 +96,7 @@ async def send_onchain(
             try:
                 total_sats = amount_sats + (result.fee_sats or 0)
                 budget_service.record_spend(total_sats)
+                budget_service.record_payment_time()
             except Exception:
                 pass
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from ..budget_service import BudgetService
+    from ..lnd_wallet import LndWallet
     from ..strike_wallet import StrikeWallet
 
 logger = logging.getLogger("lightning-enable-mcp.tools.send_onchain")
@@ -19,19 +20,19 @@ logger = logging.getLogger("lightning-enable-mcp.tools.send_onchain")
 async def send_onchain(
     address: str,
     amount_sats: int,
-    wallet: "StrikeWallet | None" = None,
+    wallet: "Union[StrikeWallet, LndWallet, None]" = None,
     budget_service: "BudgetService | None" = None,
 ) -> str:
     """
     Send an on-chain Bitcoin payment to a Bitcoin address.
 
-    Currently supports Strike wallet. The payment is sent from your
-    Strike account balance.
+    Supports Strike and LND wallets. The payment is sent from your
+    wallet balance.
 
     Args:
         address: Bitcoin address to send to (e.g., bc1q...)
         amount_sats: Amount to send in satoshis
-        wallet: Strike wallet instance
+        wallet: Strike or LND wallet instance
         budget_service: BudgetService for spending limits
 
     Returns:
@@ -52,29 +53,30 @@ async def send_onchain(
     if not wallet:
         return json.dumps({
             "success": False,
-            "error": "Wallet not configured. Set STRIKE_API_KEY environment variable for on-chain payments."
+            "error": "Wallet not configured. Set STRIKE_API_KEY or LND_REST_HOST+LND_MACAROON_HEX for on-chain payments."
         })
 
-    # Verify it's a Strike wallet
+    # Verify it's a supported wallet type
     from ..strike_wallet import StrikeWallet
-    if not isinstance(wallet, StrikeWallet):
+    from ..lnd_wallet import LndWallet
+    if not isinstance(wallet, (StrikeWallet, LndWallet)):
         provider_name = type(wallet).__name__.replace("Wallet", "")
         return json.dumps({
             "success": False,
-            "error": f"{provider_name} does not support on-chain payments. Use Strike wallet.",
+            "error": f"{provider_name} does not support on-chain payments. Use Strike or LND wallet.",
             "errorCode": "NOT_SUPPORTED",
-            "hint": "Set STRIKE_API_KEY environment variable for on-chain payments."
+            "hint": "Set STRIKE_API_KEY or LND_REST_HOST+LND_MACAROON_HEX for on-chain payments."
         })
 
     # Check budget if configured
     if budget_service:
         try:
-            result = await budget_service.check_approval_level(amount_sats)
+            budget_result = await budget_service.check_approval_level(amount_sats)
             from ..config import ApprovalLevel
-            if result.level == ApprovalLevel.DENY:
+            if budget_result.level == ApprovalLevel.DENY:
                 return json.dumps({
                     "success": False,
-                    "error": f"Budget check failed: {result.denial_reason}",
+                    "error": f"Budget check failed: {budget_result.denial_reason}",
                 })
         except Exception as e:
             logger.warning(f"Budget check failed: {e}")
@@ -97,6 +99,8 @@ async def send_onchain(
             except Exception:
                 pass
 
+        provider_name = "LND" if isinstance(wallet, LndWallet) else "Strike"
+
         if result.state == "COMPLETED":
             message = f"On-chain payment of {amount_sats} sats sent to {address}"
         else:
@@ -104,7 +108,7 @@ async def send_onchain(
 
         return json.dumps({
             "success": True,
-            "provider": "Strike",
+            "provider": provider_name,
             "payment": {
                 "id": result.payment_id,
                 "txId": result.txid,

--- a/python/lightning-enable-mcp/tests/test_lnd_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_lnd_wallet.py
@@ -3,9 +3,8 @@ Tests for LND Wallet
 """
 
 import base64
-import json
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from lightning_enable_mcp.lnd_wallet import (
     LndConfig,

--- a/python/lightning-enable-mcp/tests/test_lnd_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_lnd_wallet.py
@@ -1,0 +1,718 @@
+"""
+Tests for LND Wallet
+"""
+
+import base64
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from lightning_enable_mcp.lnd_wallet import (
+    LndConfig,
+    LndError,
+    LndOnChainResult,
+    LndPaymentError,
+    LndWallet,
+)
+
+
+class TestLndConfig:
+    """Tests for LND configuration."""
+
+    def test_create_config(self):
+        """Test creating a config with required fields."""
+        config = LndConfig(
+            rest_host="localhost:8080",
+            macaroon_hex="0201036c6e6402",
+        )
+        assert config.rest_host == "localhost:8080"
+        assert config.macaroon_hex == "0201036c6e6402"
+        assert config.skip_tls_verify is False
+
+    def test_skip_tls_verify(self):
+        """Test skip_tls_verify flag."""
+        config = LndConfig(
+            rest_host="localhost:8080",
+            macaroon_hex="abc123",
+            skip_tls_verify=True,
+        )
+        assert config.skip_tls_verify is True
+
+
+class TestLndOnChainResult:
+    """Tests for LndOnChainResult."""
+
+    def test_succeeded(self):
+        """Test creating a successful result."""
+        result = LndOnChainResult.succeeded(
+            payment_id="txid123",
+            txid="txid123",
+            state="PENDING",
+            amount_sats=50000,
+            fee_sats=150,
+        )
+        assert result.success is True
+        assert result.payment_id == "txid123"
+        assert result.txid == "txid123"
+        assert result.state == "PENDING"
+        assert result.amount_sats == 50000
+        assert result.fee_sats == 150
+
+    def test_failed(self):
+        """Test creating a failed result."""
+        result = LndOnChainResult.failed("NOT_CONFIGURED", "LND not configured")
+        assert result.success is False
+        assert result.error_code == "NOT_CONFIGURED"
+        assert result.error_message == "LND not configured"
+
+
+class TestLndWallet:
+    """Tests for LndWallet."""
+
+    def _make_wallet(self, rest_host="localhost:8080", macaroon_hex="abc123"):
+        """Create a wallet for testing."""
+        return LndWallet(
+            rest_host=rest_host,
+            macaroon_hex=macaroon_hex,
+            skip_tls_verify=True,
+        )
+
+    def test_init(self):
+        """Test wallet initialization."""
+        wallet = self._make_wallet()
+        assert wallet.config.rest_host == "localhost:8080"
+        assert wallet.config.macaroon_hex == "abc123"
+        assert wallet.config.skip_tls_verify is True
+        assert wallet.is_configured is True
+        assert wallet.provider_name == "LND"
+
+    def test_not_configured_empty_host(self):
+        """Test wallet reports not configured with empty host."""
+        wallet = self._make_wallet(rest_host="")
+        assert wallet.is_configured is False
+
+    def test_not_configured_empty_macaroon(self):
+        """Test wallet reports not configured with empty macaroon."""
+        wallet = self._make_wallet(macaroon_hex="")
+        assert wallet.is_configured is False
+
+    @pytest.mark.asyncio
+    async def test_connect_adds_https_scheme(self):
+        """Test connect adds https:// when no scheme present."""
+        wallet = self._make_wallet(rest_host="localhost:8080")
+        await wallet.connect()
+
+        assert wallet._client is not None
+        assert str(wallet._client.base_url).startswith("https://localhost:8080/v1/")
+        assert wallet._connected is True
+        await wallet.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_preserves_scheme(self):
+        """Test connect preserves existing http:// scheme."""
+        wallet = self._make_wallet(rest_host="http://localhost:8080")
+        await wallet.connect()
+
+        assert str(wallet._client.base_url).startswith("http://localhost:8080/v1/")
+        await wallet.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_idempotent(self):
+        """Test calling connect twice doesn't create two clients."""
+        wallet = self._make_wallet()
+        await wallet.connect()
+        client1 = wallet._client
+        await wallet.connect()
+        client2 = wallet._client
+        assert client1 is client2
+        await wallet.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disconnect(self):
+        """Test disconnect closes client."""
+        wallet = self._make_wallet()
+        await wallet.connect()
+        assert wallet._connected is True
+        await wallet.disconnect()
+        assert wallet._connected is False
+
+    @pytest.mark.asyncio
+    async def test_pay_invoice_success(self):
+        """Test successful invoice payment returns hex preimage."""
+        wallet = self._make_wallet()
+
+        # Create a known preimage and its base64 encoding
+        preimage_bytes = bytes.fromhex("deadbeef" * 8)
+        preimage_b64 = base64.b64encode(preimage_bytes).decode()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "payment_preimage": preimage_b64,
+            "payment_error": "",
+            "payment_hash": base64.b64encode(b"hash").decode(),
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.pay_invoice("lnbc100n1...")
+        assert result == "deadbeef" * 8
+
+    @pytest.mark.asyncio
+    async def test_pay_invoice_payment_error(self):
+        """Test payment error raises LndPaymentError."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "payment_preimage": "",
+            "payment_error": "insufficient balance",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(LndPaymentError, match="insufficient balance"):
+            await wallet.pay_invoice("lnbc100n1...")
+
+    @pytest.mark.asyncio
+    async def test_pay_invoice_no_preimage(self):
+        """Test missing preimage raises LndPaymentError."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "payment_preimage": "",
+            "payment_error": "",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(LndPaymentError, match="no preimage"):
+            await wallet.pay_invoice("lnbc100n1...")
+
+    @pytest.mark.asyncio
+    async def test_pay_invoice_not_configured(self):
+        """Test pay_invoice raises when not configured."""
+        wallet = self._make_wallet(rest_host="")
+
+        with pytest.raises(LndPaymentError, match="not configured"):
+            await wallet.pay_invoice("lnbc100n1...")
+
+    @pytest.mark.asyncio
+    async def test_pay_invoice_http_error(self):
+        """Test pay_invoice handles HTTP errors."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises((LndError, LndPaymentError)):
+            await wallet.pay_invoice("lnbc100n1...")
+
+    @pytest.mark.asyncio
+    async def test_get_balance_success(self):
+        """Test successful balance retrieval with string numbers."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "local_balance": {"sat": "317142", "msat": "317142000"},
+            "remote_balance": {"sat": "100000", "msat": "100000000"},
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        balance = await wallet.get_balance()
+        assert balance == 317142
+
+    @pytest.mark.asyncio
+    async def test_get_balance_zero(self):
+        """Test balance when no channels exist."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "local_balance": {"sat": "0", "msat": "0"},
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        balance = await wallet.get_balance()
+        assert balance == 0
+
+    @pytest.mark.asyncio
+    async def test_get_balance_missing_local_balance(self):
+        """Test balance when local_balance is missing."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        balance = await wallet.get_balance()
+        assert balance == 0
+
+    @pytest.mark.asyncio
+    async def test_get_balance_not_configured(self):
+        """Test get_balance raises when not configured."""
+        wallet = self._make_wallet(rest_host="")
+
+        with pytest.raises(LndError, match="not configured"):
+            await wallet.get_balance()
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_success(self):
+        """Test successful invoice creation."""
+        wallet = self._make_wallet()
+
+        r_hash_bytes = bytes.fromhex("abcdef1234567890" * 2)
+        r_hash_b64 = base64.b64encode(r_hash_bytes).decode()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "r_hash": r_hash_b64,
+            "payment_request": "lnbc100n1pj9npjpp5...",
+            "add_index": "42",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.create_invoice(100, memo="Test invoice")
+
+        assert result["invoice_id"] == "abcdef1234567890" * 2
+        assert result["bolt11"] == "lnbc100n1pj9npjpp5..."
+        assert result["amount_sats"] == 100
+        assert "expires_at" in result
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_no_payment_request(self):
+        """Test create_invoice raises when no payment_request returned."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "r_hash": base64.b64encode(b"hash").decode(),
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(LndError, match="No invoice returned"):
+            await wallet.create_invoice(100)
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_not_configured(self):
+        """Test create_invoice raises when not configured."""
+        wallet = self._make_wallet(macaroon_hex="")
+
+        with pytest.raises(LndError, match="not configured"):
+            await wallet.create_invoice(100)
+
+    @pytest.mark.asyncio
+    async def test_create_invoice_default_memo(self):
+        """Test create_invoice uses default memo when none provided."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "r_hash": base64.b64encode(b"hash").decode(),
+            "payment_request": "lnbc100n1...",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        await wallet.create_invoice(100)
+
+        # Verify the request body included default memo
+        call_args = wallet._client.request.call_args
+        assert call_args.kwargs["json"]["memo"] == "Lightning payment"
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_status_settled(self):
+        """Test invoice status for settled invoice."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "state": "SETTLED",
+            "value": "100",
+            "settled": True,
+            "settle_date": "1710460800",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.get_invoice_status("abc123")
+        assert result["id"] == "abc123"
+        assert result["state"] == "PAID"
+        assert result["is_paid"] is True
+        assert result["is_pending"] is False
+        assert result["amount_sats"] == 100
+        assert result["settled_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_status_open(self):
+        """Test invoice status for pending invoice."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "state": "OPEN",
+            "value": "500",
+            "settled": False,
+            "settle_date": "0",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.get_invoice_status("def456")
+        assert result["state"] == "PENDING"
+        assert result["is_paid"] is False
+        assert result["is_pending"] is True
+        assert result["amount_sats"] == 500
+        assert result["settled_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_status_canceled(self):
+        """Test invoice status for canceled invoice."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "state": "CANCELED",
+            "value": "1000",
+            "settled": False,
+            "settle_date": "0",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.get_invoice_status("ghi789")
+        assert result["state"] == "CANCELLED"
+        assert result["is_paid"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_status_accepted(self):
+        """Test invoice status for accepted (in-flight) invoice maps to PENDING."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "state": "ACCEPTED",
+            "value": "200",
+            "settled": False,
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.get_invoice_status("jkl012")
+        assert result["state"] == "PENDING"
+        assert result["is_pending"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_invoice_status_not_configured(self):
+        """Test get_invoice_status raises when not configured."""
+        wallet = self._make_wallet(rest_host="")
+
+        with pytest.raises(LndError, match="not configured"):
+            await wallet.get_invoice_status("abc123")
+
+    @pytest.mark.asyncio
+    async def test_send_onchain_success(self):
+        """Test successful on-chain payment."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "txid": "abc123txid456",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.send_onchain("bc1qexample...", 50000)
+        assert result.success is True
+        assert result.txid == "abc123txid456"
+        assert result.state == "PENDING"
+        assert result.amount_sats == 50000
+
+    @pytest.mark.asyncio
+    async def test_send_onchain_not_configured(self):
+        """Test on-chain payment when not configured."""
+        wallet = self._make_wallet(rest_host="")
+        result = await wallet.send_onchain("bc1q...", 50000)
+        assert result.success is False
+        assert result.error_code == "NOT_CONFIGURED"
+
+    @pytest.mark.asyncio
+    async def test_send_onchain_empty_address(self):
+        """Test on-chain payment with empty address."""
+        wallet = self._make_wallet()
+        result = await wallet.send_onchain("", 50000)
+        assert result.success is False
+        assert result.error_code == "INVALID_ADDRESS"
+
+    @pytest.mark.asyncio
+    async def test_send_onchain_zero_amount(self):
+        """Test on-chain payment with zero amount."""
+        wallet = self._make_wallet()
+        result = await wallet.send_onchain("bc1q...", 0)
+        assert result.success is False
+        assert result.error_code == "INVALID_AMOUNT"
+
+    @pytest.mark.asyncio
+    async def test_send_onchain_negative_amount(self):
+        """Test on-chain payment with negative amount."""
+        wallet = self._make_wallet()
+        result = await wallet.send_onchain("bc1q...", -100)
+        assert result.success is False
+        assert result.error_code == "INVALID_AMOUNT"
+
+    @pytest.mark.asyncio
+    async def test_send_onchain_api_error(self):
+        """Test on-chain payment handles API errors."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal error"
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.send_onchain("bc1q...", 50000)
+        assert result.success is False
+        assert result.error_code == "API_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_get_all_balances_success(self):
+        """Test get_all_balances returns BTC balance."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "local_balance": {"sat": "100000", "msat": "100000000"},
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.get_all_balances()
+        assert result["success"] is True
+        assert len(result["balances"]) == 1
+        assert result["balances"][0]["currency"] == "BTC"
+        assert result["balances"][0]["available"] == 0.001
+        assert result["provider"] == "LND"
+
+    @pytest.mark.asyncio
+    async def test_get_all_balances_error(self):
+        """Test get_all_balances handles errors gracefully."""
+        wallet = self._make_wallet()
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(
+            side_effect=Exception("Connection refused")
+        )
+
+        result = await wallet.get_all_balances()
+        assert result["success"] is False
+        assert "error_code" in result
+
+    @pytest.mark.asyncio
+    async def test_get_info_success(self):
+        """Test get_info returns node info."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "alias": "my-node",
+            "identity_pubkey": "02abc123...",
+            "num_active_channels": 5,
+            "num_peers": 10,
+            "block_height": 830000,
+            "synced_to_chain": True,
+            "version": "0.18.0-beta",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.get_info()
+        assert result["type"] == "lnd"
+        assert result["alias"] == "my-node"
+        assert result["preimage_support"] is True
+        assert result["l402_compatible"] is True
+        assert result["status"] == "connected"
+
+    @pytest.mark.asyncio
+    async def test_get_info_handles_error(self):
+        """Test get_info returns basic info on error."""
+        wallet = self._make_wallet()
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(
+            side_effect=Exception("Connection refused")
+        )
+
+        result = await wallet.get_info()
+        assert result["type"] == "lnd"
+        assert result["preimage_support"] is True
+        assert result["l402_compatible"] is True
+
+    @pytest.mark.asyncio
+    async def test_request_auto_connects(self):
+        """Test _request auto-connects if not connected."""
+        wallet = self._make_wallet()
+        assert wallet._connected is False
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"local_balance": {"sat": "0"}}
+
+        # Patch connect to set up a mock client
+        original_connect = wallet.connect
+
+        async def mock_connect():
+            await original_connect()
+            wallet._client = AsyncMock()
+            wallet._client.request = AsyncMock(return_value=mock_response)
+
+        wallet.connect = mock_connect
+
+        balance = await wallet.get_balance()
+        assert balance == 0
+
+    @pytest.mark.asyncio
+    async def test_request_http_error_raises(self):
+        """Test _request raises LndError on HTTP errors."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(LndError, match="401"):
+            await wallet._request("GET", "balance/channels")
+
+    @pytest.mark.asyncio
+    async def test_preimage_base64_to_hex_conversion(self):
+        """Test that base64 preimage from LND is correctly converted to hex."""
+        wallet = self._make_wallet()
+
+        # Known test vector: 32 bytes of 0x01
+        preimage_bytes = b"\x01" * 32
+        preimage_b64 = base64.b64encode(preimage_bytes).decode()
+        expected_hex = "01" * 32
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "payment_preimage": preimage_b64,
+            "payment_error": "",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.pay_invoice("lnbc100n1...")
+        assert result == expected_hex
+
+    @pytest.mark.asyncio
+    async def test_r_hash_base64_to_hex_conversion(self):
+        """Test that base64 r_hash from LND is correctly converted to hex."""
+        wallet = self._make_wallet()
+
+        # Known test vector
+        r_hash_bytes = bytes.fromhex("aabbccdd" * 4)
+        r_hash_b64 = base64.b64encode(r_hash_bytes).decode()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "r_hash": r_hash_b64,
+            "payment_request": "lnbc100n1...",
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        result = await wallet.create_invoice(100)
+        assert result["invoice_id"] == "aabbccdd" * 4
+
+    @pytest.mark.asyncio
+    async def test_numbers_as_strings_handled(self):
+        """Test that LND's string-encoded numbers are parsed correctly."""
+        wallet = self._make_wallet()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "local_balance": {"sat": "999999", "msat": "999999000"},
+            "remote_balance": {"sat": "500000", "msat": "500000000"},
+        }
+
+        wallet._connected = True
+        wallet._client = AsyncMock()
+        wallet._client.request = AsyncMock(return_value=mock_response)
+
+        balance = await wallet.get_balance()
+        assert balance == 999999
+        assert isinstance(balance, int)


### PR DESCRIPTION
## Summary
- Add `LndWallet` class to Python MCP for feature parity with .NET — full LND REST API support (pay_invoice, get_balance, create_invoice, get_invoice_status, send_onchain, get_all_balances)
- Update `server.py` to initialize LND as highest-priority wallet (LND > NWC > Strike > OpenNode)
- Add LND branches to `create_invoice`, `check_invoice_status`, and `send_onchain` tools
- Add 44 unit tests with 94% coverage on lnd_wallet.py
- Add LND configuration example to Python README

## Test plan
- [x] All 44 new LND wallet tests pass locally
- [x] Existing tests unaffected
- [ ] Manual test: configure LND env vars, verify wallet connects and pays invoices
- [ ] Verify LND preimage (base64→hex) conversion works end-to-end with L402

🤖 Generated with [Claude Code](https://claude.com/claude-code)