### PR TITLE
fix: Preserve L402 token when retry fails after payment

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.11.4</Version>
+    <Version>1.11.5</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>

--- a/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
@@ -134,7 +134,7 @@ public record L402FetchResult
     /// <summary>
     /// Creates a successful result.
     /// </summary>
-    public static L402FetchResult Succeeded(string url, string content, int statusCode, string? contentType = null, long paidAmount = 0, string? token = null) =>
+    public static L402FetchResult Succeeded(string url, string content, int statusCode, string? contentType = null, long paidAmountSats = 0, string? l402Token = null) =>
         new()
         {
             Success = true,
@@ -142,8 +142,8 @@ public record L402FetchResult
             Content = content,
             StatusCode = statusCode,
             ContentType = contentType,
-            PaidAmountSats = paidAmount,
-            L402Token = token
+            PaidAmountSats = paidAmountSats,
+            L402Token = l402Token
         };
 
     /// <summary>

--- a/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
@@ -149,12 +149,14 @@ public record L402FetchResult
     /// <summary>
     /// Creates a failed result.
     /// </summary>
-    public static L402FetchResult Failed(string url, string error, int statusCode = 0) =>
+    public static L402FetchResult Failed(string url, string error, int statusCode = 0, long paidAmountSats = 0, string? l402Token = null) =>
         new()
         {
             Success = false,
             Url = url,
             ErrorMessage = error,
-            StatusCode = statusCode
+            StatusCode = statusCode,
+            PaidAmountSats = paidAmountSats,
+            L402Token = l402Token
         };
 }

--- a/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
@@ -237,7 +237,7 @@ public class L402HttpClient : IL402HttpClient
             return L402FetchResult.Succeeded(url, content, (int)retryResponse.StatusCode, contentType, amountSats.Value, l402Token);
         }
 
-        return L402FetchResult.Failed(url, $"Request failed after payment: HTTP {(int)retryResponse.StatusCode}: {content}", (int)retryResponse.StatusCode);
+        return L402FetchResult.Failed(url, $"Request failed after payment: HTTP {(int)retryResponse.StatusCode}: {content}", (int)retryResponse.StatusCode, amountSats.Value, l402Token);
     }
 
     private static HttpRequestMessage CreateRequest(string url, string method, string? headers, string? body)

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -267,6 +267,32 @@ public static class AccessL402ResourceTool
             }
             else
             {
+                // If payment was made but the retry failed (e.g., store split-flow),
+                // surface the L402 token so it can be used with the correct endpoint
+                if (result.PaidAmountSats > 0 && !string.IsNullOrEmpty(result.L402Token))
+                {
+                    var amountUsd = priceService != null
+                        ? await priceService.SatsToUsdAsync(result.PaidAmountSats, cancellationToken)
+                        : 0m;
+
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = false,
+                        url = result.Url,
+                        statusCode = result.StatusCode,
+                        error = result.ErrorMessage,
+                        payment = new
+                        {
+                            paid = true,
+                            amountSats = result.PaidAmountSats,
+                            amountUsd = Math.Round(amountUsd, 2),
+                            l402Token = result.L402Token,
+                            note = "Payment succeeded but the server returned a non-success status on retry. " +
+                                   "The L402 token above is valid and can be used with the correct endpoint."
+                        }
+                    });
+                }
+
                 return JsonSerializer.Serialize(new
                 {
                     success = false,

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -271,9 +271,13 @@ public static class AccessL402ResourceTool
                 // surface the L402 token so it can be used with the correct endpoint
                 if (result.PaidAmountSats > 0 && !string.IsNullOrEmpty(result.L402Token))
                 {
-                    var amountUsd = priceService != null
-                        ? await priceService.SatsToUsdAsync(result.PaidAmountSats, cancellationToken)
-                        : 0m;
+                    decimal? amountUsd = null;
+                    try
+                    {
+                        if (priceService != null)
+                            amountUsd = Math.Round(await priceService.SatsToUsdAsync(result.PaidAmountSats, cancellationToken), 2);
+                    }
+                    catch { /* USD conversion is best-effort — never lose the token */ }
 
                     return JsonSerializer.Serialize(new
                     {
@@ -285,7 +289,7 @@ public static class AccessL402ResourceTool
                         {
                             paid = true,
                             amountSats = result.PaidAmountSats,
-                            amountUsd = Math.Round(amountUsd, 2),
+                            amountUsd,
                             l402Token = result.L402Token,
                             note = "Payment succeeded but the server returned a non-success status on retry. " +
                                    "The L402 token above is valid and can be used with the correct endpoint."

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/AgentSettleToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/AgentSettleToolTests.cs
@@ -36,8 +36,8 @@ public class AgentSettleToolTests
                 "{\"translation\": \"Hola mundo\"}",
                 200,
                 "application/json",
-                paidAmount: 100,
-                token: "macaroon123:preimage456"));
+                paidAmountSats: 100,
+                l402Token: "macaroon123:preimage456"));
 
         // Act
         var result = await AgentSettleTool.SettleAgentService(

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
@@ -51,6 +51,37 @@ public class L402ToolsTests
             "https://api.example.com/data", "GET", null, null, 1000L, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task AccessL402Resource_WhenRetryFailsAfterPayment_SurfacesL402Token()
+    {
+        // Arrange — payment succeeded but retry returned 402 (e.g., store split-flow)
+        _l402ClientMock.Setup(c => c.FetchWithL402Async(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+            It.IsAny<string?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(L402FetchResult.Failed(
+                "https://store.example.com/checkout",
+                "Request failed after payment: HTTP 402",
+                402,
+                paidAmountSats: 5000,
+                l402Token: "macaroon123:preimage456"));
+
+        // Act
+        var result = await AccessL402ResourceTool.AccessL402Resource(
+            url: "https://store.example.com/checkout",
+            l402Client: _l402ClientMock.Object);
+
+        // Assert
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("statusCode").GetInt32().Should().Be(402);
+
+        var payment = json.RootElement.GetProperty("payment");
+        payment.GetProperty("paid").GetBoolean().Should().BeTrue();
+        payment.GetProperty("amountSats").GetInt64().Should().Be(5000);
+        payment.GetProperty("l402Token").GetString().Should().Be("macaroon123:preimage456");
+        payment.GetProperty("note").GetString().Should().Contain("valid");
+    }
+
     #endregion
 
     #region PayL402ChallengeTool Tests

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.11.4"
+version = "1.11.5"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- `L402FetchResult.Failed()` now preserves the L402 token and paid amount when payment succeeded but the server retry returned a non-success status
- `HandleL402ChallengeAsync` passes the valid token through on retry failure instead of discarding it
- `AccessL402ResourceTool` surfaces the token in error responses with a note that it's valid, so the agent can use it with the correct endpoint (e.g., `/claim` for store purchases)
- Fixes the issue where paying for an L402 resource on a split-flow server (checkout → pay → claim at different URL) silently discarded the valid token, losing the payment

## Test plan
- [ ] Standard L402 flow (single-URL) continues to work as before
- [ ] When retry fails after payment, response includes `payment.l402Token` and `payment.amountSats`
- [ ] When retry fails without payment (budget denied, etc.), response has no payment info
- [ ] All 164 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)