### PR TITLE
ci(codeql): drop pull_request trigger — weekly + manual only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,22 +1,34 @@
 name: CodeQL
 
-# Static analysis for the .NET MCP server + Python port. Runs on PRs (catches
-# new findings before merge) and weekly (catches query-pack updates flagging
-# things on the existing code). Skipped on push to main — the PR already
-# scanned that exact code; running again on the merge commit just adds 10+
-# minutes to every release. NOTE: CodeQL does NOT report vulnerable NuGet/
-# npm/PyPI versions — that is Dependabot's job.
+# Static analysis for the .NET MCP server + Python port. Triggers
+# (intentionally narrow):
+#   - Weekly Sunday 06:00 UTC: catches Microsoft's query-pack updates re-
+#     flagging things on existing code.
+#   - Manual workflow_dispatch: one-click ad-hoc run from the Actions tab,
+#     for when a change touches sensitive code (NWC encryption, L402 client,
+#     wallet credentials) and we want CodeQL coverage before merging.
 #
-# Findings post to the repo's Security tab → Code scanning alerts. We don't fail
-# PRs on findings yet — first sweep is for triage; tighten the gate after the
-# initial backlog of findings is worked through (tracked under issue #14 in this
-# repo / vault priority-backlog.md item #0).
+# Why NOT on every PR or push: matrix scan (csharp + python) takes ~10-15 min,
+# and across the 2026-05-04 security batch it found nothing the other scanners
+# didn't already catch. Semgrep covers ~85% of the same SAST ground in ~2 min
+# on every PR. Copilot review covers code quality. Manual audit (F-11/F-12)
+# was the actual signal source for security work. Re-enable the pull_request
+# trigger if Semgrep/Copilot ever miss something CodeQL would catch.
+#
+# NOTE: CodeQL does NOT report vulnerable NuGet/npm/PyPI versions — that is
+# Dependabot's job.
+#
+# Findings post to the repo's Security tab → Code scanning alerts. We don't
+# fail PRs on findings yet — first sweep is for triage; tighten the gate
+# after the initial backlog of findings is worked through (tracked under
+# issue #14 in this repo / vault priority-backlog.md item #0).
 
 on:
-  pull_request:
-    branches: [main]
   schedule:
     - cron: '0 6 * * 0'  # Sundays 06:00 UTC
+  workflow_dispatch:
+    # Manual trigger from Actions tab. Useful for one-off runs against a
+    # PR branch when touching sensitive code paths.
 
 permissions:
   actions: read


### PR DESCRIPTION
Per @refined-element call: CodeQL was silent across all 12 PRs in the 2026-05-04 security batch while Semgrep/Copilot/manual audit caught the actual findings. Cutting per-PR CodeQL saves ~10-15 min per merge.

New triggers: weekly Sunday + manual workflow_dispatch from the Actions tab. Re-enable pull_request if a future PR class warrants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)