### PR TITLE
fix(security): NWC response sig verify + 0600 config perms (F-11, F-12)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetConfigurationService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetConfigurationService.cs
@@ -112,6 +112,13 @@ public class BudgetConfigurationService : IBudgetConfigurationService
             var json = JsonSerializer.Serialize(defaultConfig, JsonOptions);
             File.WriteAllText(_configFilePath, json);
 
+            // F-12: lock down config-file permissions. The file may hold
+            // wallet credentials in plaintext (NWC connection strings, LND
+            // macaroon, Strike API key) — default OS perms (0644 on Unix,
+            // ACL inheritance on Windows) leave them readable by other
+            // accounts on shared machines / CI runners.
+            RestrictFilePermissions(_configFilePath);
+
             Console.Error.WriteLine();
             Console.Error.WriteLine("╔══════════════════════════════════════════════════════════════════╗");
             Console.Error.WriteLine("║          Lightning Enable MCP - First Run Setup                  ║");
@@ -217,5 +224,56 @@ public class BudgetConfigurationService : IBudgetConfigurationService
             ? config.Limits.MaxPerSession.Value.ToString("C")
             : "unlimited";
         Console.Error.WriteLine($"[Lightning Enable] Limits: max/payment={maxPayment}, max/session={maxSession}");
+    }
+
+    /// <summary>
+    /// Restrict file permissions so only the current user can read/write the
+    /// config file. POSIX: 0600 via UnixFileMode (.NET 7+). Windows:
+    /// best-effort via icacls (no pywin32-style hard dep). Failures are
+    /// logged but non-fatal — the file is already on disk and we don't want
+    /// permission-tightening failure to hard-block first-run setup.
+    /// </summary>
+    internal static void RestrictFilePermissions(string path)
+    {
+        try
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                return;
+            }
+
+            // Windows: use icacls. /inheritance:r removes inherited permissions
+            // and /grant gives the current user full control.
+            var user = Environment.UserName;
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "icacls",
+                ArgumentList = { path, "/inheritance:r", "/grant", $"{user}:F" },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var p = System.Diagnostics.Process.Start(psi);
+            if (p != null)
+            {
+                if (!p.WaitForExit(5_000))
+                {
+                    p.Kill(entireProcessTree: true);
+                    Console.Error.WriteLine($"[Lightning Enable] Warning: icacls timeout restricting {path}");
+                    return;
+                }
+                if (p.ExitCode != 0)
+                {
+                    var err = p.StandardError.ReadToEnd().Trim();
+                    Console.Error.WriteLine($"[Lightning Enable] Warning: icacls rc={p.ExitCode} on {path}: {err}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Lightning Enable] Warning: could not restrict permissions on {path}: {ex.Message}");
+        }
     }
 }

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetConfigurationService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetConfigurationService.cs
@@ -256,19 +256,26 @@ public class BudgetConfigurationService : IBudgetConfigurationService
                 CreateNoWindow = true
             };
             using var p = System.Diagnostics.Process.Start(psi);
-            if (p != null)
+            if (p == null)
             {
-                if (!p.WaitForExit(5_000))
-                {
-                    p.Kill(entireProcessTree: true);
-                    Console.Error.WriteLine($"[Lightning Enable] Warning: icacls timeout restricting {path}");
-                    return;
-                }
-                if (p.ExitCode != 0)
-                {
-                    var err = p.StandardError.ReadToEnd().Trim();
-                    Console.Error.WriteLine($"[Lightning Enable] Warning: icacls rc={p.ExitCode} on {path}: {err}");
-                }
+                // Copilot review on PR #21: previously silent. Surface a
+                // warning so operators know the config file's perms were
+                // not actually restricted on this run.
+                Console.Error.WriteLine(
+                    $"[Lightning Enable] Warning: icacls did not start (Process.Start returned null) — "
+                    + $"perms NOT restricted on {path}. Run `icacls {path} /inheritance:r /grant {Environment.UserName}:F` manually.");
+                return;
+            }
+            if (!p.WaitForExit(5_000))
+            {
+                p.Kill(entireProcessTree: true);
+                Console.Error.WriteLine($"[Lightning Enable] Warning: icacls timeout restricting {path}");
+                return;
+            }
+            if (p.ExitCode != 0)
+            {
+                var err = p.StandardError.ReadToEnd().Trim();
+                Console.Error.WriteLine($"[Lightning Enable] Warning: icacls rc={p.ExitCode} on {path}: {err}");
             }
         }
         catch (Exception ex)

--- a/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
@@ -833,22 +833,12 @@ public class NwcWalletService : IWalletService, IDisposable
                             if (kind == 23195) // NIP-47 response
                             {
                                 // F-11: defence-in-depth on top of the NIP-04/44 encryption
-                                // layer. The encryption already authenticates the sender (only
-                                // the wallet's private key can produce ciphertext we can
-                                // decrypt), but verifying the claimed pubkey + BIP340 sig
-                                // catches malformed events earlier and rejects any future
-                                // spec extension that decouples sender identity from the
-                                // encryption ECDH. Mirror of the Python _process_message.
-                                var eventPubkey = responseEvent["pubkey"]?.GetValue<string>();
-                                if (!string.Equals(eventPubkey, _config.WalletPubkey, StringComparison.OrdinalIgnoreCase))
+                                // layer. See IsResponseEventTrustworthy for the policy +
+                                // rationale; extracted to keep the gate independently
+                                // unit-testable (Copilot review on PR #21).
+                                if (!IsResponseEventTrustworthy(responseEvent, _config.WalletPubkey, out var rejectionReason))
                                 {
-                                    Console.Error.WriteLine($"[NWC] Response event pubkey mismatch ({eventPubkey?[..Math.Min(16, eventPubkey.Length)]}...); ignoring");
-                                    continue;
-                                }
-
-                                if (!VerifyNostrEventSignature(responseEvent))
-                                {
-                                    Console.Error.WriteLine("[NWC] Response event signature verification failed; ignoring");
+                                    Console.Error.WriteLine($"[NWC] Response event rejected: {rejectionReason}");
                                     continue;
                                 }
 
@@ -1061,7 +1051,41 @@ public class NwcWalletService : IWalletService, IDisposable
     /// relay can't forge an INFO event attributed to the wallet pubkey and force an
     /// encryption downgrade. Returns false on any malformed input.
     /// </summary>
-    internal static bool VerifyNostrEventSignature(JsonObject ev)
+    internal static bool VerifyNostrEventSignature(JsonObject ev) =>
+        VerifyNostrEventSignatureImpl(ev);
+
+    /// <summary>
+    /// F-11 gate for kind-23195 (NIP-47 response) events: rejects any event
+    /// whose <c>pubkey</c> doesn't match the configured wallet OR whose BIP340
+    /// signature fails verification. Defence-in-depth on top of NIP-04/44 ECDH
+    /// encryption — see comment at the call site in the response loop.
+    ///
+    /// Extracted from the response loop so it's directly unit-testable
+    /// (Copilot review on PR #21 noted no test coverage for the gate).
+    /// </summary>
+    internal static bool IsResponseEventTrustworthy(JsonObject ev, string expectedWalletPubkey, out string rejectionReason)
+    {
+        var eventPubkey = ev["pubkey"]?.GetValue<string>();
+        if (!string.Equals(eventPubkey, expectedWalletPubkey, StringComparison.OrdinalIgnoreCase))
+        {
+            var preview = eventPubkey != null
+                ? eventPubkey[..Math.Min(16, eventPubkey.Length)] + "..."
+                : "<null>";
+            rejectionReason = $"pubkey mismatch ({preview})";
+            return false;
+        }
+
+        if (!VerifyNostrEventSignatureImpl(ev))
+        {
+            rejectionReason = "BIP340 signature verification failed";
+            return false;
+        }
+
+        rejectionReason = string.Empty;
+        return true;
+    }
+
+    private static bool VerifyNostrEventSignatureImpl(JsonObject ev)
     {
         try
         {

--- a/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
@@ -832,6 +832,26 @@ public class NwcWalletService : IWalletService, IDisposable
                             Console.Error.WriteLine($"[NWC] Event kind: {kind}");
                             if (kind == 23195) // NIP-47 response
                             {
+                                // F-11: defence-in-depth on top of the NIP-04/44 encryption
+                                // layer. The encryption already authenticates the sender (only
+                                // the wallet's private key can produce ciphertext we can
+                                // decrypt), but verifying the claimed pubkey + BIP340 sig
+                                // catches malformed events earlier and rejects any future
+                                // spec extension that decouples sender identity from the
+                                // encryption ECDH. Mirror of the Python _process_message.
+                                var eventPubkey = responseEvent["pubkey"]?.GetValue<string>();
+                                if (!string.Equals(eventPubkey, _config.WalletPubkey, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    Console.Error.WriteLine($"[NWC] Response event pubkey mismatch ({eventPubkey?[..Math.Min(16, eventPubkey.Length)]}...); ignoring");
+                                    continue;
+                                }
+
+                                if (!VerifyNostrEventSignature(responseEvent))
+                                {
+                                    Console.Error.WriteLine("[NWC] Response event signature verification failed; ignoring");
+                                    continue;
+                                }
+
                                 // Verify this response is for our specific request via e tag
                                 var responseTags = responseEvent["tags"]?.AsArray();
                                 var responseETag = responseTags?

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/NwcWalletServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/NwcWalletServiceTests.cs
@@ -602,6 +602,74 @@ public class NwcWalletServiceTests
             .Should().BeFalse("malformed hex must not throw");
     }
 
+    // ─── F-11 gate tests (PR #21 round-2) ─────────────────────────────────
+    // The response loop for kind-23195 events delegates to
+    // IsResponseEventTrustworthy. These tests prove the gate's contract so
+    // future regressions can't quietly let forged events through.
+
+    [Fact]
+    public void IsResponseEventTrustworthy_RejectsPubkeyMismatch()
+    {
+        var (privKey, pubKeyBytes) = GenerateKeyPair();
+        var attackerPubkey = Convert.ToHexString(pubKeyBytes).ToLowerInvariant();
+
+        // Event signed by attacker's keypair, but configured wallet expects a
+        // different pubkey. Must be rejected before sig verification even runs.
+        var ev = BuildSignedInfoEvent(privKey, attackerPubkey, "nip04");
+        var configuredWallet = new string('a', 64); // different from attackerPubkey
+
+        var ok = LightningEnable.Mcp.Services.NwcWalletService.IsResponseEventTrustworthy(
+            ev, configuredWallet, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Contain("pubkey mismatch");
+    }
+
+    [Fact]
+    public void IsResponseEventTrustworthy_RejectsInvalidSignature()
+    {
+        // Pubkey matches the configured wallet, but the signature is bogus.
+        // Tests that even a "from the right party" claim fails when the sig
+        // doesn't actually verify.
+        var (_, pubKeyBytes) = GenerateKeyPair();
+        var pubkeyHex = Convert.ToHexString(pubKeyBytes).ToLowerInvariant();
+
+        var ev = new JsonObject
+        {
+            ["id"] = new string('0', 64),
+            ["pubkey"] = pubkeyHex,
+            ["sig"] = new string('0', 128),  // garbage sig
+            ["created_at"] = 1700000000L,
+            ["kind"] = 23195,
+            ["tags"] = new JsonArray(),
+            ["content"] = "ciphertext"
+        };
+
+        var ok = LightningEnable.Mcp.Services.NwcWalletService.IsResponseEventTrustworthy(
+            ev, pubkeyHex, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Contain("signature verification failed");
+    }
+
+    [Fact]
+    public void IsResponseEventTrustworthy_AcceptsValidSignedEvent()
+    {
+        // Baseline: legitimately signed event from the configured wallet
+        // pubkey passes both checks. Without this assertion, the gate could
+        // be over-restrictive (e.g. always-false bug) and still pass the
+        // negative tests above.
+        var (privKey, pubKeyBytes) = GenerateKeyPair();
+        var pubkeyHex = Convert.ToHexString(pubKeyBytes).ToLowerInvariant();
+        var ev = BuildSignedInfoEvent(privKey, pubkeyHex, "nip04 nip44_v2");
+
+        var ok = LightningEnable.Mcp.Services.NwcWalletService.IsResponseEventTrustworthy(
+            ev, pubkeyHex, out var reason);
+
+        ok.Should().BeTrue($"valid event must pass; rejection reason: {reason}");
+        reason.Should().BeEmpty();
+    }
+
     private static JsonObject BuildSignedInfoEvent(ECPrivKey privKey, string pubkeyHex, string encryptionTagValue)
     {
         var createdAt = 1700000000L;

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/config.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/config.py
@@ -8,6 +8,7 @@ Configuration is READ-ONLY at runtime - AI agents CANNOT modify it.
 import json
 import logging
 import os
+import stat
 import sys
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -16,6 +17,51 @@ from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger("lightning-enable-mcp.config")
+
+
+def _restrict_file_permissions(path: Path) -> None:
+    """
+    Restrict file permissions so only the current user can read/write.
+    POSIX: 0600. Windows: best-effort via icacls (the actual ACL change
+    happens out-of-process; we don't want to take a hard dep on pywin32 just
+    for first-run config). Failures here are logged but non-fatal — the
+    config still gets written, the user just gets a warning.
+    """
+    try:
+        if os.name == "posix":
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+            return
+
+        # Windows: clear inherited ACEs and grant the current user full
+        # control. Use icacls because it ships with every Windows install.
+        import getpass
+        import subprocess
+
+        user = os.environ.get("USERNAME") or getpass.getuser()
+        # /inheritance:r removes inherited permissions; /grant gives the
+        # current user full control. Errors here are surfaced as a warning,
+        # not raised — the file is already on disk and we don't want
+        # config-file-permission failure to hard-block first-run setup.
+        result = subprocess.run(
+            ["icacls", str(path), "/inheritance:r", "/grant", f"{user}:F"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "Could not restrict permissions on %s via icacls (rc=%d): %s",
+                path,
+                result.returncode,
+                (result.stderr or "").strip(),
+            )
+    except Exception as ex:  # noqa: BLE001 — best-effort hardening
+        logger.warning(
+            "Could not restrict permissions on %s: %s",
+            path,
+            ex,
+        )
 
 
 class ApprovalLevel(Enum):
@@ -430,6 +476,14 @@ class ConfigurationService:
 
             with open(self._config_file_path, "w", encoding="utf-8") as f:
                 f.write(json_data)
+
+            # F-12: lock down permissions on the config file. It can hold
+            # wallet credentials in plaintext (NWC connection strings, LND
+            # macaroon, Strike API key) — default 0644 leaves them
+            # world-readable on shared machines / CI runners. chmod is a no-op
+            # on Windows but the file inherits the parent dir ACL, which the
+            # ACL block below tightens further.
+            _restrict_file_permissions(self._config_file_path)
 
             # Print first-run setup message
             print("", file=sys.stderr)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/config.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/config.py
@@ -480,9 +480,9 @@ class ConfigurationService:
             # F-12: lock down permissions on the config file. It can hold
             # wallet credentials in plaintext (NWC connection strings, LND
             # macaroon, Strike API key) — default 0644 leaves them
-            # world-readable on shared machines / CI runners. chmod is a no-op
-            # on Windows but the file inherits the parent dir ACL, which the
-            # ACL block below tightens further.
+            # world-readable on shared machines / CI runners. The helper
+            # handles both POSIX (chmod 0600) and Windows (icacls
+            # inheritance:r + grant current user full) paths internally.
             _restrict_file_permissions(self._config_file_path)
 
             # Print first-run setup message

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
@@ -680,7 +680,30 @@ class NWCWallet:
         if event.get("kind") != 23195:  # NIP-47 response kind
             return
 
-        # Check if this is for us
+        # F-11: defence-in-depth on top of the NIP-04/44 encryption layer.
+        # The encryption itself authenticates the sender (only the wallet's
+        # private key can produce ciphertext we can decrypt), but verifying the
+        # claimed pubkey + BIP340 signature catches malformed/garbage events
+        # earlier and rejects any future spec extension that decouples sender
+        # identity from the encryption ECDH (e.g. relayed delegated responses).
+        # Mirror of the .NET handler in NwcWalletService.cs.
+        event_pubkey = event.get("pubkey", "").lower()
+        wallet_pubkey = self.config.wallet_pubkey.lower()
+        if event_pubkey != wallet_pubkey:
+            logger.warning(
+                "NWC response event pubkey mismatch (event=%s, expected=%s); ignoring",
+                event_pubkey[:16] if event_pubkey else "<empty>",
+                wallet_pubkey[:16],
+            )
+            return
+
+        if not _verify_nostr_event_signature(event):
+            logger.warning(
+                "NWC response event signature verification failed; ignoring"
+            )
+            return
+
+        # Check this response is addressed to us and references one of our requests
         p_tag = None
         e_tag = None
         for tag in event.get("tags", []):

--- a/python/lightning-enable-mcp/tests/test_security_f11_f12.py
+++ b/python/lightning-enable-mcp/tests/test_security_f11_f12.py
@@ -1,0 +1,150 @@
+"""
+Regression tests for security audit findings F-11 and F-12.
+
+F-11: NWC kind-23195 response events must be sig-verified before their
+content is trusted. The encryption layer authenticates as well, but the
+explicit signature check catches malformed/relay-forged events earlier and
+guards against future spec extensions that decouple encryption from
+identity.
+
+F-12: ~/.lightning-enable/config.json holds wallet credentials in plaintext.
+Default OS permissions can leave it world-readable on shared machines.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from lightning_enable_mcp.config import (
+    ConfigurationService,
+    _restrict_file_permissions,
+)
+from lightning_enable_mcp.nwc_wallet import _verify_nostr_event_signature
+
+
+# ─── F-11 tests ───────────────────────────────────────────────────────────
+
+class TestF11NwcEventSignatureVerification:
+    """The verifier helper is the gate the response loop now passes events
+    through. Confirms it rejects events the response loop must drop."""
+
+    def test_returns_false_on_empty_event(self):
+        assert _verify_nostr_event_signature({}) is False
+
+    def test_returns_false_on_missing_id(self):
+        assert _verify_nostr_event_signature({
+            "pubkey": "a" * 64,
+            "sig": "b" * 128,
+            "kind": 23195,
+            "created_at": 0,
+            "tags": [],
+            "content": "",
+        }) is False
+
+    def test_returns_false_on_missing_pubkey(self):
+        assert _verify_nostr_event_signature({
+            "id": "a" * 64,
+            "sig": "b" * 128,
+            "kind": 23195,
+            "created_at": 0,
+            "tags": [],
+            "content": "",
+        }) is False
+
+    def test_returns_false_on_missing_sig(self):
+        assert _verify_nostr_event_signature({
+            "id": "a" * 64,
+            "pubkey": "b" * 64,
+            "kind": 23195,
+            "created_at": 0,
+            "tags": [],
+            "content": "",
+        }) is False
+
+    def test_returns_false_on_wrong_field_lengths(self):
+        # id != 64 hex
+        assert _verify_nostr_event_signature({
+            "id": "abc",
+            "pubkey": "a" * 64,
+            "sig": "b" * 128,
+            "kind": 23195,
+            "created_at": 0,
+            "tags": [],
+            "content": "",
+        }) is False
+
+    def test_returns_false_on_random_id(self):
+        # All fields well-formed length but id is arbitrary; recomputed id
+        # won't match → reject.
+        assert _verify_nostr_event_signature({
+            "id": "0" * 64,
+            "pubkey": "1" * 64,
+            "sig": "2" * 128,
+            "kind": 23195,
+            "created_at": 1700000000,
+            "tags": [["e", "x" * 64]],
+            "content": "ciphertext",
+        }) is False
+
+
+# ─── F-12 tests ───────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(os.name != "posix",
+                    reason="POSIX-only — Windows uses icacls (process spawn)")
+class TestF12RestrictFilePermissionsPosix:
+    """On POSIX, _restrict_file_permissions chmods to 0600. Verifies the
+    actual mode bits after the call."""
+
+    def test_restrict_sets_user_only_rw(self, tmp_path: Path):
+        target = tmp_path / "config.json"
+        target.write_text("{}")
+        # World-readable starting state (typical default)
+        os.chmod(target, 0o644)
+
+        _restrict_file_permissions(target)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+    def test_restrict_idempotent_on_already_locked(self, tmp_path: Path):
+        target = tmp_path / "config.json"
+        target.write_text("{}")
+        os.chmod(target, 0o600)
+
+        _restrict_file_permissions(target)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+
+    def test_restrict_does_not_raise_on_missing_file(self, tmp_path: Path):
+        # Best-effort hardening — failure logs a warning, never raises.
+        # An exception here would hard-block first-run setup.
+        missing = tmp_path / "does-not-exist.json"
+        _restrict_file_permissions(missing)  # should not raise
+
+
+class TestF12ConfigurationServiceCreatesLockedFile:
+    """End-to-end: ConfigurationService._create_default_config_file must
+    leave the file with 0600 perms on POSIX."""
+
+    @pytest.mark.skipif(os.name != "posix",
+                        reason="POSIX-only — Windows uses icacls")
+    def test_first_run_creates_locked_config(self, tmp_path: Path):
+        # The service hardcodes Path.home() / ".lightning-enable", so we
+        # patch Path.home at import time to redirect to a temp dir.
+        with patch("lightning_enable_mcp.config.Path.home", return_value=tmp_path):
+            svc = ConfigurationService()
+            # Trigger the create-default path explicitly so the test is robust
+            # to any caching or reload logic in the service constructor.
+            svc._create_default_config_file()
+
+            config_path = svc._config_file_path
+            assert config_path.exists()
+            mode = stat.S_IMODE(config_path.stat().st_mode)
+            assert mode == 0o600, f"expected 0600 on freshly-written config, got {oct(mode)}"

--- a/python/lightning-enable-mcp/tests/test_security_f11_f12.py
+++ b/python/lightning-enable-mcp/tests/test_security_f11_f12.py
@@ -13,9 +13,10 @@ Default OS permissions can leave it world-readable on shared machines.
 
 from __future__ import annotations
 
-import json
+import asyncio
 import os
 import stat
+import urllib.parse
 from pathlib import Path
 from unittest.mock import patch
 
@@ -25,7 +26,10 @@ from lightning_enable_mcp.config import (
     ConfigurationService,
     _restrict_file_permissions,
 )
-from lightning_enable_mcp.nwc_wallet import _verify_nostr_event_signature
+from lightning_enable_mcp.nwc_wallet import (
+    NWCWallet,
+    _verify_nostr_event_signature,
+)
 
 
 # ─── F-11 tests ───────────────────────────────────────────────────────────
@@ -94,6 +98,93 @@ class TestF11NwcEventSignatureVerification:
 
 
 # ─── F-12 tests ───────────────────────────────────────────────────────────
+
+# ─── F-11 gate tests (added in PR #21 round-2) ────────────────────────────
+
+class TestF11ProcessMessageRejectsForgedEvents:
+    """End-to-end gate test for F-11: kind-23195 events whose pubkey doesn't
+    match the configured wallet OR whose BIP340 sig is invalid must NOT
+    resolve a pending request future. Helper-level coverage above is
+    necessary but not sufficient — Copilot review on PR #21 noted there's
+    no proof the *gate inside _process_message* actually invokes the helper.
+
+    Constructing an NWCWallet calls _get_pubkey which requires the secp256k1
+    native extension; skip the whole class if it's not installed in the test
+    env (CI installs it via dev deps).
+    """
+
+    pytestmark = pytest.mark.skipif(
+        __import__("importlib").util.find_spec("secp256k1") is None,
+        reason="secp256k1 native extension not installed in this env",
+    )
+
+    @staticmethod
+    def _make_nwc_uri(wallet_pubkey_hex: str) -> str:
+        # Construct a valid-shaped NWC URI without actually connecting. The
+        # secret can be any 64-hex-char string for ctor purposes.
+        secret_hex = "1" * 64
+        relay = urllib.parse.quote("wss://relay.example.invalid", safe="")
+        return f"nostr+walletconnect://{wallet_pubkey_hex}?relay={relay}&secret={secret_hex}"
+
+    @pytest.mark.asyncio
+    async def test_forged_pubkey_does_not_resolve_pending_future(self):
+        # Wallet expects events from this pubkey
+        expected_wallet_pubkey = "a" * 64
+        wallet = NWCWallet(self._make_nwc_uri(expected_wallet_pubkey))
+
+        # Register a pending request the forged event tries to resolve
+        request_id = "deadbeef" * 8  # 64 hex chars
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        wallet._pending_requests[request_id] = future
+
+        # Forged event: kind 23195 but pubkey != wallet's
+        forged_event = {
+            "id": "0" * 64,
+            "pubkey": "b" * 64,  # WRONG — attacker pubkey
+            "sig": "0" * 128,
+            "kind": 23195,
+            "created_at": 1700000000,
+            "tags": [
+                ["p", wallet._pubkey],  # addressed to us
+                ["e", request_id],
+            ],
+            "content": "ciphertext-irrelevant",
+        }
+
+        await wallet._process_message(["EVENT", "subid", forged_event])
+
+        assert not future.done(), \
+            "F-11 — forged event with wrong pubkey must not resolve our pending future"
+
+    @pytest.mark.asyncio
+    async def test_invalid_signature_does_not_resolve_pending_future(self):
+        # Wallet expects events from THIS pubkey; the forged event matches the
+        # pubkey but has a bogus signature.
+        expected_wallet_pubkey = "a" * 64
+        wallet = NWCWallet(self._make_nwc_uri(expected_wallet_pubkey))
+
+        request_id = "cafef00d" * 8
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        wallet._pending_requests[request_id] = future
+
+        forged_event = {
+            "id": "0" * 64,           # Won't match recomputed id either
+            "pubkey": expected_wallet_pubkey,
+            "sig": "0" * 128,         # Invalid sig
+            "kind": 23195,
+            "created_at": 1700000000,
+            "tags": [
+                ["p", wallet._pubkey],
+                ["e", request_id],
+            ],
+            "content": "ciphertext-irrelevant",
+        }
+
+        await wallet._process_message(["EVENT", "subid", forged_event])
+
+        assert not future.done(), \
+            "F-11 — forged event with invalid sig must not resolve our pending future"
+
 
 @pytest.mark.skipif(os.name != "posix",
                     reason="POSIX-only — Windows uses icacls (process spawn)")


### PR DESCRIPTION
Closes #17, #19.

## Summary

Two findings, applied symmetrically across .NET + Python.

### F-11 — NWC response event signature verification (BOTH PORTS)

The kind-23195 (NIP-47 response) handler decrypted and trusted event content without verifying the BIP340 Schnorr signature. The audit flagged Python only, but reading the .NET response loop (`NwcWalletService.cs:833`) revealed the same gap — `VerifyNostrEventSignature` was only called on INFO events.

The encryption layer (NIP-04/44 ECDH) already authenticates the sender (only the wallet's private key produces ciphertext we can decrypt), so this is **defense-in-depth, not an exploitable bypass on its own**. Real value:
- Drops malformed/garbage events earlier (CPU + log noise)
- Catches future spec extensions that decouple identity from encryption
- Catches misbehaving relays sending events with spoofed pubkey claims

Both ports now check `event.pubkey == config.wallet_pubkey` then call the existing `_verify_nostr_event_signature` / `VerifyNostrEventSignature` helper before any content trust. Mirror implementations.

### F-12 — Restrict `~/.lightning-enable/config.json` to 0600 (BOTH PORTS)

Config holds wallet credentials in plaintext. Default OS perms (0644 POSIX, ACL inheritance Windows) leave them readable by other accounts on shared machines / CI runners.

After write:
- POSIX: chmod 0600 (Python `os.chmod`, .NET `File.SetUnixFileMode`)
- Windows: best-effort via `icacls` subprocess. Failures log a warning — the file is already on disk and we don't want hardening failure to block first-run setup.

## Test plan

- [x] Python: 6 helper tests for F-11, 3 POSIX-conditional tests for F-12 (`tests/test_security_f11_f12.py`). Full suite 342/345 pass — 3 pre-existing failures in `test_server.py` from MCP library API drift, unrelated.
- [x] .NET: 227/227 pass. F-11 helper coverage already exists (`NwcWalletServiceTests` sig tests cover `VerifyNostrEventSignature` directly).
- [ ] After merge: confirm with a real NWC wallet (Primal/CoinOS) that pay_invoice still succeeds — both checks (pubkey match + sig verify) should pass against legitimate wallet responses.

## Versioning note

Did not bump `pyproject.toml` / `.csproj` versions in this PR to avoid conflicting with the open #20 (F-13 dep bump) which goes 1.12.6 → 1.12.7. Whichever PR merges second can pick up the version bump on the combined release. Recommend merging #20 first then this one (rebase) so both changes ship together as 1.12.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)