### PR TITLE
Add glama.json for MCP server metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "thewhitestwolfe"
+  ]
+}


### PR DESCRIPTION
Adds glama.json to enable Glama MCP directory features:
- Server inspection and installation
- Tool detection
- Proper metadata display

Required for users to install from Glama's directory.

See: https://glama.ai/blog/2025-07-08-what-is-glamajson