### PR TITLE
ci: add CodeQL + Semgrep + gitleaks security workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# Static analysis for the .NET MCP server + Python port. Runs on every PR + push
+# to main, and weekly to catch CVEs in deps that surface after merge.
+#
+# Findings post to the repo's Security tab → Code scanning alerts. We don't fail
+# PRs on findings yet — first sweep is for triage; tighten the gate after the
+# initial backlog of findings is worked through (tracked under issue #14 in this
+# repo / vault priority-backlog.md item #0).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 0'  # Sundays 06:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [csharp, python]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Build .NET MCP
+        if: matrix.language == 'csharp'
+        run: dotnet build dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj --configuration Release
+
+      - name: Setup Python
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,9 +19,13 @@ on:
 
 permissions:
   contents: read
-  # No `pull-requests: write`: Copilot review on PR #16 noted the broader scope
-  # is unnecessary — gitleaks-action only checks out the repo and runs the
-  # binary; it does not post PR comments. Stay least-privilege.
+  # `pull-requests: read` (not write) — gitleaks-action needs READ to
+  # enumerate PR commits for the diff scan (without it the action 403s on
+  # `GET /repos/{}/pulls/{}/commits`). Original spec on PR #16 was `write`
+  # which is over-broad; round-2 dropped it entirely. This MCP PR happened
+  # to squeak through with no commits API call (small PR), but LE PR #74
+  # hit the 403. Mirroring LE's round-3 fix: read-only is the actual minimum.
+  pull-requests: read
 
 jobs:
   scan:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,40 @@
+name: gitleaks
+
+# Secret-scan the working tree + full git history. Important for this repo
+# specifically because we deal with NWC connection strings, LND macaroons,
+# and Strike API keys — all easy to fat-finger into a commit.
+#
+# Unlike CodeQL/Semgrep (report-only initially), gitleaks DOES fail the PR on
+# any finding. False-positive rate is very low and a leaked credential is a
+# rotate-everything event we want to block before merge, not after.
+#
+# To allow a known false positive, add the path/rule to .gitleaks.toml at the
+# repo root.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -19,7 +19,9 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  # No `pull-requests: write`: Copilot review on PR #16 noted the broader scope
+  # is unnecessary — gitleaks-action only checks out the repo and runs the
+  # binary; it does not post PR comments. Stay least-privilege.
 
 jobs:
   scan:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,11 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:latest
+      # Pinned to a specific Semgrep release for reproducibility — `latest`
+      # would silently change rule behaviour and CLI flags between runs. Bump
+      # this tag intentionally when picking up a new Semgrep version, after a
+      # quick local re-run to confirm finding stability.
+      image: semgrep/semgrep:1.108.0
     timeout-minutes: 20
 
     steps:
@@ -35,7 +39,15 @@ jobs:
         # Multi-language coverage — both .NET and Python live in this repo.
         # p/python + p/csharp + p/dotnet are language-specific rule packs;
         # p/owasp-top-ten + p/security-audit + p/secrets are language-agnostic.
+        #
+        # Exit code handling (Copilot review on PR #16):
+        #   0 = clean scan, no findings
+        #   1 = findings present (report-only mode — don't fail the workflow yet)
+        #   any other code = real execution failure (config download, rule
+        #     compilation, CLI crash) — must fail the workflow so we don't
+        #     silently stop scanning. The previous `|| echo` masked all errors.
         run: |
+          set +e
           semgrep scan \
             --config=p/owasp-top-ten \
             --config=p/security-audit \
@@ -45,8 +57,17 @@ jobs:
             --config=p/python \
             --json \
             --output=semgrep-results.json \
-            --metrics=off \
-            || echo "semgrep scan completed with findings (report-only mode)"
+            --metrics=off
+          ec=$?
+          set -e
+          if [ "$ec" -eq 0 ]; then
+            echo "Semgrep clean — no findings."
+          elif [ "$ec" -eq 1 ]; then
+            echo "Semgrep findings present (report-only mode, exit code 1 ignored)."
+          else
+            echo "::error::Semgrep failed with exit code $ec — real execution error, not findings."
+            exit $ec
+          fi
 
       - name: Surface finding summary
         if: always()

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,66 @@
+name: Semgrep
+
+# Third-party SAST that complements CodeQL — different rule set, catches things
+# CodeQL misses (auth context leaks, race conditions, weak HMAC). Runs
+# anonymously (no Semgrep account / token required) using their published rule
+# packs. Covers both the .NET and Python ports.
+#
+# Currently report-only (no --error). After the initial backlog of findings is
+# triaged, switch to --error so it gates PRs. Tracked under issue #14 / vault
+# priority-backlog.md item #0.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 0'  # Sundays 07:00 UTC, after CodeQL
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        # Multi-language coverage — both .NET and Python live in this repo.
+        # p/python + p/csharp + p/dotnet are language-specific rule packs;
+        # p/owasp-top-ten + p/security-audit + p/secrets are language-agnostic.
+        run: |
+          semgrep scan \
+            --config=p/owasp-top-ten \
+            --config=p/security-audit \
+            --config=p/secrets \
+            --config=p/csharp \
+            --config=p/dotnet \
+            --config=p/python \
+            --json \
+            --output=semgrep-results.json \
+            --metrics=off \
+            || echo "semgrep scan completed with findings (report-only mode)"
+
+      - name: Surface finding summary
+        if: always()
+        run: |
+          if [ -f semgrep-results.json ]; then
+            count=$(jq '.results | length' semgrep-results.json)
+            echo "Semgrep findings: $count"
+            jq -r '.results[] | "[\(.extra.severity)] \(.check_id) — \(.path):\(.start.line)"' semgrep-results.json | head -50
+          fi
+
+      - name: Upload findings artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: semgrep-results
+          path: semgrep-results.json
+          retention-days: 30

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,12 +40,15 @@ jobs:
         # p/python + p/csharp + p/dotnet are language-specific rule packs;
         # p/owasp-top-ten + p/security-audit + p/secrets are language-agnostic.
         #
-        # Exit code handling (Copilot review on PR #16):
-        #   0 = clean scan, no findings
-        #   1 = findings present (report-only mode — don't fail the workflow yet)
-        #   any other code = real execution failure (config download, rule
-        #     compilation, CLI crash) — must fail the workflow so we don't
-        #     silently stop scanning. The previous `|| echo` masked all errors.
+        # Exit-code policy (Copilot review on PR #16, refined after first
+        # observed exit 7 in the wild):
+        #   - If semgrep produced valid JSON output, the scan completed —
+        #     even if exit code is non-zero (e.g. exit 7 = parse warnings on
+        #     a few files). Treat as report-only success.
+        #   - If no JSON output, semgrep didn't actually scan (bad config,
+        #     missing rules, CLI crash). Fail the workflow.
+        # This is more robust than enumerating exit codes — semgrep adds new
+        # ones over time and the original `|| echo` mask was too lenient.
         run: |
           set +e
           semgrep scan \
@@ -60,12 +63,16 @@ jobs:
             --metrics=off
           ec=$?
           set -e
-          if [ "$ec" -eq 0 ]; then
-            echo "Semgrep clean — no findings."
-          elif [ "$ec" -eq 1 ]; then
-            echo "Semgrep findings present (report-only mode, exit code 1 ignored)."
+          if [ -s semgrep-results.json ] && jq empty semgrep-results.json 2>/dev/null; then
+            count=$(jq '.results | length' semgrep-results.json)
+            errors=$(jq '[.errors[]?] | length' semgrep-results.json)
+            if [ "$ec" -eq 0 ]; then
+              echo "Semgrep clean — no findings."
+            else
+              echo "Semgrep completed (exit $ec): $count findings, $errors parse warnings (report-only mode)."
+            fi
           else
-            echo "::error::Semgrep failed with exit code $ec — real execution error, not findings."
+            echo "::error::Semgrep produced no valid JSON output (exit $ec) — real execution failure."
             exit $ec
           fi
 


### PR DESCRIPTION
## Summary

Mirror of the lightning-enable-side workflows. Tracked under #14.

| Workflow | Tool | Behavior |
|---|---|---|
| `codeql.yml` | GitHub CodeQL (csharp + python matrix) | `security-extended` + `security-and-quality` query packs across both ports. **Report-only.** |
| `semgrep.yml` | Semgrep (anonymous) | OWASP + security-audit + secrets + csharp + dotnet + python rule packs. **Report-only.** |
| `gitleaks.yml` | gitleaks (full-history) | Secret scan. **Fails the PR on any finding** — important here because we deal with NWC connection strings, LND macaroons, Strike API keys daily. |

## Cost

Zero. All free tiers.

## Test plan

- [x] Workflow files validate
- [ ] First push triggers all three; check Security tab + Actions logs
- [ ] CodeQL python lane builds without setup (Python is interpreted; no build step needed)
- [ ] Confirm gitleaks history scan doesn't trip on prior commits

Closes part of #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)