### PR TITLE
chore: Bump MCP version 1.12.2 → 1.12.3 (trigger Smithery + Docker Hub publish)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.3: Discovery + distribution improvements. Smithery.ai manifest added to the repo root so the server auto-lists on Cursor / VS Code / Claude Desktop "Add MCP" flows. Docker Hub description now auto-populated from the repo README on each release. No code changes in this version.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.3: Discovery + distribution improvements. Smithery.ai manifest added to the repo root so the server auto-lists on Cursor / VS Code / Claude Desktop "Add MCP" flows. Docker Hub description now auto-populated from the repo README on each release. No .NET code changes; the companion Python package in this release switches `__version__` to derive from package metadata.</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.2</Version>
+    <Version>1.12.3</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.2: CRITICAL FIX — Payment confirmation broken on all .NET MCP clients. Elicitation-based confirmation silently failed, blocking payments above auto-approve threshold with no recovery path. Now always falls back to nonce-based confirmation. Affects PayInvoice, AccessL402Resource, PayL402Challenge.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.3: Discovery + distribution improvements. Smithery.ai manifest added to the repo root so the server auto-lists on Cursor / VS Code / Claude Desktop "Add MCP" flows. Docker Hub description now auto-populated from the repo README on each release. No code changes in this version.</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.2"
+version = "1.12.3"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
@@ -13,14 +13,8 @@ Available tools:
 - pay_l402_challenge - Manual L402 payment
 """
 
-# Derive __version__ from installed package metadata so it can never drift from
-# pyproject.toml (which is the single source of truth). Fall back to a sentinel when
-# running directly from an uninstalled source checkout (e.g., without pip install).
-from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PackageNotFoundError
-try:
-    __version__ = _pkg_version("lightning-enable-mcp")
-except _PackageNotFoundError:  # pragma: no cover
-    __version__ = "0.0.0+unknown"
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 from .budget import BudgetManager, BudgetExceededError, PaymentRecord
 from .budget_service import (
@@ -52,6 +46,14 @@ from .price_service import (
     usd_to_sats,
 )
 from .server import LightningEnableServer, main
+
+# Derive __version__ from installed package metadata so it can never drift from
+# pyproject.toml (which is the single source of truth). Fall back to a sentinel when
+# running directly from an uninstalled source checkout (e.g., without pip install).
+try:
+    __version__ = _pkg_version("lightning-enable-mcp")
+except _PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     # Server

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
@@ -13,7 +13,14 @@ Available tools:
 - pay_l402_challenge - Manual L402 payment
 """
 
-__version__ = "1.6.0"
+# Derive __version__ from installed package metadata so it can never drift from
+# pyproject.toml (which is the single source of truth). Fall back to a sentinel when
+# running from an uninstalled source tree (e.g. editable dev without pip install -e).
+from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PackageNotFoundError
+try:
+    __version__ = _pkg_version("lightning-enable-mcp")
+except _PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0+unknown"
 
 from .budget import BudgetManager, BudgetExceededError, PaymentRecord
 from .budget_service import (

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
@@ -15,7 +15,7 @@ Available tools:
 
 # Derive __version__ from installed package metadata so it can never drift from
 # pyproject.toml (which is the single source of truth). Fall back to a sentinel when
-# running from an uninstalled source tree (e.g. editable dev without pip install -e).
+# running directly from an uninstalled source checkout (e.g., without pip install).
 from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PackageNotFoundError
 try:
     __version__ = _pkg_version("lightning-enable-mcp")


### PR DESCRIPTION
## Summary
Version bump to trigger a fresh publish cycle. The prior PR (#9) added the Smithery manifest and automated Docker Hub description publishing, but the publish workflow's `paths` filter only watches `csproj`, `pyproject.toml`, and `Dockerfile`. Neither the smithery.yaml addition nor the workflow edit itself fired a publish run on merge.

## What this triggers
- **Docker Hub description auto-populates** from the repo README (currently empty despite 2,454+ pulls)
- **Smithery.ai auto-ingest** has a published-package version to pin against
- **NuGet + PyPI 1.12.3** republish with refreshed release notes

## Changes
- `LightningEnable.Mcp.csproj`: `<Version>` 1.12.2 → 1.12.3; release notes updated
- `pyproject.toml`: version 1.12.2 → 1.12.3
- `lightning_enable_mcp/__init__.py`: small Python code change — `__version__` now derives from `importlib.metadata` instead of a hardcoded constant (was drifting; 1.6.0 vs actual 1.12.2). Single-source-of-truth = pyproject.toml going forward.

No .NET code changes.

## Test plan
- [ ] On merge, publish-mcp.yml fires on the matching `paths` trigger
- [ ] NuGet `LightningEnable.Mcp` 1.12.3 is live
- [ ] PyPI `lightning-enable-mcp` 1.12.3 is live
- [ ] Docker Hub `refinedelement/lightning-enable-mcp` shows the new description + README
- [ ] Smithery.ai lists Lightning Enable (search "lightning")

🤖 Generated with [Claude Code](https://claude.com/claude-code)