### PR TITLE
fix: Nonce fallback for broken MCP elicitation (v1.12.2)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.1</Version>
+    <Version>1.12.2</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.9.0: Add LND wallet support (both .NET and Python). LND is now highest-priority wallet — ideal for L402 (always returns preimage). Fix LND JSON string-to-number deserialization.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.2: CRITICAL FIX — Payment confirmation broken on all .NET MCP clients. Elicitation-based confirmation silently failed, blocking payments above auto-approve threshold with no recovery path. Now always falls back to nonce-based confirmation. Affects PayInvoice, AccessL402Resource, PayL402Challenge, CreatePayout, InitiateDeposit, InitiatePayout.</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.2: CRITICAL FIX — Payment confirmation broken on all .NET MCP clients. Elicitation-based confirmation silently failed, blocking payments above auto-approve threshold with no recovery path. Now always falls back to nonce-based confirmation. Affects PayInvoice, AccessL402Resource, PayL402Challenge, CreatePayout, InitiateDeposit, InitiatePayout.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.2: CRITICAL FIX — Payment confirmation broken on all .NET MCP clients. Elicitation-based confirmation silently failed, blocking payments above auto-approve threshold with no recovery path. Now always falls back to nonce-based confirmation. Affects PayInvoice, AccessL402Resource, PayL402Challenge.</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -138,7 +138,7 @@ public static class AccessL402ResourceTool
                 }
                 else
                 {
-                    // Try MCP elicitation first
+                    // Try MCP elicitation first (most clients don't support this yet)
                     var elicitationConfirmed = await RequestL402ConfirmationAsync(
                         server,
                         approvalResult,
@@ -147,52 +147,35 @@ public static class AccessL402ResourceTool
 
                     if (!elicitationConfirmed)
                     {
-                        // Check if elicitation was even available
-                        var elicitationAvailable = server?.ClientCapabilities?.Elicitation != null;
+                        // Always fall back to nonce-based confirmation.
+                        // MCP elicitation is unreliable — many clients (including Claude Code)
+                        // report Elicitation capability but don't handle it correctly.
+                        var urlDisplay = url.Length > 60 ? url.Substring(0, 60) + "..." : url;
+                        var pending = budgetService.CreatePendingConfirmation(
+                            maxSats,
+                            approvalResult.AmountUsd,
+                            "access_l402_resource",
+                            urlDisplay);
 
-                        if (!elicitationAvailable)
-                        {
-                            // Create a pending confirmation with a nonce
-                            var urlDisplay = url.Length > 60 ? url.Substring(0, 60) + "..." : url;
-                            var pending = budgetService.CreatePendingConfirmation(
-                                maxSats,
-                                approvalResult.AmountUsd,
-                                "access_l402_resource",
-                                urlDisplay);
-
-                            return JsonSerializer.Serialize(new
-                            {
-                                success = false,
-                                requiresConfirmation = true,
-                                error = "L402 payment requires your confirmation",
-                                message = $"This L402 request may cost up to {approvalResult.AmountUsd:C} ({maxSats:N0} sats), which exceeds the auto-approve threshold.",
-                                nonce = pending.Nonce,
-                                howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
-                                               $"Step 2: Call access_l402_resource(url=\"{url}\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
-                                expiresInSeconds = 120,
-                                amount = new
-                                {
-                                    maxSats,
-                                    usd = Math.Round(approvalResult.AmountUsd, 2)
-                                },
-                                thresholds = new
-                                {
-                                    autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
-                                    note = "Payments above this require confirmation via confirm_payment tool"
-                                }
-                            });
-                        }
-
-                        // Elicitation was available but user declined
                         return JsonSerializer.Serialize(new
                         {
                             success = false,
-                            error = "L402 payment cancelled by user",
                             requiresConfirmation = true,
+                            error = "L402 payment requires your confirmation",
+                            message = $"This L402 request may cost up to {approvalResult.AmountUsd:C} ({maxSats:N0} sats), which exceeds the auto-approve threshold.",
+                            nonce = pending.Nonce,
+                            howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
+                                           $"Step 2: Call access_l402_resource(url=\"{url}\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
+                            expiresInSeconds = 120,
                             amount = new
                             {
                                 maxSats,
-                                usd = approvalResult.AmountUsd
+                                usd = Math.Round(approvalResult.AmountUsd, 2)
+                            },
+                            thresholds = new
+                            {
+                                autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
+                                note = "Payments above this require confirmation via confirm_payment tool"
                             }
                         });
                     }

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
@@ -140,7 +140,7 @@ public static class PayInvoiceTool
                     }
                     else
                     {
-                        // Try MCP elicitation first
+                        // Try MCP elicitation first (most clients don't support this yet)
                         var elicitationConfirmed = await RequestConfirmationAsync(
                             server,
                             approvalResult,
@@ -149,52 +149,36 @@ public static class PayInvoiceTool
 
                         if (!elicitationConfirmed)
                         {
-                            // Check if elicitation was even available
-                            var elicitationAvailable = server?.ClientCapabilities?.Elicitation != null;
+                            // Always fall back to nonce-based confirmation.
+                            // MCP elicitation is unreliable — many clients (including Claude Code)
+                            // report Elicitation capability but don't handle it correctly,
+                            // causing payments to fail with no recovery path.
+                            var invoicePrefix = normalizedInvoice.Substring(0, Math.Min(30, normalizedInvoice.Length)) + "...";
+                            var pending = budgetService.CreatePendingConfirmation(
+                                amountSats.Value,
+                                approvalResult.AmountUsd,
+                                "pay_invoice",
+                                invoicePrefix);
 
-                            if (!elicitationAvailable)
-                            {
-                                // Create a pending confirmation with a nonce
-                                var invoicePrefix = normalizedInvoice.Substring(0, Math.Min(30, normalizedInvoice.Length)) + "...";
-                                var pending = budgetService.CreatePendingConfirmation(
-                                    amountSats.Value,
-                                    approvalResult.AmountUsd,
-                                    "pay_invoice",
-                                    invoicePrefix);
-
-                                return JsonSerializer.Serialize(new
-                                {
-                                    success = false,
-                                    requiresConfirmation = true,
-                                    error = "Payment requires your confirmation",
-                                    message = $"This payment of {approvalResult.AmountUsd:C} ({amountSats.Value:N0} sats) exceeds the auto-approve threshold.",
-                                    nonce = pending.Nonce,
-                                    howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
-                                                   $"Step 2: Call pay_invoice(invoice=\"...\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
-                                    expiresInSeconds = 120,
-                                    amount = new
-                                    {
-                                        sats = amountSats.Value,
-                                        usd = Math.Round(approvalResult.AmountUsd, 2)
-                                    },
-                                    thresholds = new
-                                    {
-                                        autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
-                                        note = "Payments above this require confirmation via confirm_payment tool"
-                                    }
-                                });
-                            }
-
-                            // Elicitation was available but user declined
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
-                                error = "Payment cancelled by user",
                                 requiresConfirmation = true,
+                                error = "Payment requires your confirmation",
+                                message = $"This payment of {approvalResult.AmountUsd:C} ({amountSats.Value:N0} sats) exceeds the auto-approve threshold.",
+                                nonce = pending.Nonce,
+                                howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
+                                               $"Step 2: Call pay_invoice(invoice=\"...\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
+                                expiresInSeconds = 120,
                                 amount = new
                                 {
                                     sats = amountSats.Value,
-                                    usd = approvalResult.AmountUsd
+                                    usd = Math.Round(approvalResult.AmountUsd, 2)
+                                },
+                                thresholds = new
+                                {
+                                    autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
+                                    note = "Payments above this require confirmation via confirm_payment tool"
                                 }
                             });
                         }

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -108,7 +108,7 @@ public static class PayL402ChallengeTool
                     }
                     else
                     {
-                        // Try MCP elicitation first
+                        // Try MCP elicitation first (most clients don't support this yet)
                         var elicitationConfirmed = await RequestL402ChallengeConfirmationAsync(
                             server,
                             approvalResult,
@@ -117,51 +117,35 @@ public static class PayL402ChallengeTool
 
                         if (!elicitationConfirmed)
                         {
-                            var elicitationAvailable = server?.ClientCapabilities?.Elicitation != null;
+                            // Always fall back to nonce-based confirmation.
+                            // MCP elicitation is unreliable — many clients (including Claude Code)
+                            // report Elicitation capability but don't handle it correctly.
+                            var invoicePrefix = normalizedInvoice.Substring(0, Math.Min(30, normalizedInvoice.Length)) + "...";
+                            var pending = budgetService.CreatePendingConfirmation(
+                                budgetCheckAmount,
+                                approvalResult.AmountUsd,
+                                "pay_l402_challenge",
+                                invoicePrefix);
 
-                            if (!elicitationAvailable)
-                            {
-                                // Create a pending confirmation with a nonce
-                                var invoicePrefix = normalizedInvoice.Substring(0, Math.Min(30, normalizedInvoice.Length)) + "...";
-                                var pending = budgetService.CreatePendingConfirmation(
-                                    budgetCheckAmount,
-                                    approvalResult.AmountUsd,
-                                    "pay_l402_challenge",
-                                    invoicePrefix);
-
-                                return JsonSerializer.Serialize(new
-                                {
-                                    success = false,
-                                    requiresConfirmation = true,
-                                    error = "L402 challenge payment requires your confirmation",
-                                    message = $"This payment of {approvalResult.AmountUsd:C} ({budgetCheckAmount:N0} sats) exceeds the auto-approve threshold.",
-                                    nonce = pending.Nonce,
-                                    howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
-                                                   $"Step 2: Call pay_l402_challenge(invoice=\"...\", macaroon=\"...\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
-                                    expiresInSeconds = 120,
-                                    amount = new
-                                    {
-                                        sats = budgetCheckAmount,
-                                        usd = Math.Round(approvalResult.AmountUsd, 2)
-                                    },
-                                    thresholds = new
-                                    {
-                                        autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
-                                        note = "Payments above this require confirmation via confirm_payment tool"
-                                    }
-                                });
-                            }
-
-                            // Elicitation was available but user declined
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
-                                error = "L402 challenge payment cancelled by user",
                                 requiresConfirmation = true,
+                                error = "L402 challenge payment requires your confirmation",
+                                message = $"This payment of {approvalResult.AmountUsd:C} ({budgetCheckAmount:N0} sats) exceeds the auto-approve threshold.",
+                                nonce = pending.Nonce,
+                                howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
+                                               $"Step 2: Call pay_l402_challenge(invoice=\"...\", macaroon=\"...\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
+                                expiresInSeconds = 120,
                                 amount = new
                                 {
                                     sats = budgetCheckAmount,
-                                    usd = approvalResult.AmountUsd
+                                    usd = Math.Round(approvalResult.AmountUsd, 2)
+                                },
+                                thresholds = new
+                                {
+                                    autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
+                                    note = "Payments above this require confirmation via confirm_payment tool"
                                 }
                             });
                         }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
@@ -172,4 +172,105 @@ public class L402ToolsTests
     }
 
     #endregion
+
+    #region Nonce Fallback Tests
+
+    [Fact]
+    public async Task AccessL402Resource_RequiresConfirmation_ElicitationFails_ReturnsNonceFallback()
+    {
+        // Arrange — budget says RequiresConfirmation, no server (elicitation unavailable)
+        var budgetServiceMock = new Mock<IBudgetService>();
+        var priceServiceMock = new Mock<IPriceService>();
+
+        budgetServiceMock.Setup(b => b.CheckApprovalLevelAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApprovalCheckResult
+            {
+                Level = ApprovalLevel.FormConfirm,
+                AmountSats = 1000,
+                AmountUsd = 5.00m,
+                RemainingSessionBudgetUsd = 95.00m
+            });
+        budgetServiceMock.Setup(b => b.CreatePendingConfirmation(
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new PendingConfirmation
+            {
+                Nonce = "L4C123",
+                AmountSats = 1000,
+                AmountUsd = 5.00m,
+                ToolName = "access_l402_resource",
+                Description = "https://api.example.com/data",
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddMinutes(2)
+            });
+        budgetServiceMock.Setup(b => b.GetUserConfiguration())
+            .Returns(new UserBudgetConfiguration());
+
+        // Act — no McpServer, so elicitation can't work
+        var result = await AccessL402ResourceTool.AccessL402Resource(
+            url: "https://api.example.com/data",
+            l402Client: _l402ClientMock.Object,
+            budgetService: budgetServiceMock.Object,
+            priceService: priceServiceMock.Object);
+
+        // Assert — should return nonce-based fallback
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("nonce").GetString().Should().Be("L4C123");
+        json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
+        json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
+        json.RootElement.GetProperty("amount").GetProperty("maxSats").GetInt32().Should().Be(1000);
+        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(5.00m);
+    }
+
+    [Fact]
+    public async Task PayL402Challenge_RequiresConfirmation_ElicitationFails_ReturnsNonceFallback()
+    {
+        // Arrange — budget says RequiresConfirmation, no server (elicitation unavailable)
+        var budgetServiceMock = new Mock<IBudgetService>();
+        var priceServiceMock = new Mock<IPriceService>();
+
+        budgetServiceMock.Setup(b => b.CheckApprovalLevelAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApprovalCheckResult
+            {
+                Level = ApprovalLevel.FormConfirm,
+                AmountSats = 500,
+                AmountUsd = 2.50m,
+                RemainingSessionBudgetUsd = 97.50m
+            });
+        budgetServiceMock.Setup(b => b.CreatePendingConfirmation(
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new PendingConfirmation
+            {
+                Nonce = "PLC456",
+                AmountSats = 500,
+                AmountUsd = 2.50m,
+                ToolName = "pay_l402_challenge",
+                Description = "lnbc500n1pjtest...",
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddMinutes(2)
+            });
+        budgetServiceMock.Setup(b => b.GetUserConfiguration())
+            .Returns(new UserBudgetConfiguration());
+
+        // Act — no McpServer, so elicitation can't work
+        var result = await PayL402ChallengeTool.PayL402Challenge(
+            invoice: "lnbc500n1pjtest",
+            macaroon: "base64macaroon",
+            l402Client: _l402ClientMock.Object,
+            budgetService: budgetServiceMock.Object,
+            priceService: priceServiceMock.Object);
+
+        // Assert — should return nonce-based fallback
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("nonce").GetString().Should().Be("PLC456");
+        json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
+        json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
+        json.RootElement.GetProperty("amount").GetProperty("sats").GetInt64().Should().Be(50); // lnbc500n = 50 sats
+        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(2.50m);
+    }
+
+    #endregion
 }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
@@ -527,4 +527,54 @@ public class PayInvoiceToolTests
     }
 
     #endregion
+
+    #region Nonce Fallback Tests
+
+    [Fact]
+    public async Task PayInvoice_RequiresConfirmation_ElicitationFails_ReturnsNonceFallback()
+    {
+        // Arrange — budget says RequiresConfirmation, elicitation unavailable (no server)
+        _walletServiceMock.Setup(w => w.IsConfigured).Returns(true);
+        _budgetServiceMock.Setup(b => b.CheckApprovalLevelAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApprovalCheckResult
+            {
+                Level = ApprovalLevel.FormConfirm,
+                AmountSats = 1000,
+                AmountUsd = 5.00m,
+                RemainingSessionBudgetUsd = 95.00m
+            });
+        _budgetServiceMock.Setup(b => b.CreatePendingConfirmation(
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new PendingConfirmation
+            {
+                Nonce = "ABC123",
+                AmountSats = 1000,
+                AmountUsd = 5.00m,
+                ToolName = "pay_invoice",
+                Description = "lnbc1000n1p3abcdef...",
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddMinutes(2)
+            });
+        _budgetServiceMock.Setup(b => b.GetUserConfiguration())
+            .Returns(new UserBudgetConfiguration());
+
+        // Act — no McpServer, so elicitation can't work
+        var result = await PayInvoiceTool.PayInvoice(
+            invoice: TestInvoice,
+            walletService: _walletServiceMock.Object,
+            budgetService: _budgetServiceMock.Object,
+            priceService: _priceServiceMock.Object);
+
+        // Assert — should return nonce-based fallback, not an error
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("nonce").GetString().Should().Be("ABC123");
+        json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
+        json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
+        json.RootElement.GetProperty("amount").GetProperty("sats").GetInt64().Should().Be(100); // lnbc1000n = 100 sats
+        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(5.00m);
+    }
+
+    #endregion
 }

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.1"
+version = "1.12.2"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- **CRITICAL BUG FIX** — Payment confirmation broken for all .NET MCP clients since v1.6.0 (every published version)
- When a client reports `Elicitation` capability (as Claude Code does) but elicitation doesn't actually work, the code returned "Payment cancelled by user" with **no nonce and no recovery path**
- Any payment above the auto-approve threshold ($0.10 default) was permanently blocked — users could not complete the purchase
- Fix: always fall back to nonce-based confirmation when elicitation fails, regardless of reported client capabilities
- Affected tools: `PayInvoice`, `AccessL402Resource`, `PayL402Challenge`
- Python package was never affected (uses simple `confirmed=True` parameter)
- Bumps version to 1.12.2 (.NET + Python)

## After merge

1. CI/CD publishes to NuGet, PyPI, Docker Hub, MCP Registry
2. Deprecate all .NET versions 1.6.0–1.12.1 on nuget.org as "Critical Bugs" pointing to 1.12.2

## Test plan

- [x] All 187 .NET tests pass
- [x] Build succeeds with no errors
- [ ] After publish: `dotnet tool update -g LightningEnable.Mcp` and verify payment confirmation works
- [ ] Deprecate affected versions on nuget.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)