### PR TITLE
feat: Add smithery.yaml + automate Docker Hub description

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -158,15 +158,18 @@ jobs:
           # resolve on Docker Hub. Generate a Docker-Hub-specific copy with absolute
           # GitHub URLs so links render correctly on the listing page.
           REPO_URL="https://github.com/refined-element/lightning-enable-mcp"
-          BRANCH="main"
+          # Pin link targets to the exact commit that produced this image rather than `main`,
+          # so the Docker Hub README keeps pointing at the version it was published alongside
+          # even after main moves on.
+          BLOB_REF="${GITHUB_SHA}"
           sed -E \
-            -e "s|\]\((dotnet/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
-            -e "s|\]\((python/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
-            -e "s|\]\((docs/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
-            -e "s|\]\((server\.json)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
-            -e "s|\]\((LICENSE)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
-            -e "s|\]\((CHANGELOG\.md)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
-            -e "s|\]\((CONTRIBUTING\.md)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((dotnet/[^)]+)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
+            -e "s|\]\((python/[^)]+)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
+            -e "s|\]\((docs/[^)]+)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
+            -e "s|\]\((server\.json)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
+            -e "s|\]\((LICENSE)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
+            -e "s|\]\((CHANGELOG\.md)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
+            -e "s|\]\((CONTRIBUTING\.md)\)|](${REPO_URL}/blob/${BLOB_REF}/\1)|g" \
             README.md > README.dockerhub.md
           echo "=== Docker Hub README preview (first 40 lines) ==="
           head -n 40 README.dockerhub.md

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -152,6 +152,15 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: refinedelement/lightning-enable-mcp
+          short-description: "MCP server for AI agent Lightning payments (L402, Strike, LND, NWC). 23 tools, 15 free, 8 unlock with an LE API key. MIT license."
+          readme-filepath: ./README.md
+
   publish-registry:
     runs-on: ubuntu-latest
     needs: [publish-packages, publish-docker]

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -164,6 +164,9 @@ jobs:
             -e "s|\]\((python/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
             -e "s|\]\((docs/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
             -e "s|\]\((server\.json)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((LICENSE)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((CHANGELOG\.md)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((CONTRIBUTING\.md)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
             README.md > README.dockerhub.md
           echo "=== Docker Hub README preview (first 40 lines) ==="
           head -n 40 README.dockerhub.md

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -152,6 +152,22 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      - name: Prepare Docker Hub README (rewrite relative links to absolute GitHub URLs)
+        run: |
+          # README.md uses relative paths (dotnet/..., python/..., etc.) which don't
+          # resolve on Docker Hub. Generate a Docker-Hub-specific copy with absolute
+          # GitHub URLs so links render correctly on the listing page.
+          REPO_URL="https://github.com/refined-element/lightning-enable-mcp"
+          BRANCH="main"
+          sed -E \
+            -e "s|\]\((dotnet/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((python/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((docs/[^)]+)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            -e "s|\]\((server\.json)\)|](${REPO_URL}/blob/${BRANCH}/\1)|g" \
+            README.md > README.dockerhub.md
+          echo "=== Docker Hub README preview (first 40 lines) ==="
+          head -n 40 README.dockerhub.md
+
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v4
         with:
@@ -159,7 +175,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: refinedelement/lightning-enable-mcp
           short-description: "MCP server for AI agent Lightning payments (L402, Strike, LND, NWC). 23 tools, 15 free, 8 unlock with an LE API key. MIT license."
-          readme-filepath: ./README.md
+          readme-filepath: ./README.dockerhub.md
 
   publish-registry:
     runs-on: ubuntu-latest

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,92 @@
+# Smithery configuration for the Lightning Enable MCP server.
+# Smithery is the default discovery surface for Cursor / VS Code / Claude Desktop
+# "Add MCP server" flows. This manifest lets Smithery auto-ingest the server
+# from its PyPI package.
+#
+# Docs: https://smithery.ai/docs/build/publish
+
+name: lightning-enable
+version: 1.12.2
+description: AI agent Lightning payments and commerce — invoices, L402, API discovery, budgets, ASA negotiation. 23 tools, 15 free, 8 unlock with a Lightning Enable API key.
+author: Lightning Enable
+license: MIT
+repository: https://github.com/refined-element/lightning-enable-mcp
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      lightningEnableApiKey:
+        type: string
+        description: >-
+          Optional. Your Lightning Enable API key. Required only to enable the 8
+          subscription-gated tools (2 producer + 6 ASA). The 15 consumer tools
+          work without it. Get a key at https://lightningenable.com.
+        secret: true
+      strikeApiKey:
+        type: string
+        description: >-
+          Optional. Strike API key for wallet operations (preferred for L402 —
+          returns preimage on payments). Generate at dashboard.strike.me.
+        secret: true
+      nwcUrl:
+        type: string
+        description: >-
+          Optional. Nostr Wallet Connect URI (nostr+walletconnect://...) for
+          wallets like Alby Hub, CoinOS, CLINK. Alternative to Strike/LND.
+        secret: true
+      lndRestHost:
+        type: string
+        description: >-
+          Optional. Your LND node REST host (e.g., https://my-lnd:8080). Used
+          with your own Lightning node.
+      lndMacaroonHex:
+        type: string
+        description: >-
+          Optional. Hex-encoded LND admin.macaroon for REST authentication.
+        secret: true
+      l402MaxSatsPerRequest:
+        type: string
+        description: >-
+          Optional. Per-request spending cap in satoshis for L402 payments.
+          Defaults to a conservative value if unset.
+      l402MaxSatsPerSession:
+        type: string
+        description: >-
+          Optional. Per-session spending cap in satoshis for L402 payments.
+  commandFunction: |-
+    (config) => {
+      const env = {};
+      if (config.lightningEnableApiKey) env.LIGHTNING_ENABLE_API_KEY = config.lightningEnableApiKey;
+      if (config.strikeApiKey)          env.STRIKE_API_KEY            = config.strikeApiKey;
+      if (config.nwcUrl)                env.NWC_URL                   = config.nwcUrl;
+      if (config.lndRestHost)           env.LND_REST_HOST             = config.lndRestHost;
+      if (config.lndMacaroonHex)        env.LND_MACAROON_HEX          = config.lndMacaroonHex;
+      if (config.l402MaxSatsPerRequest) env.L402_MAX_SATS_PER_REQUEST = config.l402MaxSatsPerRequest;
+      if (config.l402MaxSatsPerSession) env.L402_MAX_SATS_PER_SESSION = config.l402MaxSatsPerSession;
+      return {
+        command: 'uvx',
+        args: ['lightning-enable-mcp'],
+        env
+      };
+    }
+  exampleConfig: {}
+
+tags:
+  - mcp
+  - lightning
+  - bitcoin
+  - l402
+  - payments
+  - agent
+  - agents
+  - commerce
+  - strike
+  - opennode
+  - lnd
+  - nwc
+  - ai
+  - agentic-commerce
+  - asa
+  - nostr

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -4,9 +4,12 @@
 # from its PyPI package.
 #
 # Docs: https://smithery.ai/docs/build/publish
+#
+# Note: no explicit `version` field — Smithery resolves the current version from
+# the published PyPI package (lightning-enable-mcp), so there's no second place
+# to keep in sync on every release.
 
 name: lightning-enable
-version: 1.12.2
 description: AI agent Lightning payments and commerce — invoices, L402, API discovery, budgets, ASA negotiation. 23 tools, 15 free, 8 unlock with a Lightning Enable API key.
 author: Lightning Enable
 license: MIT
@@ -46,6 +49,26 @@ startCommand:
         description: >-
           Optional. Hex-encoded LND admin.macaroon for REST authentication.
         secret: true
+      lndSkipTlsVerify:
+        type: boolean
+        default: false
+        description: >-
+          Optional, dev-only. Skip TLS verification when connecting to LND.
+          Useful for self-signed / development LND instances. Do not enable
+          in production.
+      opennodeApiKey:
+        type: string
+        description: >-
+          Optional. OpenNode API key. Note: OpenNode does not return preimage
+          on incoming payments, so L402 auto-pay does not work with OpenNode.
+        secret: true
+      opennodeEnvironment:
+        type: string
+        enum: [production, dev]
+        default: production
+        description: >-
+          Optional. OpenNode environment — "production" or "dev" (testnet).
+          Defaults to production.
       l402MaxSatsPerRequest:
         type: integer
         minimum: 0
@@ -65,6 +88,9 @@ startCommand:
       if (config.nwcConnectionString)   env.NWC_CONNECTION_STRING     = config.nwcConnectionString;
       if (config.lndRestHost)           env.LND_REST_HOST             = config.lndRestHost;
       if (config.lndMacaroonHex)        env.LND_MACAROON_HEX          = config.lndMacaroonHex;
+      if (config.lndSkipTlsVerify === true) env.LND_SKIP_TLS_VERIFY   = 'true';
+      if (config.opennodeApiKey)        env.OPENNODE_API_KEY          = config.opennodeApiKey;
+      if (config.opennodeEnvironment)   env.OPENNODE_ENVIRONMENT      = config.opennodeEnvironment;
       if (typeof config.l402MaxSatsPerRequest === 'number') env.L402_MAX_SATS_PER_REQUEST = String(config.l402MaxSatsPerRequest);
       if (typeof config.l402MaxSatsPerSession === 'number') env.L402_MAX_SATS_PER_SESSION = String(config.l402MaxSatsPerSession);
       return {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -30,11 +30,11 @@ startCommand:
           Optional. Strike API key for wallet operations (preferred for L402 —
           returns preimage on payments). Generate at dashboard.strike.me.
         secret: true
-      nwcUrl:
+      nwcConnectionString:
         type: string
         description: >-
-          Optional. Nostr Wallet Connect URI (nostr+walletconnect://...) for
-          wallets like Alby Hub, CoinOS, CLINK. Alternative to Strike/LND.
+          Optional. Nostr Wallet Connect connection string (nostr+walletconnect://...)
+          for wallets like Alby Hub, CoinOS, CLINK. Alternative to Strike/LND.
         secret: true
       lndRestHost:
         type: string
@@ -47,12 +47,14 @@ startCommand:
           Optional. Hex-encoded LND admin.macaroon for REST authentication.
         secret: true
       l402MaxSatsPerRequest:
-        type: string
+        type: integer
+        minimum: 0
         description: >-
           Optional. Per-request spending cap in satoshis for L402 payments.
           Defaults to a conservative value if unset.
       l402MaxSatsPerSession:
-        type: string
+        type: integer
+        minimum: 0
         description: >-
           Optional. Per-session spending cap in satoshis for L402 payments.
   commandFunction: |-
@@ -60,11 +62,11 @@ startCommand:
       const env = {};
       if (config.lightningEnableApiKey) env.LIGHTNING_ENABLE_API_KEY = config.lightningEnableApiKey;
       if (config.strikeApiKey)          env.STRIKE_API_KEY            = config.strikeApiKey;
-      if (config.nwcUrl)                env.NWC_URL                   = config.nwcUrl;
+      if (config.nwcConnectionString)   env.NWC_CONNECTION_STRING     = config.nwcConnectionString;
       if (config.lndRestHost)           env.LND_REST_HOST             = config.lndRestHost;
       if (config.lndMacaroonHex)        env.LND_MACAROON_HEX          = config.lndMacaroonHex;
-      if (config.l402MaxSatsPerRequest) env.L402_MAX_SATS_PER_REQUEST = config.l402MaxSatsPerRequest;
-      if (config.l402MaxSatsPerSession) env.L402_MAX_SATS_PER_SESSION = config.l402MaxSatsPerSession;
+      if (typeof config.l402MaxSatsPerRequest === 'number') env.L402_MAX_SATS_PER_REQUEST = String(config.l402MaxSatsPerRequest);
+      if (typeof config.l402MaxSatsPerSession === 'number') env.L402_MAX_SATS_PER_SESSION = String(config.l402MaxSatsPerSession);
       return {
         command: 'uvx',
         args: ['lightning-enable-mcp'],


### PR DESCRIPTION
## Summary

Two discovery improvements for the Lightning Enable MCP server:

### 1. smithery.yaml at repo root

Lets **smithery.ai** auto-ingest the server. Smithery is the default 'Add MCP server' catalog surfaced in Cursor, VS Code, and Claude Desktop — so this is the single highest-impact discovery listing we can add.

- Manifest points at the `uvx lightning-enable-mcp` entry point
- `configSchema` exposes optional `LIGHTNING_ENABLE_API_KEY`, Strike / LND / NWC credentials, and L402 spending caps
- Tags align with registry discoverability: mcp, lightning, bitcoin, l402, payments, agent, agents, commerce, strike, opennode, lnd, nwc, ai, agentic-commerce, asa, nostr

### 2. Docker Hub description automation

The Docker Hub listing (refinedelement/lightning-enable-mcp) currently has an empty short description despite 2,454 pulls. Added a `peter-evans/dockerhub-description@v4` step to the `publish-docker` job. On each release, the README.md is pushed as the Docker Hub long description and a short tagline is set.

**Manual follow-up needed:** The action only runs when the publish workflow fires (push to main touching csproj/pyproject/Dockerfile, or a `mcp-v*` tag, or workflow_dispatch). On merge this won't retroactively populate the current listing — for an immediate fix, bump a patch version or run the action on-demand with workflow_dispatch.

## Test plan
- [ ] Smithery ingests the YAML on push (verify by searching 'lightning' at smithery.ai after merge)
- [x] Workflow YAML is syntactically valid (`gh` parse succeeds)
- [ ] Docker Hub description populates on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)