### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,8 @@ MIT — see [LICENSE](LICENSE).
 - [NuGet](https://www.nuget.org/packages/LightningEnable.Mcp) — .NET package
 - [PyPI](https://pypi.org/project/lightning-enable-mcp) — Python package
 - [Docker Hub](https://hub.docker.com/r/refinedelement/lightning-enable-mcp) — Docker image
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/refined-element-lightning-enable-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/refined-element-lightning-enable-mcp).