### PR TITLE
fix(security): bump aiohttp + cryptography for HIGH CVEs (F-13)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.6</Version>
+    <Version>1.12.7</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.6: NWC outbound encryption is now auto-detected via the wallet's NIP-47 INFO event (kind 13194) — zero-config across Primal NWC, CoinOS, Mutiny, ZBD, Alby Hub, and any other spec-compliant wallet. On first request, fetches the wallet's INFO event, reads the encryption tag, picks the strongest advertised scheme (nip44_v2 if listed; nip04 otherwise), and caches the choice for the lifetime of the service instance. Falls back to nip04 if the INFO event isn't available within ~3 seconds. NWC_ENCRYPTION env var is preserved as an explicit override (auto/nip04/nip44_v2). Mirrors the same change in the Python package.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.7: Python dependency security update — bumps `aiohttp` to >=3.13.4 (10 HIGH CVEs in 3.13.3 series, including request smuggling and header injection) and `cryptography` to >=46.0.7 (CVE-2026-26007, CVE-2026-34073, CVE-2026-39892). .NET package has no functional changes; version bumped to keep parity with the Python release. (sec audit F-13)</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.6"
+version = "1.12.7"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"
@@ -41,13 +41,13 @@ classifiers = [
 dependencies = [
     "mcp>=1.0.0",
     "httpx>=0.25.0",
-    "aiohttp>=3.9.0",
+    "aiohttp>=3.13.4",
     "pydantic>=2.0.0",
     "bolt11>=2.0.0",
     "secp256k1>=0.14.0",
     "websockets>=12.0",
     "bech32>=1.2.0",
-    "cryptography>=41.0.0",
+    "cryptography>=46.0.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #18.

## Summary

- **aiohttp** `3.13.3` → `>=3.13.4` — fixes 10 HIGH CVEs (CVE-2026-34515, -34513, -34516, -34517, -34518, -34519, -34520, -34525, -22815, -34514) covering request smuggling, header injection, and parser confusion in the HTTP client/server.
- **cryptography** `46.0.3` → `>=46.0.7` — fixes CVE-2026-26007, CVE-2026-34073, CVE-2026-39892.
- Version bumped `1.12.6` → `1.12.7` in both `pyproject.toml` and `LightningEnable.Mcp.csproj` to keep Python + .NET lockstep per repo convention. .NET package has no functional changes — version bump only, so the publish step republishes a fresh build alongside the patched Python wheel.

Source: vault audit doc § F-13.

## Test plan

- [ ] CI on this branch is green (build + unit tests).
- [ ] After merge, confirm CI publishes `lightning-enable-mcp 1.12.7` to PyPI and `LightningEnable.Mcp 1.12.7` to NuGet.
- [ ] `pip install lightning-enable-mcp==1.12.7` resolves `aiohttp>=3.13.4` and `cryptography>=46.0.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)