### PR TITLE
feat: Add MPP client-side support (.NET + Python)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace LightningEnable.Mcp.Models;
 
 /// <summary>
@@ -21,10 +23,15 @@ public record L402ClientChallenge
     /// </summary>
     public required string Invoice { get; init; }
 
+    // Regex: scheme is L402 or LSAT (case-insensitive), followed by one or more whitespace chars (SP/HTAB)
+    private static readonly Regex SchemeRegex = new(
+        @"^\s*(L402|LSAT)\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     /// <summary>
     /// Parses an L402 challenge from a WWW-Authenticate header value.
     /// Expected format: L402 macaroon="base64...", invoice="lnbc..."
     /// Or legacy: LSAT macaroon="base64...", invoice="lnbc..."
+    /// Tolerates tabs, multiple whitespace, and optional whitespace around = in params.
     /// </summary>
     public static L402ClientChallenge? Parse(string? wwwAuthenticateHeader)
     {
@@ -33,28 +40,16 @@ public record L402ClientChallenge
 
         var header = wwwAuthenticateHeader.Trim();
 
-        // Check for L402 or LSAT scheme
-        string scheme;
-        string remainder;
-
-        if (header.StartsWith("L402 ", StringComparison.OrdinalIgnoreCase))
-        {
-            scheme = "L402";
-            remainder = header[5..].Trim();
-        }
-        else if (header.StartsWith("LSAT ", StringComparison.OrdinalIgnoreCase))
-        {
-            scheme = "LSAT";
-            remainder = header[5..].Trim();
-        }
-        else
-        {
+        var schemeMatch = SchemeRegex.Match(header);
+        if (!schemeMatch.Success)
             return null;
-        }
 
-        // Parse key="value" pairs
-        var macaroon = ExtractQuotedValue(remainder, "macaroon");
-        var invoice = ExtractQuotedValue(remainder, "invoice");
+        var scheme = schemeMatch.Groups[1].Value.ToUpperInvariant();
+        var remainder = header[schemeMatch.Length..].Trim();
+
+        // Parse key="value" pairs (tolerant of whitespace around =)
+        var macaroon = AuthParamParser.ExtractQuotedValue(remainder, "macaroon");
+        var invoice = AuthParamParser.ExtractQuotedValue(remainder, "invoice");
 
         if (string.IsNullOrEmpty(macaroon) || string.IsNullOrEmpty(invoice))
             return null;
@@ -65,23 +60,6 @@ public record L402ClientChallenge
             MacaroonBase64 = macaroon,
             Invoice = invoice
         };
-    }
-
-    private static string? ExtractQuotedValue(string input, string key)
-    {
-        var keyPattern = $"{key}=\"";
-        var startIndex = input.IndexOf(keyPattern, StringComparison.OrdinalIgnoreCase);
-
-        if (startIndex < 0)
-            return null;
-
-        startIndex += keyPattern.Length;
-        var endIndex = input.IndexOf('"', startIndex);
-
-        if (endIndex < 0)
-            return null;
-
-        return input[startIndex..endIndex];
     }
 }
 
@@ -106,9 +84,14 @@ public record MppClientChallenge
     /// </summary>
     public string? Realm { get; init; }
 
+    // Regex: "Payment" scheme (case-insensitive), followed by one or more whitespace chars (SP/HTAB)
+    private static readonly Regex SchemeRegex = new(
+        @"^\s*Payment\s+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     /// <summary>
     /// Parses an MPP challenge from a WWW-Authenticate header value.
     /// Expected format: Payment realm="...", method="lightning", invoice="lnbc...", amount="100", currency="sat"
+    /// Tolerates tabs, multiple whitespace, and optional whitespace around = in params.
     /// </summary>
     public static MppClientChallenge? Parse(string? wwwAuthenticateHeader)
     {
@@ -117,24 +100,25 @@ public record MppClientChallenge
 
         var header = wwwAuthenticateHeader.Trim();
 
-        if (!header.StartsWith("Payment ", StringComparison.OrdinalIgnoreCase))
+        var schemeMatch = SchemeRegex.Match(header);
+        if (!schemeMatch.Success)
             return null;
 
-        var remainder = header[8..].Trim();
+        var remainder = header[schemeMatch.Length..].Trim();
 
-        // Verify method="lightning"
-        var method = ExtractQuotedValue(remainder, "method");
+        // Verify method="lightning" (tolerant of whitespace around =)
+        var method = AuthParamParser.ExtractQuotedValue(remainder, "method");
         if (method == null || !method.Equals("lightning", StringComparison.OrdinalIgnoreCase))
             return null;
 
         // Extract invoice (required)
-        var invoice = ExtractQuotedValue(remainder, "invoice");
+        var invoice = AuthParamParser.ExtractQuotedValue(remainder, "invoice");
         if (string.IsNullOrEmpty(invoice))
             return null;
 
         // Extract optional fields
-        var amount = ExtractQuotedValue(remainder, "amount");
-        var realm = ExtractQuotedValue(remainder, "realm");
+        var amount = AuthParamParser.ExtractQuotedValue(remainder, "amount");
+        var realm = AuthParamParser.ExtractQuotedValue(remainder, "realm");
 
         return new MppClientChallenge
         {
@@ -143,22 +127,59 @@ public record MppClientChallenge
             Realm = realm
         };
     }
+}
 
-    private static string? ExtractQuotedValue(string input, string key)
+/// <summary>
+/// Shared helper for parsing RFC 7235 auth-param key="value" pairs.
+/// Tolerates optional whitespace around '=' per the HTTP auth-param grammar.
+/// </summary>
+internal static class AuthParamParser
+{
+    // Matches: key (optional whitespace) = (optional whitespace) "value"
+    // Case-insensitive key matching handled by building the pattern dynamically.
+    public static string? ExtractQuotedValue(string input, string key)
     {
-        var keyPattern = $"{key}=\"";
-        var startIndex = input.IndexOf(keyPattern, StringComparison.OrdinalIgnoreCase);
+        // Build a regex that matches key with optional whitespace around = and quoted value
+        // This handles: key="value", key ="value", key= "value", key = "value"
+        var pattern = $@"(?i){Regex.Escape(key)}\s*=\s*""([^""]*)""";
+        var match = Regex.Match(input, pattern);
+        return match.Success ? match.Groups[1].Value : null;
+    }
 
-        if (startIndex < 0)
-            return null;
+    /// <summary>
+    /// Splits a single WWW-Authenticate header value that may contain multiple
+    /// comma-separated challenges into individual challenge strings.
+    /// Detects boundaries at known auth scheme tokens (L402, LSAT, Payment).
+    /// </summary>
+    public static List<string> ExpandChallenges(string headerValue)
+    {
+        if (string.IsNullOrWhiteSpace(headerValue))
+            return [];
 
-        startIndex += keyPattern.Length;
-        var endIndex = input.IndexOf('"', startIndex);
+        // Find boundaries where a new scheme starts, handling comma-separated challenges.
+        // Scheme tokens: L402, LSAT, Payment (case-insensitive), preceded by start-of-string or comma.
+        var boundaryRegex = new Regex(
+            @"(?:^|,\s*)(?=(?:l402|lsat|payment)\s)", RegexOptions.IgnoreCase);
+        var matches = boundaryRegex.Matches(headerValue);
 
-        if (endIndex < 0)
-            return null;
+        if (matches.Count <= 1)
+            return [headerValue.Trim()];
 
-        return input[startIndex..endIndex];
+        var challenges = new List<string>();
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var start = matches[i].Index;
+            // Skip leading comma and whitespace
+            while (start < headerValue.Length && (headerValue[start] == ',' || headerValue[start] == ' '))
+                start++;
+
+            var end = i + 1 < matches.Count ? matches[i + 1].Index : headerValue.Length;
+            var segment = headerValue[start..end].Trim().TrimEnd(',').Trim();
+            if (!string.IsNullOrEmpty(segment))
+                challenges.Add(segment);
+        }
+
+        return challenges;
     }
 }
 
@@ -166,6 +187,7 @@ public record MppClientChallenge
 /// Selects the best payment challenge from multiple WWW-Authenticate headers.
 /// Prefers L402 when both are present (caveats, no cache dependency).
 /// Falls back to MPP when L402 is not available.
+/// Handles comma-separated challenges within a single header value.
 /// </summary>
 public static class PaymentChallengeParser
 {
@@ -190,16 +212,22 @@ public static class PaymentChallengeParser
     /// <summary>
     /// Parses the best challenge from a collection of WWW-Authenticate header values.
     /// Prefers L402 when available; falls back to MPP.
+    /// Handles comma-separated challenges within a single header value.
     /// </summary>
     public static ParsedChallenge ParseBest(IEnumerable<string> wwwAuthenticateHeaders)
     {
         L402ClientChallenge? l402 = null;
         MppClientChallenge? mpp = null;
 
-        foreach (var header in wwwAuthenticateHeaders)
+        foreach (var headerValue in wwwAuthenticateHeaders)
         {
-            l402 ??= L402ClientChallenge.Parse(header);
-            mpp ??= MppClientChallenge.Parse(header);
+            // Expand comma-separated challenges within a single header value
+            var challenges = AuthParamParser.ExpandChallenges(headerValue);
+            foreach (var challenge in challenges)
+            {
+                l402 ??= L402ClientChallenge.Parse(challenge);
+                mpp ??= MppClientChallenge.Parse(challenge);
+            }
         }
 
         return new ParsedChallenge { L402 = l402, Mpp = mpp };

--- a/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/L402ClientChallenge.cs
@@ -86,6 +86,127 @@ public record L402ClientChallenge
 }
 
 /// <summary>
+/// Represents an MPP (Machine Payments Protocol) challenge parsed from a WWW-Authenticate header.
+/// Per IETF draft-ryan-httpauth-payment. Simpler than L402 — no macaroon, just invoice + preimage.
+/// </summary>
+public record MppClientChallenge
+{
+    /// <summary>
+    /// BOLT11 Lightning invoice that must be paid to obtain the preimage.
+    /// </summary>
+    public required string Invoice { get; init; }
+
+    /// <summary>
+    /// Amount in the specified currency (typically satoshis).
+    /// </summary>
+    public string? Amount { get; init; }
+
+    /// <summary>
+    /// Payment realm identifier.
+    /// </summary>
+    public string? Realm { get; init; }
+
+    /// <summary>
+    /// Parses an MPP challenge from a WWW-Authenticate header value.
+    /// Expected format: Payment realm="...", method="lightning", invoice="lnbc...", amount="100", currency="sat"
+    /// </summary>
+    public static MppClientChallenge? Parse(string? wwwAuthenticateHeader)
+    {
+        if (string.IsNullOrWhiteSpace(wwwAuthenticateHeader))
+            return null;
+
+        var header = wwwAuthenticateHeader.Trim();
+
+        if (!header.StartsWith("Payment ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var remainder = header[8..].Trim();
+
+        // Verify method="lightning"
+        var method = ExtractQuotedValue(remainder, "method");
+        if (method == null || !method.Equals("lightning", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Extract invoice (required)
+        var invoice = ExtractQuotedValue(remainder, "invoice");
+        if (string.IsNullOrEmpty(invoice))
+            return null;
+
+        // Extract optional fields
+        var amount = ExtractQuotedValue(remainder, "amount");
+        var realm = ExtractQuotedValue(remainder, "realm");
+
+        return new MppClientChallenge
+        {
+            Invoice = invoice,
+            Amount = amount,
+            Realm = realm
+        };
+    }
+
+    private static string? ExtractQuotedValue(string input, string key)
+    {
+        var keyPattern = $"{key}=\"";
+        var startIndex = input.IndexOf(keyPattern, StringComparison.OrdinalIgnoreCase);
+
+        if (startIndex < 0)
+            return null;
+
+        startIndex += keyPattern.Length;
+        var endIndex = input.IndexOf('"', startIndex);
+
+        if (endIndex < 0)
+            return null;
+
+        return input[startIndex..endIndex];
+    }
+}
+
+/// <summary>
+/// Selects the best payment challenge from multiple WWW-Authenticate headers.
+/// Prefers L402 when both are present (caveats, no cache dependency).
+/// Falls back to MPP when L402 is not available.
+/// </summary>
+public static class PaymentChallengeParser
+{
+    /// <summary>
+    /// Result of parsing payment challenge headers.
+    /// </summary>
+    public record ParsedChallenge
+    {
+        public L402ClientChallenge? L402 { get; init; }
+        public MppClientChallenge? Mpp { get; init; }
+
+        /// <summary>Whether any valid challenge was found.</summary>
+        public bool HasChallenge => L402 != null || Mpp != null;
+
+        /// <summary>Whether the MPP protocol was selected (no L402 available).</summary>
+        public bool IsMpp => L402 == null && Mpp != null;
+
+        /// <summary>The invoice to pay (from whichever protocol was selected).</summary>
+        public string? Invoice => L402?.Invoice ?? Mpp?.Invoice;
+    }
+
+    /// <summary>
+    /// Parses the best challenge from a collection of WWW-Authenticate header values.
+    /// Prefers L402 when available; falls back to MPP.
+    /// </summary>
+    public static ParsedChallenge ParseBest(IEnumerable<string> wwwAuthenticateHeaders)
+    {
+        L402ClientChallenge? l402 = null;
+        MppClientChallenge? mpp = null;
+
+        foreach (var header in wwwAuthenticateHeaders)
+        {
+            l402 ??= L402ClientChallenge.Parse(header);
+            mpp ??= MppClientChallenge.Parse(header);
+        }
+
+        return new ParsedChallenge { L402 = l402, Mpp = mpp };
+    }
+}
+
+/// <summary>
 /// Result of fetching a URL with L402 support.
 /// </summary>
 public record L402FetchResult
@@ -122,9 +243,14 @@ public record L402FetchResult
 
     /// <summary>
     /// The L402 token used for authentication (if payment was made).
-    /// Format: macaroon:preimage
+    /// Format: macaroon:preimage (L402) or just preimage (MPP)
     /// </summary>
     public string? L402Token { get; init; }
+
+    /// <summary>
+    /// The protocol used for payment (L402 or MPP).
+    /// </summary>
+    public string? Protocol { get; init; }
 
     /// <summary>
     /// The URL that was fetched.
@@ -134,7 +260,7 @@ public record L402FetchResult
     /// <summary>
     /// Creates a successful result.
     /// </summary>
-    public static L402FetchResult Succeeded(string url, string content, int statusCode, string? contentType = null, long paidAmountSats = 0, string? l402Token = null) =>
+    public static L402FetchResult Succeeded(string url, string content, int statusCode, string? contentType = null, long paidAmountSats = 0, string? l402Token = null, string? protocol = null) =>
         new()
         {
             Success = true,
@@ -143,13 +269,14 @@ public record L402FetchResult
             StatusCode = statusCode,
             ContentType = contentType,
             PaidAmountSats = paidAmountSats,
-            L402Token = l402Token
+            L402Token = l402Token,
+            Protocol = protocol
         };
 
     /// <summary>
     /// Creates a failed result.
     /// </summary>
-    public static L402FetchResult Failed(string url, string error, int statusCode = 0, long paidAmountSats = 0, string? l402Token = null) =>
+    public static L402FetchResult Failed(string url, string error, int statusCode = 0, long paidAmountSats = 0, string? l402Token = null, string? protocol = null) =>
         new()
         {
             Success = false,
@@ -157,6 +284,7 @@ public record L402FetchResult
             ErrorMessage = error,
             StatusCode = statusCode,
             PaidAmountSats = paidAmountSats,
-            L402Token = l402Token
+            L402Token = l402Token,
+            Protocol = protocol
         };
 }

--- a/dotnet/src/LightningEnable.Mcp/Services/IL402HttpClient.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/IL402HttpClient.cs
@@ -27,15 +27,15 @@ public interface IL402HttpClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Manually pays an L402 invoice and returns the token.
+    /// Manually pays an L402/MPP invoice and returns the token.
     /// </summary>
-    /// <param name="macaroonBase64">Base64-encoded macaroon from challenge.</param>
+    /// <param name="macaroonBase64">Base64-encoded macaroon from L402 challenge. Null for MPP (preimage-only).</param>
     /// <param name="invoice">BOLT11 invoice to pay.</param>
     /// <param name="maxSats">Maximum satoshis to pay.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>L402 token (macaroon:preimage) for use in Authorization header.</returns>
+    /// <returns>L402 token (macaroon:preimage) or MPP preimage for use in Authorization header.</returns>
     Task<string> PayChallengeAsync(
-        string macaroonBase64,
+        string? macaroonBase64,
         string invoice,
         long maxSats = 1000,
         CancellationToken cancellationToken = default);

--- a/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
@@ -90,6 +90,9 @@ public class L402HttpClient : IL402HttpClient
             throw new InvalidOperationException("NWC wallet not configured. Set NWC_CONNECTION_STRING environment variable.");
         }
 
+        // Normalize inputs: trim whitespace to prevent invalid tokens/payment failures
+        invoice = invoice.Trim();
+        macaroonBase64 = macaroonBase64?.Trim();
         var isMpp = string.IsNullOrWhiteSpace(macaroonBase64);
 
         // Extract amount from invoice

--- a/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
@@ -80,7 +80,7 @@ public class L402HttpClient : IL402HttpClient
     }
 
     public async Task<string> PayChallengeAsync(
-        string macaroonBase64,
+        string? macaroonBase64,
         string invoice,
         long maxSats = 1000,
         CancellationToken cancellationToken = default)
@@ -89,6 +89,8 @@ public class L402HttpClient : IL402HttpClient
         {
             throw new InvalidOperationException("NWC wallet not configured. Set NWC_CONNECTION_STRING environment variable.");
         }
+
+        var isMpp = string.IsNullOrWhiteSpace(macaroonBase64);
 
         // Extract amount from invoice
         var amountSats = ExtractAmountFromBolt11(invoice);
@@ -119,28 +121,46 @@ public class L402HttpClient : IL402HttpClient
             throw new InvalidOperationException($"Payment failed: {paymentResult.ErrorMessage}");
         }
 
-        // Check if preimage is available - L402 requires it
+        // Check if preimage is available - both L402 and MPP require it
         if (!paymentResult.HasPreimage)
         {
             var trackingInfo = !string.IsNullOrEmpty(paymentResult.TrackingId)
                 ? $" (tracking ID: {paymentResult.TrackingId})"
                 : "";
+            var protocol = isMpp ? "MPP" : "L402";
             throw new InvalidOperationException(
                 $"Payment succeeded{trackingInfo} but wallet did not return preimage. " +
-                "L402 requires preimage for verification. Use NWC or LND wallet for L402 support.");
+                $"{protocol} requires preimage for verification. Use NWC or LND wallet for L402/MPP support.");
         }
 
         // Record payment
         _budgetService.RecordSpend(amountSats.Value);
+
+        if (isMpp)
+        {
+            // MPP mode: return just the preimage
+            _historyService.RecordPayment(
+                url: "manual_payment",
+                method: "MANUAL",
+                amountSats: amountSats.Value,
+                invoice: invoice,
+                preimageHex: paymentResult.PreimageHex,
+                l402Token: paymentResult.PreimageHex);
+
+            return paymentResult.PreimageHex;
+        }
+
+        // L402 mode: return macaroon:preimage
+        var l402Token = $"{macaroonBase64}:{paymentResult.PreimageHex}";
         _historyService.RecordPayment(
             url: "manual_payment",
             method: "MANUAL",
             amountSats: amountSats.Value,
             invoice: invoice,
             preimageHex: paymentResult.PreimageHex,
-            l402Token: $"{macaroonBase64}:{paymentResult.PreimageHex}");
+            l402Token: l402Token);
 
-        return $"{macaroonBase64}:{paymentResult.PreimageHex}";
+        return l402Token;
     }
 
     private async Task<L402FetchResult> HandleL402ChallengeAsync(
@@ -152,13 +172,13 @@ public class L402HttpClient : IL402HttpClient
         HttpResponseMessage initialResponse,
         CancellationToken cancellationToken)
     {
-        // Parse WWW-Authenticate header
-        var wwwAuth = initialResponse.Headers.WwwAuthenticate.FirstOrDefault()?.ToString();
-        var challenge = L402ClientChallenge.Parse(wwwAuth);
+        // Parse WWW-Authenticate headers (may contain both L402 and MPP challenges)
+        var wwwAuthHeaders = initialResponse.Headers.WwwAuthenticate.Select(h => h.ToString()).ToList();
+        var parsed = PaymentChallengeParser.ParseBest(wwwAuthHeaders);
 
-        if (challenge == null)
+        if (!parsed.HasChallenge)
         {
-            return L402FetchResult.Failed(url, "Invalid L402 challenge: Could not parse WWW-Authenticate header", 402);
+            return L402FetchResult.Failed(url, "Invalid payment challenge: Could not parse WWW-Authenticate header (expected L402 or Payment scheme)", 402);
         }
 
         // Check wallet configuration
@@ -168,12 +188,12 @@ public class L402HttpClient : IL402HttpClient
         }
 
         // Extract amount from invoice
-        var amountSats = ExtractAmountFromBolt11(challenge.Invoice);
+        var amountSats = ExtractAmountFromBolt11(parsed.Invoice!);
 
         // Reject no-amount invoices (security: could bypass budget checks)
         if (amountSats == null || amountSats.Value <= 0)
         {
-            return L402FetchResult.Failed(url, "L402 invoice has no amount specified. For security, only invoices with explicit amounts are supported.", 402);
+            return L402FetchResult.Failed(url, "Payment invoice has no amount specified. For security, only invoices with explicit amounts are supported.", 402);
         }
 
         // Check budget
@@ -189,34 +209,58 @@ public class L402HttpClient : IL402HttpClient
         }
 
         // Pay invoice via wallet
-        var paymentResult = await _walletService.PayInvoiceAsync(challenge.Invoice, cancellationToken);
+        var paymentResult = await _walletService.PayInvoiceAsync(parsed.Invoice!, cancellationToken);
 
         if (!paymentResult.Success)
         {
-            _historyService.RecordFailedPayment(url, method, amountSats.Value, paymentResult.ErrorMessage ?? "Unknown error", challenge.Invoice);
+            _historyService.RecordFailedPayment(url, method, amountSats.Value, paymentResult.ErrorMessage ?? "Unknown error", parsed.Invoice!);
             return L402FetchResult.Failed(url, $"Payment failed: {paymentResult.ErrorMessage}", 402);
         }
 
-        // Check if preimage is available - L402 requires it for verification
+        // Check if preimage is available - both L402 and MPP require it for verification
         if (!paymentResult.HasPreimage)
         {
             var trackingInfo = !string.IsNullOrEmpty(paymentResult.TrackingId)
                 ? $" (tracking ID: {paymentResult.TrackingId})"
                 : "";
+            var protocolName = parsed.IsMpp ? "MPP" : "L402";
             _historyService.RecordFailedPayment(url, method, amountSats.Value,
-                $"Payment succeeded but no preimage returned{trackingInfo}. L402 requires preimage.", challenge.Invoice);
+                $"Payment succeeded but no preimage returned{trackingInfo}. {protocolName} requires preimage.", parsed.Invoice!);
             return L402FetchResult.Failed(url,
                 $"Payment succeeded{trackingInfo} but wallet did not return preimage. " +
-                "L402 requires preimage for verification. Use NWC or LND wallet for L402 support.", 402);
+                $"{protocolName} requires preimage for verification. Use NWC or LND wallet for L402/MPP support.", 402);
         }
 
         // Record successful payment
         _budgetService.RecordSpend(amountSats.Value);
-        var l402Token = $"{challenge.MacaroonBase64}:{paymentResult.PreimageHex}";
 
-        // Retry request with L402 token
+        string authToken;
+        string protocol;
+
+        if (parsed.IsMpp)
+        {
+            // MPP: preimage-only authentication
+            authToken = paymentResult.PreimageHex;
+            protocol = "MPP";
+        }
+        else
+        {
+            // L402: macaroon:preimage authentication
+            authToken = $"{parsed.L402!.MacaroonBase64}:{paymentResult.PreimageHex}";
+            protocol = "L402";
+        }
+
+        // Retry request with payment proof
         using var retryRequest = CreateRequest(url, method, headers, body);
-        retryRequest.Headers.Authorization = new AuthenticationHeaderValue(challenge.Scheme, l402Token);
+        if (parsed.IsMpp)
+        {
+            retryRequest.Headers.TryAddWithoutValidation("Authorization",
+                $"Payment method=\"lightning\", preimage=\"{paymentResult.PreimageHex}\"");
+        }
+        else
+        {
+            retryRequest.Headers.Authorization = new AuthenticationHeaderValue(parsed.L402!.Scheme, authToken);
+        }
 
         var retryResponse = await _httpClient.SendAsync(retryRequest, cancellationToken);
         var content = await retryResponse.Content.ReadAsStringAsync(cancellationToken);
@@ -227,17 +271,17 @@ public class L402HttpClient : IL402HttpClient
             url: url,
             method: method,
             amountSats: amountSats.Value,
-            invoice: challenge.Invoice,
+            invoice: parsed.Invoice!,
             preimageHex: paymentResult.PreimageHex,
-            l402Token: l402Token,
+            l402Token: authToken,
             statusCode: (int)retryResponse.StatusCode);
 
         if (retryResponse.IsSuccessStatusCode)
         {
-            return L402FetchResult.Succeeded(url, content, (int)retryResponse.StatusCode, contentType, amountSats.Value, l402Token);
+            return L402FetchResult.Succeeded(url, content, (int)retryResponse.StatusCode, contentType, amountSats.Value, authToken, protocol);
         }
 
-        return L402FetchResult.Failed(url, $"Request failed after payment: HTTP {(int)retryResponse.StatusCode}: {content}", (int)retryResponse.StatusCode, amountSats.Value, l402Token);
+        return L402FetchResult.Failed(url, $"Request failed after payment: HTTP {(int)retryResponse.StatusCode}: {content}", (int)retryResponse.StatusCode, amountSats.Value, authToken, protocol);
     }
 
     private static HttpRequestMessage CreateRequest(string url, string method, string? headers, string? body)

--- a/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/L402HttpClient.cs
@@ -254,6 +254,8 @@ public class L402HttpClient : IL402HttpClient
         using var retryRequest = CreateRequest(url, method, headers, body);
         if (parsed.IsMpp)
         {
+            // Ensure we do not send multiple Authorization headers: remove any existing one first.
+            retryRequest.Headers.Remove("Authorization");
             retryRequest.Headers.TryAddWithoutValidation("Authorization",
                 $"Payment method=\"lightning\", preimage=\"{paymentResult.PreimageHex}\"");
         }

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -225,7 +225,7 @@ public static class AccessL402ResourceTool
                     budgetService?.RecordPaymentTime();
                     paymentHistory?.RecordPayment(
                         url,
-                        "L402",
+                        result.Protocol ?? "L402",
                         result.PaidAmountSats,
                         null,
                         null,

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -220,17 +220,7 @@ public static class AccessL402ResourceTool
             {
                 if (result.PaidAmountSats > 0)
                 {
-                    // Record the actual payment
-                    budgetService?.RecordSpend(result.PaidAmountSats);
-                    budgetService?.RecordPaymentTime();
-                    paymentHistory?.RecordPayment(
-                        url,
-                        result.Protocol ?? "L402",
-                        result.PaidAmountSats,
-                        null,
-                        null,
-                        result.L402Token,
-                        result.StatusCode);
+                    // Budget recording and payment history are handled by L402HttpClient.FetchWithL402Async()
 
                     var amountUsd = priceService != null
                         ? await priceService.SatsToUsdAsync(result.PaidAmountSats, cancellationToken)

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -248,7 +248,8 @@ public static class AccessL402ResourceTool
                             paid = true,
                             amountSats = result.PaidAmountSats,
                             amountUsd = Math.Round(amountUsd, 2),
-                            l402Token = result.L402Token
+                            l402Token = result.L402Token,
+                            protocol = result.Protocol ?? "L402"
                         }
                     });
                 }
@@ -291,8 +292,9 @@ public static class AccessL402ResourceTool
                             amountSats = result.PaidAmountSats,
                             amountUsd,
                             l402Token = result.L402Token,
+                            protocol = result.Protocol ?? "L402",
                             note = "Payment succeeded but the server returned a non-success status on retry. " +
-                                   "The L402 token above is valid and can be used with the correct endpoint."
+                                   "The payment token above is valid and can be used with the correct endpoint."
                         }
                     });
                 }

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -175,7 +175,7 @@ public static class PayL402ChallengeTool
                 }
             }
 
-            var token = await l402Client.PayChallengeAsync(macaroon, invoice, maxSats, cancellationToken);
+            var token = await l402Client.PayChallengeAsync(macaroon, normalizedInvoice, maxSats, cancellationToken);
 
             var isMpp = string.IsNullOrWhiteSpace(macaroon);
             var protocolName = isMpp ? "MPP" : "L402";
@@ -204,6 +204,7 @@ public static class PayL402ChallengeTool
             {
                 success = true,
                 l402Token = token,
+                protocol = protocolName,
                 payment = new
                 {
                     amountSats = budgetCheckAmount,

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -8,17 +8,18 @@ using ModelContextProtocol.Server;
 namespace LightningEnable.Mcp.Tools;
 
 /// <summary>
-/// MCP tool for manually paying an L402 invoice.
+/// MCP tool for manually paying an L402 or MPP (Machine Payments Protocol) invoice.
 /// Use this when you have received a 402 response and want to pay it manually
-/// to get the L402 token for subsequent requests.
+/// to get the authorization token for subsequent requests.
+/// Supports both L402 (macaroon + preimage) and MPP (preimage only) protocols.
 /// </summary>
 [McpServerToolType]
 public static class PayL402ChallengeTool
 {
     /// <summary>
-    /// Manually pays an L402 invoice and returns the token.
+    /// Manually pays an L402 or MPP invoice and returns the authorization token.
     /// </summary>
-    [McpServerTool(Name = "pay_l402_challenge"), Description("Manually pay an L402 Lightning invoice to get the authentication token")]
+    [McpServerTool(Name = "pay_l402_challenge"), Description("Manually pay an L402 or MPP Lightning invoice to get the authentication token. Omit macaroon for MPP mode.")]
     public static async Task<string> PayL402Challenge(
         [Description("BOLT11 Lightning invoice string from the L402 challenge")] string invoice,
         [Description("Base64-encoded macaroon from the L402 challenge. Optional for MPP (Machine Payments Protocol) where only invoice + preimage are needed.")] string? macaroon = null,

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -21,7 +21,7 @@ public static class PayL402ChallengeTool
     [McpServerTool(Name = "pay_l402_challenge"), Description("Manually pay an L402 Lightning invoice to get the authentication token")]
     public static async Task<string> PayL402Challenge(
         [Description("BOLT11 Lightning invoice string from the L402 challenge")] string invoice,
-        [Description("Base64-encoded macaroon from the L402 challenge")] string macaroon,
+        [Description("Base64-encoded macaroon from the L402 challenge. Optional for MPP (Machine Payments Protocol) where only invoice + preimage are needed.")] string? macaroon = null,
         [Description("Maximum satoshis allowed to pay. Defaults to 1000")] int maxSats = 1000,
         [Description("Confirmation nonce from confirm_payment tool. Required when previous call returned requiresConfirmation=true.")] string? confirmationNonce = null,
         McpServer? server = null,
@@ -37,15 +37,6 @@ public static class PayL402ChallengeTool
             {
                 success = false,
                 error = "Invoice is required"
-            });
-        }
-
-        if (string.IsNullOrWhiteSpace(macaroon))
-        {
-            return JsonSerializer.Serialize(new
-            {
-                success = false,
-                error = "Macaroon is required"
             });
         }
 
@@ -185,12 +176,15 @@ public static class PayL402ChallengeTool
 
             var token = await l402Client.PayChallengeAsync(macaroon, invoice, maxSats, cancellationToken);
 
+            var isMpp = string.IsNullOrWhiteSpace(macaroon);
+            var protocolName = isMpp ? "MPP" : "L402";
+
             // Record the payment
             budgetService?.RecordSpend(budgetCheckAmount);
             budgetService?.RecordPaymentTime();
             paymentHistory?.RecordPayment(
                 "l402-challenge",
-                "L402",
+                protocolName,
                 budgetCheckAmount,
                 normalizedInvoice,
                 null,
@@ -200,6 +194,10 @@ public static class PayL402ChallengeTool
             var amountUsd = priceService != null
                 ? await priceService.SatsToUsdAsync(budgetCheckAmount, cancellationToken)
                 : 0m;
+
+            var headerValue = isMpp
+                ? $"Payment method=\"lightning\", preimage=\"{token}\""
+                : $"L402 {token}";
 
             return JsonSerializer.Serialize(new
             {
@@ -213,7 +211,8 @@ public static class PayL402ChallengeTool
                 usage = new
                 {
                     headerName = "Authorization",
-                    headerValue = $"L402 {token}",
+                    headerValue,
+                    protocol = protocolName,
                     description = "Include this header in subsequent requests to the same endpoint"
                 }
             });

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -180,17 +180,7 @@ public static class PayL402ChallengeTool
             var isMpp = string.IsNullOrWhiteSpace(macaroon);
             var protocolName = isMpp ? "MPP" : "L402";
 
-            // Record the payment
-            budgetService?.RecordSpend(budgetCheckAmount);
-            budgetService?.RecordPaymentTime();
-            paymentHistory?.RecordPayment(
-                "l402-challenge",
-                protocolName,
-                budgetCheckAmount,
-                normalizedInvoice,
-                null,
-                token,
-                200);
+            // Budget recording and payment history are handled by L402HttpClient.PayChallengeAsync()
 
             var amountUsd = priceService != null
                 ? await priceService.SatsToUsdAsync(budgetCheckAmount, cancellationToken)

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Models/MppClientChallengeTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Models/MppClientChallengeTests.cs
@@ -68,4 +68,41 @@ public class MppClientChallengeTests
         result.Amount.Should().BeNull();
         result.Realm.Should().BeNull();
     }
+
+    [Fact]
+    public void Parse_TabAfterScheme_Works()
+    {
+        var header = "Payment\tmethod=\"lightning\", invoice=\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+    }
+
+    [Fact]
+    public void Parse_MultipleWhitespaceAfterScheme_Works()
+    {
+        var header = "Payment   \t  method=\"lightning\", invoice=\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+    }
+
+    [Fact]
+    public void Parse_WhitespaceAroundEquals_Works()
+    {
+        var header = "Payment method = \"lightning\", invoice = \"lnbc100n1pjtest\", amount = \"100\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+        result.Amount.Should().Be("100");
+    }
+
+    [Fact]
+    public void Parse_WhitespaceBeforeEquals_Works()
+    {
+        var header = "Payment method =\"lightning\", invoice =\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+    }
 }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Models/MppClientChallengeTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Models/MppClientChallengeTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using LightningEnable.Mcp.Models;
+
+namespace LightningEnable.Mcp.Tests.Models;
+
+public class MppClientChallengeTests
+{
+    [Fact]
+    public void Parse_ValidPaymentHeader_ReturnsMppChallenge()
+    {
+        var header = "Payment realm=\"api.example.com\", method=\"lightning\", invoice=\"lnbc100n1pjtest\", amount=\"100\", currency=\"sat\"";
+        var result = MppClientChallenge.Parse(header);
+
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+        result.Amount.Should().Be("100");
+        result.Realm.Should().Be("api.example.com");
+    }
+
+    [Fact]
+    public void Parse_NonLightningMethod_ReturnsNull()
+    {
+        var header = "Payment realm=\"test\", method=\"stripe\", invoice=\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_MissingInvoice_ReturnsNull()
+    {
+        var header = "Payment realm=\"test\", method=\"lightning\", amount=\"100\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_NonPaymentScheme_ReturnsNull()
+    {
+        var header = "L402 macaroon=\"abc\", invoice=\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_NullOrEmpty_ReturnsNull()
+    {
+        MppClientChallenge.Parse(null).Should().BeNull();
+        MppClientChallenge.Parse("").Should().BeNull();
+        MppClientChallenge.Parse("  ").Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_CaseInsensitive_Works()
+    {
+        var header = "payment realm=\"test\", METHOD=\"Lightning\", invoice=\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+    }
+
+    [Fact]
+    public void Parse_MinimalHeader_Works()
+    {
+        var header = "Payment method=\"lightning\", invoice=\"lnbc100n1pjtest\"";
+        var result = MppClientChallenge.Parse(header);
+        result.Should().NotBeNull();
+        result!.Invoice.Should().Be("lnbc100n1pjtest");
+        result.Amount.Should().BeNull();
+        result.Realm.Should().BeNull();
+    }
+}

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Models/ParseBestChallengeTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Models/ParseBestChallengeTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using LightningEnable.Mcp.Models;
+
+namespace LightningEnable.Mcp.Tests.Models;
+
+public class ParseBestChallengeTests
+{
+    [Fact]
+    public void ParseBest_BothHeaders_PrefersL402()
+    {
+        var headers = new[]
+        {
+            "L402 macaroon=\"abc123\", invoice=\"lnbc100n1pjl402\"",
+            "Payment realm=\"test\", method=\"lightning\", invoice=\"lnbc100n1pjmpp\", amount=\"100\", currency=\"sat\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeTrue();
+        result.IsMpp.Should().BeFalse();
+        result.L402.Should().NotBeNull();
+        result.L402!.Invoice.Should().Be("lnbc100n1pjl402");
+        result.Invoice.Should().Be("lnbc100n1pjl402");
+    }
+
+    [Fact]
+    public void ParseBest_BothHeaders_StillParsesMpp()
+    {
+        var headers = new[]
+        {
+            "L402 macaroon=\"abc123\", invoice=\"lnbc100n1pjl402\"",
+            "Payment realm=\"test\", method=\"lightning\", invoice=\"lnbc100n1pjmpp\", amount=\"100\", currency=\"sat\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        // Even though L402 is preferred, MPP should still be parsed
+        result.Mpp.Should().NotBeNull();
+        result.Mpp!.Invoice.Should().Be("lnbc100n1pjmpp");
+    }
+
+    [Fact]
+    public void ParseBest_OnlyMpp_SelectsMpp()
+    {
+        var headers = new[]
+        {
+            "Payment realm=\"test\", method=\"lightning\", invoice=\"lnbc100n1pjmpp\", amount=\"100\", currency=\"sat\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeTrue();
+        result.IsMpp.Should().BeTrue();
+        result.Mpp.Should().NotBeNull();
+        result.Invoice.Should().Be("lnbc100n1pjmpp");
+    }
+
+    [Fact]
+    public void ParseBest_OnlyL402_SelectsL402()
+    {
+        var headers = new[]
+        {
+            "L402 macaroon=\"abc123\", invoice=\"lnbc100n1pjl402\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeTrue();
+        result.IsMpp.Should().BeFalse();
+        result.L402.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ParseBest_NoValidHeaders_ReturnsEmpty()
+    {
+        var headers = new[] { "Bearer token123", "Basic abc" };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeFalse();
+        result.IsMpp.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseBest_EmptyCollection_ReturnsEmpty()
+    {
+        var result = PaymentChallengeParser.ParseBest(Array.Empty<string>());
+        result.HasChallenge.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseBest_InvoiceProperty_PrefersL402OverMpp()
+    {
+        var headers = new[]
+        {
+            "Payment realm=\"test\", method=\"lightning\", invoice=\"lnbc100n1pjmpp\"",
+            "L402 macaroon=\"abc123\", invoice=\"lnbc100n1pjl402\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        // Invoice should come from L402 since it takes precedence
+        result.Invoice.Should().Be("lnbc100n1pjl402");
+        result.IsMpp.Should().BeFalse();
+    }
+}

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Models/ParseBestChallengeTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Models/ParseBestChallengeTests.cs
@@ -103,4 +103,55 @@ public class ParseBestChallengeTests
         result.Invoice.Should().Be("lnbc100n1pjl402");
         result.IsMpp.Should().BeFalse();
     }
+
+    [Fact]
+    public void ParseBest_CommaSeparatedChallenges_PrefersL402()
+    {
+        // Single header value with Payment first, L402 second (comma-separated)
+        var headers = new[]
+        {
+            "Payment realm=\"test\", method=\"lightning\", invoice=\"lnbc100n1pjmpp\", amount=\"100\", L402 macaroon=\"abc123\", invoice=\"lnbc100n1pjl402\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeTrue();
+        result.IsMpp.Should().BeFalse();
+        result.L402.Should().NotBeNull();
+        result.L402!.Invoice.Should().Be("lnbc100n1pjl402");
+        result.Mpp.Should().NotBeNull();
+        result.Mpp!.Invoice.Should().Be("lnbc100n1pjmpp");
+    }
+
+    [Fact]
+    public void ParseBest_CommaSeparatedL402First_Works()
+    {
+        // L402 first, then Payment in same header value
+        var headers = new[]
+        {
+            "L402 macaroon=\"abc123\", invoice=\"lnbc100n1pjl402\", Payment realm=\"test\", method=\"lightning\", invoice=\"lnbc100n1pjmpp\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeTrue();
+        result.IsMpp.Should().BeFalse();
+        result.L402.Should().NotBeNull();
+        result.L402!.Invoice.Should().Be("lnbc100n1pjl402");
+    }
+
+    [Fact]
+    public void ParseBest_TabWhitespaceInHeaders_Works()
+    {
+        var headers = new[]
+        {
+            "Payment\tmethod=\"lightning\", invoice=\"lnbc100n1pjmpp\""
+        };
+
+        var result = PaymentChallengeParser.ParseBest(headers);
+
+        result.HasChallenge.Should().BeTrue();
+        result.IsMpp.Should().BeTrue();
+        result.Mpp!.Invoice.Should().Be("lnbc100n1pjmpp");
+    }
 }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
@@ -126,18 +126,49 @@ public class L402ToolsTests
     }
 
     [Fact]
-    public async Task PayL402Challenge_WithMissingMacaroon_ReturnsInputError()
+    public async Task PayL402Challenge_WithNullMacaroon_MppMode_ReturnsPreimageOnly()
     {
+        // Arrange
+        _l402ClientMock.Setup(c => c.PayChallengeAsync(
+            null, It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("abcdef1234567890");
+
         // Act
         var result = await PayL402ChallengeTool.PayL402Challenge(
-            invoice: "lnbc100n1...",
-            macaroon: "",
+            invoice: "lnbc100n1pjtest",
+            macaroon: null,
             l402Client: _l402ClientMock.Object);
 
         // Assert
         var json = JsonDocument.Parse(result);
-        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
-        json.RootElement.GetProperty("error").GetString().Should().Contain("Macaroon is required");
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("l402Token").GetString().Should().Be("abcdef1234567890");
+        json.RootElement.GetProperty("usage").GetProperty("protocol").GetString().Should().Be("MPP");
+        json.RootElement.GetProperty("usage").GetProperty("headerValue").GetString()
+            .Should().Contain("Payment method=\"lightning\"");
+    }
+
+    [Fact]
+    public async Task PayL402Challenge_WithMacaroon_L402Mode_ReturnsFullToken()
+    {
+        // Arrange
+        _l402ClientMock.Setup(c => c.PayChallengeAsync(
+            "base64macaroon", It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("base64macaroon:preimage123");
+
+        // Act
+        var result = await PayL402ChallengeTool.PayL402Challenge(
+            invoice: "lnbc100n1pjtest",
+            macaroon: "base64macaroon",
+            l402Client: _l402ClientMock.Object);
+
+        // Assert
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("l402Token").GetString().Should().Be("base64macaroon:preimage123");
+        json.RootElement.GetProperty("usage").GetProperty("protocol").GetString().Should().Be("L402");
+        json.RootElement.GetProperty("usage").GetProperty("headerValue").GetString()
+            .Should().StartWith("L402 ");
     }
 
     #endregion

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -54,6 +54,24 @@ class L402Challenge:
 
 
 @dataclass
+class MppChallenge:
+    """Parsed MPP (Machine Payments Protocol) challenge from WWW-Authenticate header.
+    Per IETF draft-ryan-httpauth-payment. No macaroon — just invoice + preimage."""
+
+    invoice: str
+    amount: str | None = None
+    realm: str | None = None
+    amount_msat: int | None = None
+
+    @property
+    def amount_sats(self) -> int | None:
+        """Return amount in satoshis."""
+        if self.amount_msat is not None:
+            return self.amount_msat // 1000
+        return None
+
+
+@dataclass
 class L402Token:
     """L402 authorization token (macaroon + preimage)."""
 
@@ -63,6 +81,17 @@ class L402Token:
     def to_header(self) -> str:
         """Format as Authorization header value."""
         return f"L402 {self.macaroon}:{self.preimage}"
+
+
+@dataclass
+class MppToken:
+    """MPP authorization token (preimage only, no macaroon)."""
+
+    preimage: str
+
+    def to_header(self) -> str:
+        """Format as Authorization header value."""
+        return f'Payment method="lightning", preimage="{self.preimage}"'
 
 
 class L402Client:
@@ -125,6 +154,74 @@ class L402Client:
 
         return L402Challenge(macaroon=macaroon, invoice=invoice, amount_msat=amount_msat)
 
+    def parse_mpp_challenge(self, www_authenticate: str) -> MppChallenge:
+        """
+        Parse WWW-Authenticate header for MPP (Payment) challenge.
+
+        The header format is:
+        Payment realm="<realm>", method="lightning", invoice="<bolt11>", amount="<amount>", currency="sat"
+
+        Args:
+            www_authenticate: WWW-Authenticate header value
+
+        Returns:
+            Parsed MppChallenge
+
+        Raises:
+            L402Error: If header cannot be parsed
+        """
+        if not www_authenticate.lower().startswith("payment "):
+            raise L402Error(f"Invalid MPP challenge: {www_authenticate[:50]}")
+
+        method_match = re.search(r'method="([^"]+)"', www_authenticate, re.IGNORECASE)
+        if not method_match or method_match.group(1).lower() != "lightning":
+            raise L402Error("MPP challenge method must be 'lightning'")
+
+        invoice_match = re.search(r'invoice="([^"]+)"', www_authenticate, re.IGNORECASE)
+        if not invoice_match:
+            raise L402Error("Missing invoice in MPP challenge")
+        invoice = invoice_match.group(1)
+
+        amount_match = re.search(r'amount="([^"]+)"', www_authenticate, re.IGNORECASE)
+        amount = amount_match.group(1) if amount_match else None
+
+        realm_match = re.search(r'realm="([^"]+)"', www_authenticate, re.IGNORECASE)
+        realm = realm_match.group(1) if realm_match else None
+
+        amount_msat = self._get_invoice_amount_msat(invoice)
+
+        return MppChallenge(invoice=invoice, amount=amount, realm=realm, amount_msat=amount_msat)
+
+    def parse_best_challenge(self, www_authenticate: str) -> L402Challenge | MppChallenge:
+        """
+        Parse WWW-Authenticate header, trying L402 first then MPP.
+
+        Prefers L402 when available (caveats, no cache dependency).
+        Falls back to MPP only when L402 is not available.
+
+        Args:
+            www_authenticate: WWW-Authenticate header value
+
+        Returns:
+            Parsed L402Challenge or MppChallenge
+
+        Raises:
+            L402Error: If neither L402 nor MPP can be parsed
+        """
+        # Try L402 first (preferred)
+        try:
+            return self.parse_l402_challenge(www_authenticate)
+        except L402Error:
+            pass
+
+        # Try MPP fallback
+        try:
+            return self.parse_mpp_challenge(www_authenticate)
+        except L402Error:
+            pass
+
+        raise L402Error(f"No valid L402 or MPP challenge found: {www_authenticate[:80]}")
+
     def _get_invoice_amount_msat(self, bolt11: str) -> int | None:
         """
         Extract amount in millisatoshis from a BOLT11 invoice.
@@ -183,8 +280,8 @@ class L402Client:
             if not www_auth:
                 raise L402Error("402 response without WWW-Authenticate header")
 
-            # Parse challenge
-            challenge = self.parse_l402_challenge(www_auth)
+            # Parse challenge (tries L402 first, falls back to MPP)
+            challenge = self.parse_best_challenge(www_auth)
 
             # Check budget
             if challenge.amount_sats is not None and challenge.amount_sats > max_sats:
@@ -193,11 +290,15 @@ class L402Client:
                 )
 
             # Pay invoice
-            logger.info(f"Paying L402 invoice for {challenge.amount_sats} sats")
+            protocol = "MPP" if isinstance(challenge, MppChallenge) else "L402"
+            logger.info(f"Paying {protocol} invoice for {challenge.amount_sats} sats")
             preimage = await self.wallet.pay_invoice(challenge.invoice)
 
             # Create token
-            token = L402Token(macaroon=challenge.macaroon, preimage=preimage)
+            if isinstance(challenge, MppChallenge):
+                token = MppToken(preimage=preimage)
+            else:
+                token = L402Token(macaroon=challenge.macaroon, preimage=preimage)
 
             # Retry with authorization
             auth_headers = {**headers, "Authorization": token.to_header()}
@@ -221,19 +322,19 @@ class L402Client:
     async def pay_challenge(
         self,
         invoice: str,
-        macaroon: str,
+        macaroon: str | None = None,
         max_sats: int = 1000,
-    ) -> L402Token:
+    ) -> L402Token | MppToken:
         """
-        Pay an L402 invoice and return the authorization token.
+        Pay an L402/MPP invoice and return the authorization token.
 
         Args:
             invoice: BOLT11 invoice string
-            macaroon: Base64-encoded macaroon
+            macaroon: Base64-encoded macaroon (optional; if None, returns MPP token)
             max_sats: Maximum satoshis allowed
 
         Returns:
-            L402Token for authorization
+            L402Token (if macaroon provided) or MppToken (if no macaroon) for authorization
 
         Raises:
             L402BudgetExceededError: If invoice exceeds max_sats
@@ -254,4 +355,6 @@ class L402Client:
         except Exception as e:
             raise L402PaymentError(f"Payment failed: {e!s}") from e
 
-        return L402Token(macaroon=macaroon, preimage=preimage)
+        if macaroon:
+            return L402Token(macaroon=macaroon, preimage=preimage)
+        return MppToken(preimage=preimage)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -133,8 +133,9 @@ class L402Client:
         Raises:
             L402Error: If header cannot be parsed
         """
-        # Handle both L402 and legacy LSAT
-        if not www_authenticate.startswith(("L402 ", "LSAT ")):
+        # Handle both L402 and legacy LSAT (case-insensitive per HTTP spec)
+        upper = www_authenticate.strip().upper()
+        if not (upper.startswith("L402 ") or upper.startswith("LSAT ")):
             raise L402Error(f"Invalid L402 challenge: {www_authenticate[:50]}")
 
         # Extract macaroon
@@ -222,6 +223,48 @@ class L402Client:
 
         raise L402Error(f"No valid L402 or MPP challenge found: {www_authenticate[:80]}")
 
+    def _select_best_challenge(self, www_auth_values: list[str]) -> "L402Challenge | MppChallenge":
+        """
+        Select the best challenge from a list of WWW-Authenticate header values.
+
+        Parses each value individually. Prefers L402/LSAT over MPP.
+
+        Args:
+            www_auth_values: List of WWW-Authenticate header values
+
+        Returns:
+            Best available challenge (L402 preferred, MPP fallback)
+
+        Raises:
+            L402Error: If no valid challenge is found
+        """
+        l402_challenge = None
+        mpp_challenge = None
+
+        for value in www_auth_values:
+            value = value.strip()
+            if not value:
+                continue
+            # Try L402 first
+            try:
+                l402_challenge = self.parse_l402_challenge(value)
+                # L402 is preferred — return immediately
+                return l402_challenge
+            except L402Error:
+                pass
+            # Try MPP
+            try:
+                if mpp_challenge is None:
+                    mpp_challenge = self.parse_mpp_challenge(value)
+            except L402Error:
+                pass
+
+        if mpp_challenge is not None:
+            return mpp_challenge
+
+        combined = "; ".join(v[:40] for v in www_auth_values)
+        raise L402Error(f"No valid L402 or MPP challenge found in headers: {combined}")
+
     def _get_invoice_amount_msat(self, bolt11: str) -> int | None:
         """
         Extract amount in millisatoshis from a BOLT11 invoice.
@@ -276,12 +319,14 @@ class L402Client:
 
         # Check for L402 challenge
         if response.status_code == 402:
-            www_auth = response.headers.get("WWW-Authenticate")
-            if not www_auth:
+            # Use get_list to properly handle multiple WWW-Authenticate headers
+            # (httpx may comma-join them into a single string otherwise)
+            www_auth_values = response.headers.get_list("WWW-Authenticate")
+            if not www_auth_values:
                 raise L402Error("402 response without WWW-Authenticate header")
 
-            # Parse challenge (tries L402 first, falls back to MPP)
-            challenge = self.parse_best_challenge(www_auth)
+            # Parse each header value separately, preferring L402 over MPP
+            challenge = self._select_best_challenge(www_auth_values)
 
             # Check budget
             if challenge.amount_sats is not None and challenge.amount_sats > max_sats:

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -171,6 +171,7 @@ class L402Client:
         Raises:
             L402Error: If header cannot be parsed
         """
+        www_authenticate = www_authenticate.strip()
         if not www_authenticate.lower().startswith("payment "):
             raise L402Error(f"Invalid MPP challenge: {www_authenticate[:50]}")
 
@@ -400,6 +401,7 @@ class L402Client:
         except Exception as e:
             raise L402PaymentError(f"Payment failed: {e!s}") from e
 
-        if macaroon:
-            return L402Token(macaroon=macaroon, preimage=preimage)
+        normalized_macaroon = macaroon.strip() if macaroon is not None else None
+        if normalized_macaroon:
+            return L402Token(macaroon=normalized_macaroon, preimage=preimage)
         return MppToken(preimage=preimage)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -224,11 +224,54 @@ class L402Client:
 
         raise L402Error(f"No valid L402 or MPP challenge found: {www_authenticate[:80]}")
 
+    @staticmethod
+    def _expand_challenges(www_auth_values: list[str]) -> list[str]:
+        """
+        Expand a list of WWW-Authenticate header values into individual challenges.
+
+        A single header value may contain multiple challenges comma-separated, e.g.:
+            'Payment method="lightning", invoice="...", L402 macaroon="...", invoice="..."'
+        This splits on known auth scheme boundaries so each challenge is parsed
+        individually.
+
+        Args:
+            www_auth_values: Raw WWW-Authenticate header values (may be comma-joined)
+
+        Returns:
+            List of individual challenge strings
+        """
+        # Pattern matches the start of a known auth scheme (case-insensitive).
+        # We look for scheme names at the start of a segment or after a comma.
+        scheme_boundary = re.compile(r"(?i)(?:^|,\s*)(?=(?:l402|lsat|payment)\s)", re.IGNORECASE)
+
+        expanded: list[str] = []
+        for value in www_auth_values:
+            if not value or not value.strip():
+                continue
+            matches = list(scheme_boundary.finditer(value))
+            if len(matches) <= 1:
+                # Single challenge (or no recognized scheme) — keep as-is
+                expanded.append(value.strip())
+                continue
+            # Multiple scheme boundaries found — split into segments
+            for i, match in enumerate(matches):
+                start = match.start()
+                # Skip any leading comma/whitespace at the boundary
+                while start < len(value) and value[start] in ", ":
+                    start += 1
+                end = matches[i + 1].start() if i + 1 < len(matches) else len(value)
+                segment = value[start:end].strip().rstrip(",").strip()
+                if segment:
+                    expanded.append(segment)
+
+        return expanded
+
     def _select_best_challenge(self, www_auth_values: list[str]) -> "L402Challenge | MppChallenge":
         """
         Select the best challenge from a list of WWW-Authenticate header values.
 
-        Parses each value individually. Prefers L402/LSAT over MPP.
+        Handles comma-separated challenges within a single header value by expanding
+        them first. Prefers L402/LSAT over MPP.
 
         Args:
             www_auth_values: List of WWW-Authenticate header values
@@ -239,10 +282,13 @@ class L402Client:
         Raises:
             L402Error: If no valid challenge is found
         """
+        # Expand comma-joined header values into individual challenges
+        expanded = self._expand_challenges(www_auth_values)
+
         l402_challenge = None
         mpp_challenge = None
 
-        for value in www_auth_values:
+        for value in expanded:
             value = value.strip()
             if not value:
                 continue

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -329,8 +329,14 @@ class L402Client:
             # Parse each header value separately, preferring L402 over MPP
             challenge = self._select_best_challenge(www_auth_values)
 
+            # Reject no-amount invoices (security: could bypass budget checks)
+            if challenge.amount_sats is None or challenge.amount_sats <= 0:
+                raise L402Error(
+                    "Invoice has no amount specified. For security, only invoices with explicit amounts are supported."
+                )
+
             # Check budget
-            if challenge.amount_sats is not None and challenge.amount_sats > max_sats:
+            if challenge.amount_sats > max_sats:
                 raise L402BudgetExceededError(
                     f"Invoice amount {challenge.amount_sats} sats exceeds maximum {max_sats} sats"
                 )
@@ -383,17 +389,22 @@ class L402Client:
             L402Token (if macaroon provided) or MppToken (if no macaroon) for authorization
 
         Raises:
+            L402Error: If invoice has no amount specified
             L402BudgetExceededError: If invoice exceeds max_sats
             L402PaymentError: If payment fails
         """
-        # Check invoice amount
+        # Check invoice amount — reject no-amount invoices (security: could bypass budget checks)
         amount_msat = self._get_invoice_amount_msat(invoice)
-        if amount_msat is not None:
-            amount_sats = amount_msat // 1000
-            if amount_sats > max_sats:
-                raise L402BudgetExceededError(
-                    f"Invoice amount {amount_sats} sats exceeds maximum {max_sats} sats"
-                )
+        if amount_msat is None or amount_msat <= 0:
+            raise L402Error(
+                "Invoice has no amount specified. For security, only invoices with explicit amounts are supported."
+            )
+
+        amount_sats = amount_msat // 1000
+        if amount_sats > max_sats:
+            raise L402BudgetExceededError(
+                f"Invoice amount {amount_sats} sats exceeds maximum {max_sats} sats"
+            )
 
         # Pay invoice
         try:

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -133,9 +133,10 @@ class L402Client:
         Raises:
             L402Error: If header cannot be parsed
         """
-        # Handle both L402 and legacy LSAT (case-insensitive per HTTP spec)
-        upper = www_authenticate.strip().upper()
-        if not (upper.startswith("L402 ") or upper.startswith("LSAT ")):
+        # Handle both L402 and legacy LSAT (case-insensitive per HTTP spec),
+        # allowing any valid HTTP whitespace (SP / HTAB) and multiple characters.
+        scheme_match = re.match(r'^\s*(L402|LSAT)\s+', www_authenticate, re.IGNORECASE)
+        if not scheme_match:
             raise L402Error(f"Invalid L402 challenge: {www_authenticate[:50]}")
 
         # Extract macaroon
@@ -172,22 +173,25 @@ class L402Client:
             L402Error: If header cannot be parsed
         """
         www_authenticate = www_authenticate.strip()
-        if not www_authenticate.lower().startswith("payment "):
+        parts = www_authenticate.split(None, 1)
+        if not parts or parts[0].lower() != "payment":
             raise L402Error(f"Invalid MPP challenge: {www_authenticate[:50]}")
 
-        method_match = re.search(r'method="([^"]+)"', www_authenticate, re.IGNORECASE)
+        params_str = parts[1] if len(parts) > 1 else ""
+
+        method_match = re.search(r'method="([^"]+)"', params_str, re.IGNORECASE)
         if not method_match or method_match.group(1).lower() != "lightning":
             raise L402Error("MPP challenge method must be 'lightning'")
 
-        invoice_match = re.search(r'invoice="([^"]+)"', www_authenticate, re.IGNORECASE)
+        invoice_match = re.search(r'invoice="([^"]+)"', params_str, re.IGNORECASE)
         if not invoice_match:
             raise L402Error("Missing invoice in MPP challenge")
         invoice = invoice_match.group(1)
 
-        amount_match = re.search(r'amount="([^"]+)"', www_authenticate, re.IGNORECASE)
+        amount_match = re.search(r'amount="([^"]+)"', params_str, re.IGNORECASE)
         amount = amount_match.group(1) if amount_match else None
 
-        realm_match = re.search(r'realm="([^"]+)"', www_authenticate, re.IGNORECASE)
+        realm_match = re.search(r'realm="([^"]+)"', params_str, re.IGNORECASE)
         realm = realm_match.group(1) if realm_match else None
 
         amount_msat = self._get_invoice_amount_msat(invoice)
@@ -200,6 +204,8 @@ class L402Client:
 
         Prefers L402 when available (caveats, no cache dependency).
         Falls back to MPP only when L402 is not available.
+        Handles comma-separated challenges in a single header value
+        (e.g., "Payment ..., L402 ...") by delegating to _select_best_challenge.
 
         Args:
             www_authenticate: WWW-Authenticate header value
@@ -210,19 +216,7 @@ class L402Client:
         Raises:
             L402Error: If neither L402 nor MPP can be parsed
         """
-        # Try L402 first (preferred)
-        try:
-            return self.parse_l402_challenge(www_authenticate)
-        except L402Error:
-            pass
-
-        # Try MPP fallback
-        try:
-            return self.parse_mpp_challenge(www_authenticate)
-        except L402Error:
-            pass
-
-        raise L402Error(f"No valid L402 or MPP challenge found: {www_authenticate[:80]}")
+        return self._select_best_challenge([www_authenticate])
 
     @staticmethod
     def _expand_challenges(www_auth_values: list[str]) -> list[str]:

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -47,9 +47,9 @@ class L402Challenge:
 
     @property
     def amount_sats(self) -> int | None:
-        """Return amount in satoshis."""
+        """Return amount in satoshis (ceiling division to avoid sub-sat amounts rounding to 0)."""
         if self.amount_msat is not None:
-            return self.amount_msat // 1000
+            return -(-self.amount_msat // 1000)  # ceil division
         return None
 
 
@@ -65,9 +65,9 @@ class MppChallenge:
 
     @property
     def amount_sats(self) -> int | None:
-        """Return amount in satoshis."""
+        """Return amount in satoshis (ceiling division to avoid sub-sat amounts rounding to 0)."""
         if self.amount_msat is not None:
-            return self.amount_msat // 1000
+            return -(-self.amount_msat // 1000)  # ceil division
         return None
 
 
@@ -440,7 +440,7 @@ class L402Client:
                 "Invoice has no amount specified. For security, only invoices with explicit amounts are supported."
             )
 
-        amount_sats = amount_msat // 1000
+        amount_sats = -(-amount_msat // 1000)  # ceil division: sub-sat amounts round up to 1
         if amount_sats > max_sats:
             raise L402BudgetExceededError(
                 f"Invoice amount {amount_sats} sats exceeds maximum {max_sats} sats"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -148,7 +148,7 @@ class LightningEnableServer:
                                 "description": "BOLT11 Lightning invoice string",
                             },
                             "macaroon": {
-                                "type": "string",
+                                "type": ["string", "null"],
                                 "description": "Base64-encoded macaroon from the L402 challenge. Omit for MPP mode (preimage-only authentication).",
                             },
                             "max_sats": {

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -136,8 +136,9 @@ class LightningEnableServer:
                 Tool(
                     name="pay_l402_challenge",
                     description=(
-                        "Manually pay an L402 invoice and receive the authorization token. "
-                        "Use this if you need to handle the L402 flow yourself."
+                        "Manually pay an L402 or MPP invoice and receive the authorization token. "
+                        "Use this if you need to handle the L402/MPP flow yourself. "
+                        "Omit macaroon for MPP (Machine Payments Protocol) mode."
                     ),
                     inputSchema={
                         "type": "object",
@@ -148,7 +149,7 @@ class LightningEnableServer:
                             },
                             "macaroon": {
                                 "type": "string",
-                                "description": "Base64-encoded macaroon from the L402 challenge",
+                                "description": "Base64-encoded macaroon from the L402 challenge. Omit for MPP mode (preimage-only authentication).",
                             },
                             "max_sats": {
                                 "type": "integer",
@@ -156,7 +157,7 @@ class LightningEnableServer:
                                 "default": 1000,
                             },
                         },
-                        "required": ["invoice", "macaroon"],
+                        "required": ["invoice"],
                     },
                 ),
                 Tool(
@@ -490,7 +491,7 @@ class LightningEnableServer:
                 elif name == "pay_l402_challenge":
                     result = await pay_l402_challenge(
                         invoice=arguments["invoice"],
-                        macaroon=arguments["macaroon"],
+                        macaroon=arguments.get("macaroon"),
                         max_sats=arguments.get("max_sats", 1000),
                         wallet=self.wallet,
                         budget_manager=self.budget_manager,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -20,26 +20,29 @@ logger = logging.getLogger("lightning-enable-mcp.tools.pay")
 
 async def pay_l402_challenge(
     invoice: str,
-    macaroon: str,
+    macaroon: str | None = None,
     max_sats: int = 1000,
     wallet: "NWCWallet | None" = None,
     budget_manager: "BudgetManager | None" = None,
 ) -> str:
     """
-    Manually pay an L402 invoice and receive the authorization token.
+    Manually pay an L402 or MPP invoice and receive the authorization token.
 
-    This is useful when you want to handle the L402 flow yourself rather than
+    This is useful when you want to handle the L402/MPP flow yourself rather than
     using access_l402_resource which does it automatically.
+
+    When macaroon is provided, uses L402 protocol.
+    When macaroon is omitted, uses MPP (Machine Payments Protocol) — preimage only.
 
     Args:
         invoice: BOLT11 Lightning invoice string
-        macaroon: Base64-encoded macaroon from the L402 challenge
+        macaroon: Base64-encoded macaroon from the L402 challenge (optional; omit for MPP mode)
         max_sats: Maximum satoshis allowed for this payment
         wallet: NWC wallet instance
         budget_manager: Budget manager for tracking spending
 
     Returns:
-        JSON with L402 token or error message
+        JSON with L402/MPP token or error message
     """
     if not wallet:
         return json.dumps(
@@ -49,8 +52,8 @@ async def pay_l402_challenge(
     if not invoice:
         return json.dumps({"success": False, "error": "Invoice is required"})
 
-    if not macaroon:
-        return json.dumps({"success": False, "error": "Macaroon is required"})
+    # Determine protocol: L402 if macaroon provided, MPP otherwise
+    is_mpp = not macaroon
 
     try:
         # Parse invoice to get amount
@@ -84,36 +87,51 @@ async def pay_l402_challenge(
                 )
 
         # Pay the invoice
-        logger.info(f"Paying invoice for {amount_sats} sats")
+        protocol = "MPP" if is_mpp else "L402"
+        logger.info(f"Paying {protocol} invoice for {amount_sats} sats")
         preimage = await wallet.pay_invoice(invoice)
 
         # Record payment
         if budget_manager and amount_sats:
             budget_manager.record_payment(
-                url="manual_l402_payment",
+                url=f"manual_{protocol.lower()}_payment",
                 amount_sats=amount_sats,
                 invoice=invoice,
                 preimage=preimage,
                 status="success",
             )
 
-        # Construct L402 token
-        l402_token = f"{macaroon}:{preimage}"
+        # Construct authorization header based on protocol
+        if is_mpp:
+            authorization_header = f'Payment method="lightning", preimage="{preimage}"'
+        else:
+            l402_token = f"{macaroon}:{preimage}"
+            authorization_header = f"L402 {l402_token}"
 
         result = {
             "success": True,
-            "token": l402_token,
-            "authorization_header": f"L402 {l402_token}",
             "preimage": preimage,
             "amount_sats": amount_sats,
+            "protocol": protocol,
+            "usage": {
+                "headerName": "Authorization",
+                "headerValue": authorization_header,
+                "protocol": protocol,
+                "description": "Include this header in subsequent requests to the same endpoint",
+            },
             "message": (
-                f"Payment successful. Use the authorization_header value in your "
-                f"Authorization header to access the L402-protected resource."
+                f"Payment successful ({protocol}). Use the authorization header value "
+                f"to access the protected resource."
             ),
         }
+
+        # Include token for L402 backward compatibility
+        if not is_mpp:
+            result["token"] = f"{macaroon}:{preimage}"
+            result["authorization_header"] = authorization_header
 
         return json.dumps(result, indent=2)
 
     except Exception as e:
-        logger.exception("Error paying L402 challenge")
+        logger.exception("Error paying L402/MPP challenge")
         return json.dumps({"success": False, "error": sanitize_error(str(e))})

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -71,8 +71,17 @@ async def pay_l402_challenge(
         elif hasattr(decoded, "amount") and decoded.amount:
             amount_sats = decoded.amount
 
+        # Reject no-amount invoices (security: could bypass budget checks)
+        if amount_sats is None or amount_sats <= 0:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": "Invoice has no amount specified. For security, only invoices with explicit amounts are supported.",
+                }
+            )
+
         # Check against max_sats
-        if amount_sats is not None and amount_sats > max_sats:
+        if amount_sats > max_sats:
             return json.dumps(
                 {
                     "success": False,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -67,7 +67,7 @@ async def pay_l402_challenge(
 
         if hasattr(decoded, "amount_msat") and decoded.amount_msat:
             amount_msat = decoded.amount_msat
-            amount_sats = amount_msat // 1000
+            amount_sats = -(-amount_msat // 1000)  # ceil division: sub-sat amounts round up to 1
         elif hasattr(decoded, "amount") and decoded.amount:
             amount_sats = decoded.amount
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -52,8 +52,12 @@ async def pay_l402_challenge(
     if not invoice:
         return json.dumps({"success": False, "error": "Invoice is required"})
 
-    # Determine protocol: L402 if macaroon provided, MPP otherwise
-    is_mpp = not macaroon
+    # Normalize macaroon: strip whitespace and treat empty/whitespace-only as None
+    if macaroon is not None:
+        macaroon = macaroon.strip()
+        if not macaroon:
+            macaroon = None
+    is_mpp = macaroon is None
 
     try:
         # Parse invoice to get amount

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -125,10 +125,16 @@ async def pay_l402_challenge(
             ),
         }
 
-        # Include token for L402 backward compatibility
-        if not is_mpp:
+        # Include token and authorization_header for backward compatibility across protocols
+        if is_mpp:
+            # For MPP, the token is just the preimage
+            result["token"] = preimage
+        else:
+            # For L402, preserve existing macaroon:preimage token format
             result["token"] = f"{macaroon}:{preimage}"
-            result["authorization_header"] = authorization_header
+
+        # Always include the full authorization header
+        result["authorization_header"] = authorization_header
 
         return json.dumps(result, indent=2)
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -52,6 +52,9 @@ async def pay_l402_challenge(
     if not invoice:
         return json.dumps({"success": False, "error": "Invoice is required"})
 
+    # Normalize invoice: strip whitespace/newlines that could cause decode or payment failures
+    invoice = invoice.strip()
+
     # Normalize macaroon: strip whitespace and treat empty/whitespace-only as None
     if macaroon is not None:
         macaroon = macaroon.strip()

--- a/python/lightning-enable-mcp/tests/test_l402_client.py
+++ b/python/lightning-enable-mcp/tests/test_l402_client.py
@@ -2,6 +2,8 @@
 Tests for L402 Client
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from lightning_enable_mcp.l402_client import (
     L402Client,
@@ -9,6 +11,7 @@ from lightning_enable_mcp.l402_client import (
     L402Token,
     L402Error,
     L402BudgetExceededError,
+    MppToken,
 )
 
 
@@ -120,3 +123,74 @@ class TestL402ChallengeAmount:
         )
 
         assert challenge.amount_sats is None
+
+
+class TestPayChallengeNoAmountRejection:
+    """Tests that pay_challenge rejects invoices without an explicit amount (security)."""
+
+    def setup_method(self):
+        """Create a client with a mock wallet."""
+
+        class MockWallet:
+            pass
+
+        self.client = L402Client(wallet=MockWallet())  # type: ignore
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_rejects_no_amount_invoice(self):
+        """Invoices without an amount should be rejected for security."""
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=None
+        ):
+            with pytest.raises(L402Error, match="no amount specified"):
+                await self.client.pay_challenge(invoice="lnbc1pjtest")
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_rejects_zero_amount_invoice(self):
+        """Invoices with zero amount should be rejected for security."""
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=0
+        ):
+            with pytest.raises(L402Error, match="no amount specified"):
+                await self.client.pay_challenge(invoice="lnbc1pjtest")
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_rejects_no_amount_mpp_mode(self):
+        """MPP mode (no macaroon) should also reject no-amount invoices."""
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=None
+        ):
+            with pytest.raises(L402Error, match="no amount specified"):
+                await self.client.pay_challenge(invoice="lnbc1pjtest", macaroon=None)
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_accepts_valid_amount(self):
+        """Invoices with a valid amount should proceed to payment."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage123")
+        self.client.wallet = mock_wallet
+
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=10000
+        ):
+            result = await self.client.pay_challenge(
+                invoice="lnbc10n1pjtest", macaroon="mac123"
+            )
+            assert isinstance(result, L402Token)
+            assert result.preimage == "preimage123"
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_mpp_accepts_valid_amount(self):
+        """MPP mode with a valid amount should return MppToken."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage456")
+        self.client.wallet = mock_wallet
+
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=5000
+        ):
+            result = await self.client.pay_challenge(
+                invoice="lnbc5n1pjtest", macaroon=None
+            )
+            assert isinstance(result, MppToken)
+            assert result.preimage == "preimage456"

--- a/python/lightning-enable-mcp/tests/test_l402_client.py
+++ b/python/lightning-enable-mcp/tests/test_l402_client.py
@@ -124,6 +124,26 @@ class TestL402ChallengeAmount:
 
         assert challenge.amount_sats is None
 
+    def test_amount_sats_sub_sat_rounds_up(self):
+        """Sub-satoshi amounts (1-999 msat) should round up to 1 sat, not 0."""
+        challenge = L402Challenge(
+            macaroon="test",
+            invoice="test",
+            amount_msat=500,
+        )
+
+        assert challenge.amount_sats == 1
+
+    def test_amount_sats_rounds_up(self):
+        """Millisats that don't divide evenly by 1000 should round up (ceiling)."""
+        challenge = L402Challenge(
+            macaroon="test",
+            invoice="test",
+            amount_msat=10999,
+        )
+
+        assert challenge.amount_sats == 11
+
 
 class TestPayChallengeNoAmountRejection:
     """Tests that pay_challenge rejects invoices without an explicit amount (security)."""
@@ -194,3 +214,30 @@ class TestPayChallengeNoAmountRejection:
             )
             assert isinstance(result, MppToken)
             assert result.preimage == "preimage456"
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_sub_sat_rounds_up_and_checks_budget(self):
+        """Sub-satoshi invoices (1-999 msat) should round up to 1 sat for budget checks."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage_subsats")
+        self.client.wallet = mock_wallet
+
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=500
+        ):
+            result = await self.client.pay_challenge(
+                invoice="lnbc1pjtest", macaroon="mac123", max_sats=1
+            )
+            assert isinstance(result, L402Token)
+            assert result.preimage == "preimage_subsats"
+
+    @pytest.mark.asyncio
+    async def test_pay_challenge_sub_sat_exceeds_budget(self):
+        """Sub-sat amount rounded up to 1 should fail if max_sats is 0."""
+        with patch.object(
+            self.client, "_get_invoice_amount_msat", return_value=500
+        ):
+            with pytest.raises(L402BudgetExceededError):
+                await self.client.pay_challenge(
+                    invoice="lnbc1pjtest", macaroon="mac123", max_sats=0
+                )

--- a/python/lightning-enable-mcp/tests/test_mpp_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_mpp_challenge.py
@@ -158,6 +158,86 @@ class TestParseBestChallenge:
         assert result.realm == "weather.api.com"
         assert result.amount == "50"
 
+    def test_case_insensitive_l402_scheme(self):
+        """L402 scheme detection should be case-insensitive per HTTP spec."""
+        header = 'l402 macaroon="abc123", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, L402Challenge)
+        assert result.macaroon == "abc123"
+
+    def test_case_insensitive_lsat_scheme(self):
+        """LSAT scheme detection should be case-insensitive per HTTP spec."""
+        header = 'lsat macaroon="abc123", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, L402Challenge)
+        assert result.macaroon == "abc123"
+
+    def test_mixed_case_l402_scheme(self):
+        """Mixed case like 'L402' or 'l402' should both work."""
+        for scheme in ("L402", "l402", "Lsat", "lSAT"):
+            header = f'{scheme} macaroon="mac", invoice="lnbc100n1pjtest"'
+            result = self.client.parse_best_challenge(header)
+            assert isinstance(result, L402Challenge)
+
+
+class TestSelectBestChallenge:
+    """Tests for _select_best_challenge — handles multiple WWW-Authenticate header values."""
+
+    def setup_method(self):
+        self.client = L402Client(wallet=MockWallet())  # type: ignore
+
+    def test_single_l402_header(self):
+        headers = ['L402 macaroon="abc", invoice="lnbc100n1pjtest"']
+        result = self.client._select_best_challenge(headers)
+        assert isinstance(result, L402Challenge)
+
+    def test_single_mpp_header(self):
+        headers = ['Payment method="lightning", invoice="lnbc100n1pjtest"']
+        result = self.client._select_best_challenge(headers)
+        assert isinstance(result, MppChallenge)
+
+    def test_l402_preferred_when_both_present(self):
+        """When server sends both L402 and MPP headers, L402 should be preferred."""
+        headers = [
+            'Payment method="lightning", invoice="lnbc200n1pjmpp"',
+            'L402 macaroon="mac123", invoice="lnbc100n1pjl402"',
+        ]
+        result = self.client._select_best_challenge(headers)
+        assert isinstance(result, L402Challenge)
+        assert result.invoice == "lnbc100n1pjl402"
+
+    def test_l402_preferred_even_when_mpp_first(self):
+        """L402 should be preferred regardless of header order."""
+        headers = [
+            'Payment method="lightning", invoice="lnbc200n1pjmpp"',
+            'L402 macaroon="mac123", invoice="lnbc100n1pjl402"',
+        ]
+        result = self.client._select_best_challenge(headers)
+        assert isinstance(result, L402Challenge)
+
+    def test_falls_back_to_mpp_when_no_l402(self):
+        """When only MPP is present, it should be returned."""
+        headers = [
+            'Bearer realm="test"',
+            'Payment method="lightning", invoice="lnbc100n1pjmpp"',
+        ]
+        result = self.client._select_best_challenge(headers)
+        assert isinstance(result, MppChallenge)
+
+    def test_no_valid_headers_raises(self):
+        headers = ["Bearer token123", "Basic realm=test"]
+        with pytest.raises(L402Error, match="No valid"):
+            self.client._select_best_challenge(headers)
+
+    def test_empty_list_raises(self):
+        with pytest.raises(L402Error, match="No valid"):
+            self.client._select_best_challenge([])
+
+    def test_whitespace_headers_ignored(self):
+        headers = ["  ", "", 'L402 macaroon="abc", invoice="lnbc100n1pjtest"']
+        result = self.client._select_best_challenge(headers)
+        assert isinstance(result, L402Challenge)
+
 
 class TestPayChallengeProtocol:
     """Tests for pay_challenge return types based on macaroon presence."""

--- a/python/lightning-enable-mcp/tests/test_mpp_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_mpp_challenge.py
@@ -239,6 +239,70 @@ class TestSelectBestChallenge:
         assert isinstance(result, L402Challenge)
 
 
+class TestExpandChallenges:
+    """Tests for _expand_challenges — handles comma-separated challenges in a single header."""
+
+    def setup_method(self):
+        self.client = L402Client(wallet=MockWallet())  # type: ignore
+
+    def test_single_challenge_unchanged(self):
+        values = ['L402 macaroon="abc", invoice="lnbc100n1pjtest"']
+        result = L402Client._expand_challenges(values)
+        assert len(result) == 1
+        assert result[0].startswith("L402")
+
+    def test_single_mpp_challenge_unchanged(self):
+        values = ['Payment method="lightning", invoice="lnbc100n1pjtest"']
+        result = L402Client._expand_challenges(values)
+        assert len(result) == 1
+        assert result[0].startswith("Payment")
+
+    def test_comma_joined_payment_then_l402(self):
+        """A single header value with Payment and L402 should expand to two challenges."""
+        combined = (
+            'Payment method="lightning", invoice="lnbc200n1pjmpp", '
+            'L402 macaroon="mac123", invoice="lnbc100n1pjl402"'
+        )
+        result = L402Client._expand_challenges([combined])
+        assert len(result) == 2
+        assert result[0].startswith("Payment")
+        assert result[1].startswith("L402")
+
+    def test_comma_joined_l402_then_payment(self):
+        """L402 first, then Payment in single value — should expand to two challenges."""
+        combined = (
+            'L402 macaroon="mac123", invoice="lnbc100n1pjl402", '
+            'Payment method="lightning", invoice="lnbc200n1pjmpp"'
+        )
+        result = L402Client._expand_challenges([combined])
+        assert len(result) == 2
+        assert result[0].startswith("L402")
+        assert result[1].startswith("Payment")
+
+    def test_empty_and_whitespace_values_ignored(self):
+        result = L402Client._expand_challenges(["", "  ", ""])
+        assert len(result) == 0
+
+    def test_multiple_separate_values_passthrough(self):
+        """Multiple separate header values should pass through unchanged."""
+        values = [
+            'Payment method="lightning", invoice="lnbc200n1pjmpp"',
+            'L402 macaroon="mac123", invoice="lnbc100n1pjl402"',
+        ]
+        result = L402Client._expand_challenges(values)
+        assert len(result) == 2
+
+    def test_select_best_prefers_l402_in_comma_joined(self):
+        """When a single header has Payment then L402 comma-joined, L402 should be selected."""
+        combined = (
+            'Payment method="lightning", invoice="lnbc200n1pjmpp", '
+            'L402 macaroon="mac123", invoice="lnbc100n1pjl402"'
+        )
+        result = self.client._select_best_challenge([combined])
+        assert isinstance(result, L402Challenge)
+        assert result.invoice == "lnbc100n1pjl402"
+
+
 class TestPayChallengeProtocol:
     """Tests for pay_challenge return types based on macaroon presence."""
 

--- a/python/lightning-enable-mcp/tests/test_mpp_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_mpp_challenge.py
@@ -87,13 +87,29 @@ class TestMppChallengeAmountSats:
         )
         assert challenge.amount_sats is None
 
-    def test_amount_sats_truncation(self):
-        """Millisats that don't divide evenly by 1000 should truncate."""
+    def test_amount_sats_rounds_up(self):
+        """Millisats that don't divide evenly by 1000 should round up (ceiling)."""
         challenge = MppChallenge(
             invoice="test",
             amount_msat=10999,
         )
-        assert challenge.amount_sats == 10
+        assert challenge.amount_sats == 11
+
+    def test_amount_sats_sub_sat_rounds_up_to_one(self):
+        """Sub-satoshi amounts (1-999 msat) should round up to 1 sat, not 0."""
+        challenge = MppChallenge(
+            invoice="test",
+            amount_msat=500,
+        )
+        assert challenge.amount_sats == 1
+
+    def test_amount_sats_1_msat_rounds_up_to_one(self):
+        """Even 1 msat should round up to 1 sat."""
+        challenge = MppChallenge(
+            invoice="test",
+            amount_msat=1,
+        )
+        assert challenge.amount_sats == 1
 
 
 class TestMppToken:

--- a/python/lightning-enable-mcp/tests/test_mpp_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_mpp_challenge.py
@@ -1,0 +1,183 @@
+"""Tests for MPP (Machine Payments Protocol) challenge parsing."""
+
+import pytest
+from lightning_enable_mcp.l402_client import (
+    L402Client,
+    L402Challenge,
+    L402Error,
+    L402Token,
+    MppChallenge,
+    MppToken,
+)
+
+
+class MockWallet:
+    """Minimal mock wallet for creating L402Client instances."""
+
+    pass
+
+
+class TestMppChallengeParsing:
+    """Tests for MppChallenge parsing."""
+
+    def setup_method(self):
+        """Create a client with a mock wallet."""
+        self.client = L402Client(wallet=MockWallet())  # type: ignore
+
+    def test_parse_valid_mpp_header(self):
+        header = 'Payment realm="api.example.com", method="lightning", invoice="lnbc100n1pjtest", amount="100", currency="sat"'
+        result = self.client.parse_mpp_challenge(header)
+        assert isinstance(result, MppChallenge)
+        assert result.invoice == "lnbc100n1pjtest"
+        assert result.amount == "100"
+        assert result.realm == "api.example.com"
+
+    def test_parse_non_lightning_method_raises(self):
+        header = 'Payment realm="test", method="stripe", invoice="lnbc100n1pjtest"'
+        with pytest.raises(L402Error, match="must be 'lightning'"):
+            self.client.parse_mpp_challenge(header)
+
+    def test_parse_missing_invoice_raises(self):
+        header = 'Payment realm="test", method="lightning", amount="100"'
+        with pytest.raises(L402Error, match="Missing invoice"):
+            self.client.parse_mpp_challenge(header)
+
+    def test_parse_non_payment_scheme_raises(self):
+        header = 'L402 macaroon="abc", invoice="lnbc100n1pjtest"'
+        with pytest.raises(L402Error, match="Invalid MPP"):
+            self.client.parse_mpp_challenge(header)
+
+    def test_parse_minimal_header(self):
+        header = 'Payment method="lightning", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_mpp_challenge(header)
+        assert result.invoice == "lnbc100n1pjtest"
+        assert result.amount is None
+        assert result.realm is None
+
+    def test_parse_case_insensitive_scheme(self):
+        header = 'payment method="lightning", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_mpp_challenge(header)
+        assert result.invoice == "lnbc100n1pjtest"
+
+    def test_parse_case_insensitive_method(self):
+        header = 'Payment METHOD="Lightning", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_mpp_challenge(header)
+        assert result.invoice == "lnbc100n1pjtest"
+
+    def test_parse_missing_method_raises(self):
+        header = 'Payment invoice="lnbc100n1pjtest", amount="100"'
+        with pytest.raises(L402Error, match="must be 'lightning'"):
+            self.client.parse_mpp_challenge(header)
+
+
+class TestMppChallengeAmountSats:
+    """Tests for MppChallenge.amount_sats property."""
+
+    def test_amount_sats_conversion(self):
+        challenge = MppChallenge(
+            invoice="test",
+            amount_msat=10000,
+        )
+        assert challenge.amount_sats == 10
+
+    def test_amount_sats_none_when_no_msat(self):
+        challenge = MppChallenge(
+            invoice="test",
+            amount_msat=None,
+        )
+        assert challenge.amount_sats is None
+
+    def test_amount_sats_truncation(self):
+        """Millisats that don't divide evenly by 1000 should truncate."""
+        challenge = MppChallenge(
+            invoice="test",
+            amount_msat=10999,
+        )
+        assert challenge.amount_sats == 10
+
+
+class TestMppToken:
+    """Tests for MppToken."""
+
+    def test_to_header(self):
+        token = MppToken(preimage="abcdef1234567890")
+        expected = 'Payment method="lightning", preimage="abcdef1234567890"'
+        assert token.to_header() == expected
+
+    def test_to_header_full_preimage(self):
+        preimage = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        token = MppToken(preimage=preimage)
+        assert preimage in token.to_header()
+        assert token.to_header().startswith("Payment ")
+
+
+class TestParseBestChallenge:
+    """Tests for parse_best_challenge — prefers L402, falls back to MPP."""
+
+    def setup_method(self):
+        self.client = L402Client(wallet=MockWallet())  # type: ignore
+
+    def test_l402_header_returns_l402(self):
+        header = 'L402 macaroon="abc123", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, L402Challenge)
+        assert result.macaroon == "abc123"
+        assert result.invoice == "lnbc100n1pjtest"
+
+    def test_lsat_header_returns_l402(self):
+        header = 'LSAT macaroon="abc123", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, L402Challenge)
+        assert result.macaroon == "abc123"
+
+    def test_mpp_header_returns_mpp(self):
+        header = 'Payment method="lightning", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, MppChallenge)
+        assert result.invoice == "lnbc100n1pjtest"
+
+    def test_invalid_header_raises(self):
+        with pytest.raises(L402Error, match="No valid"):
+            self.client.parse_best_challenge("Bearer token123")
+
+    def test_empty_header_raises(self):
+        with pytest.raises(L402Error, match="No valid"):
+            self.client.parse_best_challenge("")
+
+    def test_l402_preferred_over_mpp_when_both_valid(self):
+        """When the header starts with L402, it should be parsed as L402 even though
+        it could theoretically contain MPP-style fields."""
+        header = 'L402 macaroon="mac123", invoice="lnbc100n1pjtest"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, L402Challenge)
+
+    def test_mpp_header_with_full_fields(self):
+        header = 'Payment realm="weather.api.com", method="lightning", invoice="lnbc50n1pj...", amount="50", currency="sat"'
+        result = self.client.parse_best_challenge(header)
+        assert isinstance(result, MppChallenge)
+        assert result.realm == "weather.api.com"
+        assert result.amount == "50"
+
+
+class TestPayChallengeProtocol:
+    """Tests for pay_challenge return types based on macaroon presence."""
+
+    def test_l402_token_has_macaroon_and_preimage(self):
+        token = L402Token(macaroon="mac123", preimage="pre456")
+        assert "L402" in token.to_header()
+        assert "mac123" in token.to_header()
+        assert "pre456" in token.to_header()
+
+    def test_mpp_token_has_only_preimage(self):
+        token = MppToken(preimage="pre456")
+        header = token.to_header()
+        assert "Payment" in header
+        assert "pre456" in header
+        assert "macaroon" not in header.lower()
+
+    def test_l402_and_mpp_tokens_have_different_headers(self):
+        l402 = L402Token(macaroon="mac", preimage="pre")
+        mpp = MppToken(preimage="pre")
+        assert l402.to_header() != mpp.to_header()
+        assert l402.to_header().startswith("L402 ")
+        assert mpp.to_header().startswith("Payment ")

--- a/python/lightning-enable-mcp/tests/test_pay_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_pay_challenge.py
@@ -135,6 +135,56 @@ class TestPayL402ChallengeNoAmountRejection:
         mock_wallet.pay_invoice.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_sub_sat_amount_rounds_up_to_one(self):
+        """Sub-satoshi invoices (1-999 msat) should round up to 1 sat, not 0."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage_sub")
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = 500
+        mock_decoded.amount = None
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc1pjtest",
+                    macaroon="mac123",
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is True
+        assert result["amount_sats"] == 1
+        mock_wallet.pay_invoice.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sub_sat_amount_enforces_budget(self):
+        """Sub-sat amounts rounded up to 1 sat should still be checked against max_sats."""
+        mock_wallet = AsyncMock()
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = 500
+        mock_decoded.amount = None
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc1pjtest",
+                    macaroon="mac123",
+                    max_sats=0,
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is False
+        assert "exceeds maximum" in result["error"]
+        mock_wallet.pay_invoice.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_budget_check_not_skipped_for_valid_amount(self):
         """Budget manager should be checked when amount is present."""
         mock_wallet = AsyncMock()

--- a/python/lightning-enable-mcp/tests/test_pay_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_pay_challenge.py
@@ -1,0 +1,161 @@
+"""Tests for pay_l402_challenge tool — budget and amount validation."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from lightning_enable_mcp.tools.pay_challenge import pay_l402_challenge
+
+
+class TestPayL402ChallengeNoAmountRejection:
+    """Tests that pay_l402_challenge rejects invoices without an explicit amount."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_no_amount_invoice(self):
+        """Zero-amount invoices must be rejected to prevent budget bypass."""
+        mock_wallet = AsyncMock()
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = None
+        mock_decoded.amount = None
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc1pjtest",
+                    macaroon=None,
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is False
+        assert "no amount" in result["error"].lower()
+        mock_wallet.pay_invoice.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_zero_amount_invoice(self):
+        """Invoice with amount_msat = 0 must be rejected."""
+        mock_wallet = AsyncMock()
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = 0
+        mock_decoded.amount = 0
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc1pjtest",
+                    macaroon="mac123",
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is False
+        assert "no amount" in result["error"].lower()
+        mock_wallet.pay_invoice.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_no_amount_mpp_mode(self):
+        """MPP mode (macaroon=None) must also reject no-amount invoices."""
+        mock_wallet = AsyncMock()
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = None
+        mock_decoded.amount = None
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc1pjtest",
+                    macaroon=None,
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is False
+        assert "no amount" in result["error"].lower()
+        mock_wallet.pay_invoice.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_amount(self):
+        """Invoices with a valid amount should proceed to payment."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage123")
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = 10000
+        mock_decoded.amount = 10
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc10n1pjtest",
+                    macaroon="mac123",
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is True
+        assert result["preimage"] == "preimage123"
+        assert result["protocol"] == "L402"
+        mock_wallet.pay_invoice.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_accepts_valid_amount_mpp_mode(self):
+        """MPP mode with a valid amount should succeed."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage456")
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = 5000
+        mock_decoded.amount = 5
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc5n1pjtest",
+                    macaroon=None,
+                    wallet=mock_wallet,
+                )
+            )
+
+        assert result["success"] is True
+        assert result["preimage"] == "preimage456"
+        assert result["protocol"] == "MPP"
+        mock_wallet.pay_invoice.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_budget_check_not_skipped_for_valid_amount(self):
+        """Budget manager should be checked when amount is present."""
+        mock_wallet = AsyncMock()
+        mock_wallet.pay_invoice = AsyncMock(return_value="preimage789")
+        mock_budget = MagicMock()
+        mock_budget.check_payment = MagicMock()  # no exception = within budget
+        mock_decoded = MagicMock()
+        mock_decoded.amount_msat = 100000
+        mock_decoded.amount = 100
+
+        with patch(
+            "lightning_enable_mcp.tools.pay_challenge.decode_bolt11",
+            return_value=mock_decoded,
+        ):
+            result = json.loads(
+                await pay_l402_challenge(
+                    invoice="lnbc100n1pjtest",
+                    wallet=mock_wallet,
+                    budget_manager=mock_budget,
+                )
+            )
+
+        assert result["success"] is True
+        mock_budget.check_payment.assert_called_once_with(100, 1000)


### PR DESCRIPTION
## Summary
- Parse `WWW-Authenticate: Payment` headers (IETF draft-ryan-httpauth-payment)
- Construct `Authorization: Payment method="lightning", preimage="<hex>"` for MPP
- Prefer L402 when server offers both protocols; fall back to MPP
- Make `macaroon` parameter optional in `pay_l402_challenge` tool for MPP mode
- Protocol indicator in tool responses ("L402" or "MPP")

## Changes
- **Models:** `MppClientChallenge`, `PaymentChallengeParser.ParseBest()` (.NET); `MppChallenge`, `MppToken`, `parse_best_challenge()` (Python)
- **Services:** Updated `L402HttpClient` to handle dual-protocol 402 responses
- **Tools:** `pay_l402_challenge` macaroon now optional, response includes protocol field
- **Tests:** 38 new tests (15 .NET + 23 Python)

## Test plan
- [x] `dotnet test` — 180 tests pass
- [x] `pytest` — 255 tests pass (23 new, 3 pre-existing unrelated failures)
- [x] Verify L402-only servers still work (regression) — Weather Intel API, 3 sats, 200 OK
- [x] Verify MPP challenge parsing with dual-header 402 from api.lightningenable.com — L402 correctly preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)