### PR TITLE
fix(nwc): NIP-04 uses raw shared-X — restore CoinOS compat (v1.12.9)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.8</Version>
+    <Version>1.12.9</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.8: Security hardening for NWC + on-disk config (sec audit F-11, F-12). NWC kind-23195 response events are now BIP340 sig-verified before content is trusted (defence-in-depth on top of NIP-04/44 ECDH; rejects relay-forged events earlier and guards against future spec extensions that decouple identity from encryption). The config file at ~/.lightning-enable/config.json is created with restrictive permissions on first run (chmod 0600 on POSIX, icacls user-only on Windows) so wallet credentials aren't world-readable on shared machines or CI runners.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.9: Fix NIP-04 NWC compatibility with CoinOS (and any wallet using raw shared-X for the AES-256-CBC key). v1.12.5 round-2 introduced sha256(shared_x) as the AES key derivation under the framing of "spec compliance" — but that was wrong about CoinOS. Empirically verified by the working l402-ts JS NWC client (lines 137 + 222 of src/wallets/nwc.ts use raw shared_x and the path pays CoinOS in production). The bug surface was that NIP-04 NWC payments to CoinOS silently timed out at 30s ("NWC request failed (no_response)") because CoinOS couldn't decrypt our sha256-keyed ciphertext. Reverted both .NET and Python ports to raw shared_x; pinned by EncryptNip04_DerivesKeyAsRawSharedX_ForCoinOSAndL402TsCompat (.NET) + test_nip04_decrypts_raw_sharedx_for_coinos_compat (Python).</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
@@ -1150,19 +1150,29 @@ public class NwcWalletService : IWalletService, IDisposable
         var sharedPoint = recipientPubKey.GetSharedPubkey(senderPrivKey);
         var sharedX = sharedPoint.ToBytes()[1..33]; // Take x-coordinate only
 
-        // Encrypt with AES-256-CBC.
-        // Per NIP-04 spec the AES key is sha256(shared_x), NOT raw shared_x.
-        // The raw-shared_x form previously used here was internally consistent
-        // (encrypt + decrypt agreed) but incompatible with every other NIP-04
-        // implementation (Python port in this repo, Primal, CoinOS, Mutiny, etc.)
-        // which would mean ciphertext we send under nip04 wasn't decryptable by
-        // any real wallet. Fixed before flipping the default to nip04.
+        // Encrypt with AES-256-CBC using raw shared-X as the AES key.
+        //
+        // The NIP-04 spec text is genuinely ambiguous on the key derivation —
+        // some readings call for sha256(shared_x), others for raw shared_x. v1.12.5
+        // round-2 (commit e572f57) flipped this to sha256(shared_x) under the framing
+        // of "spec compliance," but the framing's claim that CoinOS / Primal / Mutiny
+        // also used sha256 turned out to be wrong about CoinOS — empirically verified
+        // by `l402-ts/src/wallets/nwc.ts` which uses raw shared-X (lines 137 + 222)
+        // and is confirmed working against CoinOS in production. After v1.12.5
+        // shipped, NIP-04 NWC payments to CoinOS started silently timing out at 30s
+        // (NWC request failed (no_response)) because CoinOS couldn't decrypt the
+        // sha256-keyed ciphertext we were sending.
+        //
+        // This is now pinned by `EncryptNip04_DerivesKeyAsRawSharedX_ForCoinOSAndL402TsCompat`
+        // which encrypts independently with raw shared-X and asserts our DecryptContent
+        // reads it. Don't flip back to sha256 without empirically verifying compatibility
+        // against the wallets we care about (CoinOS confirmed raw, others to-be-tested).
         var plaintextBytes = Encoding.UTF8.GetBytes(plaintext);
         var iv = new byte[16];
         RandomNumberGenerator.Fill(iv);
 
         using var aes = Aes.Create();
-        aes.Key = System.Security.Cryptography.SHA256.HashData(sharedX);
+        aes.Key = sharedX; // raw 32-byte X coordinate — matches l402-ts + CoinOS
         aes.IV = iv;
         aes.Mode = CipherMode.CBC;
         aes.Padding = PaddingMode.PKCS7;
@@ -1302,11 +1312,11 @@ public class NwcWalletService : IWalletService, IDisposable
         var sharedPoint = senderPubKey.GetSharedPubkey(recipientPrivKey);
         var sharedX = sharedPoint.ToBytes()[1..33]; // Take x-coordinate only
 
-        // Decrypt with AES-256-CBC. NIP-04 derives the key as sha256(shared_x);
-        // see EncryptNip04 for context on why the previous raw-shared_x form was
-        // wrong and why this is symmetric with the encrypt side.
+        // Decrypt with AES-256-CBC using raw shared-X. Symmetric with EncryptNip04
+        // — see the longer comment there for the empirical evidence (l402-ts uses
+        // raw shared-X and works against CoinOS) that drove this away from sha256.
         using var aes = Aes.Create();
-        aes.Key = System.Security.Cryptography.SHA256.HashData(sharedX);
+        aes.Key = sharedX; // raw 32-byte X coordinate — matches l402-ts + CoinOS
         aes.IV = iv;
         aes.Mode = CipherMode.CBC;
         aes.Padding = PaddingMode.PKCS7;

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/NwcWalletServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/NwcWalletServiceTests.cs
@@ -889,39 +889,39 @@ public class NwcWalletServiceTests
     }
 
     [Fact]
-    public void EncryptNip04_DerivesKeyAsSha256OfSharedX_NotRawSharedX()
+    public void EncryptNip04_DerivesKeyAsRawSharedX_ForCoinOSAndL402TsCompat()
     {
-        // Regression test for the NIP-04 key-derivation bug Copilot caught on this PR:
-        // EncryptNip04/DecryptNip04 previously used `aes.Key = sharedX` directly. The
-        // round-trip tests passed because both sides shared the bug, but on-the-wire
-        // ciphertext was incompatible with every other NIP-04 implementation
-        // (Python port in this repo, Primal NWC, CoinOS, Mutiny, etc.).
+        // Empirical wire-format pin: l402-ts/src/wallets/nwc.ts (the working JS NWC
+        // client that pays against CoinOS in production) uses raw shared-X as the
+        // AES-256-CBC key — no sha256 wrapper. See lines 137 + 222 of that file:
+        // both encrypt and decrypt importKey("raw", sharedX, ...) directly.
         //
-        // This pin guards against regressing back to raw-sharedX: we encrypt with our
-        // implementation, then independently decrypt using AES-256-CBC keyed by
-        // SHA256(sharedX) and assert the round-trip works. If someone ever changes
-        // EncryptNip04 to use a different key derivation, this test will fail.
+        // The previous version of this test pinned the OPPOSITE behavior
+        // (sha256(sharedX)) under the framing of "NIP-04 spec compliance" — a
+        // claim that turned out to be wrong about CoinOS. After v1.12.5 round-2
+        // shipped that change (commit e572f57, May 3 2026), .NET MCP NIP-04
+        // payments stopped working against CoinOS — encrypted with sha256-keyed
+        // AES, CoinOS attempted to decrypt with raw-keyed AES, got garbage,
+        // silently dropped the event, leading to the user-visible
+        // "NWC request failed (no_response)" 30s timeout.
+        //
+        // This pin guards against regressing in the other direction — anyone
+        // who tries to "spec comply" by flipping back to sha256 will fail this
+        // test against an independently-encrypted ciphertext.
         var (alicePriv, alicePub) = GenerateKeyPair();
         var (bobPriv, bobPub) = GenerateKeyPair();
         const string plaintext = "{\"method\":\"get_balance\",\"params\":{}}";
 
-        // Reproduce the ECDH that EncryptNip04 does internally. We rely on the
-        // public DecryptContent path being correct; the assertion below also pins
-        // that the encrypt side is symmetric with the spec-compliant decrypt.
+        // Round-trip via NwcWalletService — basic sanity that encrypt + decrypt
+        // agree internally (would pass with EITHER key derivation, hence the
+        // independent-encrypt assertion below).
         var encrypted = NwcWalletService.EncryptNip04(plaintext, bobPub, alicePriv);
         var decrypted = NwcWalletService.DecryptContent(encrypted, alicePub, bobPriv);
         decrypted.Should().Be(plaintext);
 
-        // Independently parse the base64 IV + ciphertext blob and verify it can be
-        // decrypted with sha256(shared_x) but NOT with raw shared_x. This catches
-        // a future regression that flips back to raw-key on either the encrypt or
-        // decrypt side.
-        var parts = encrypted.Split("?iv=");
-        parts.Length.Should().Be(2);
-        var ciphertextBytes = Convert.FromBase64String(parts[0]);
-        var iv = Convert.FromBase64String(parts[1]);
-
-        // Recompute ECDH shared_x the same way the implementation does
+        // Independently encrypt the same plaintext using RAW sharedX as the AES key
+        // (the l402-ts / CoinOS wire format) and assert NwcWalletService.DecryptContent
+        // can read it. This is the test that fails on the buggy sha256 implementation.
         var fullPubkeyBytes = new byte[33];
         fullPubkeyBytes[0] = 0x02;
         bobPub.CopyTo(fullPubkeyBytes, 1);
@@ -929,31 +929,46 @@ public class NwcWalletServiceTests
         var sharedPoint = bobPubKey!.GetSharedPubkey(alicePriv);
         var sharedX = sharedPoint.ToBytes()[1..33];
 
-        // sha256(shared_x) must successfully decrypt
-        using (var aes = System.Security.Cryptography.Aes.Create())
-        {
-            aes.Key = System.Security.Cryptography.SHA256.HashData(sharedX);
-            aes.IV = iv;
-            aes.Mode = System.Security.Cryptography.CipherMode.CBC;
-            aes.Padding = System.Security.Cryptography.PaddingMode.PKCS7;
-            using var dec = aes.CreateDecryptor();
-            var roundTrip = Encoding.UTF8.GetString(dec.TransformFinalBlock(ciphertextBytes, 0, ciphertextBytes.Length));
-            roundTrip.Should().Be(plaintext, "spec-compliant key derivation must decrypt successfully");
-        }
+        var iv = new byte[16];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(iv);
 
-        // Raw shared_x must NOT decrypt successfully — proving we're not in the buggy
-        // state. AES-CBC with the wrong key + PKCS7 padding throws CryptographicException
-        // with overwhelming probability.
+        byte[] independentCiphertext;
         using (var aes = System.Security.Cryptography.Aes.Create())
         {
-            aes.Key = sharedX;
+            aes.Key = sharedX; // raw — what l402-ts and CoinOS use
             aes.IV = iv;
             aes.Mode = System.Security.Cryptography.CipherMode.CBC;
             aes.Padding = System.Security.Cryptography.PaddingMode.PKCS7;
+            using var enc = aes.CreateEncryptor();
+            var ptBytes = Encoding.UTF8.GetBytes(plaintext);
+            independentCiphertext = enc.TransformFinalBlock(ptBytes, 0, ptBytes.Length);
+        }
+        var independentEncrypted = Convert.ToBase64String(independentCiphertext)
+            + "?iv=" + Convert.ToBase64String(iv);
+
+        // The fix proves itself here: NwcWalletService must decrypt raw-sharedX
+        // ciphertext (the l402-ts / CoinOS wire format).
+        var independentDecrypted = NwcWalletService.DecryptContent(independentEncrypted, alicePub, bobPriv);
+        independentDecrypted.Should().Be(plaintext,
+            "DecryptContent must accept raw-sharedX NIP-04 — l402-ts confirmed working against CoinOS uses this wire format");
+
+        // Symmetric assertion: ciphertext WE produce must be readable with raw sharedX.
+        // CoinOS and other raw-sharedX wallets receive our outgoing requests this way.
+        var parts = encrypted.Split("?iv=");
+        parts.Length.Should().Be(2);
+        var ourCiphertext = Convert.FromBase64String(parts[0]);
+        var ourIv = Convert.FromBase64String(parts[1]);
+
+        using (var aes = System.Security.Cryptography.Aes.Create())
+        {
+            aes.Key = sharedX; // raw
+            aes.IV = ourIv;
+            aes.Mode = System.Security.Cryptography.CipherMode.CBC;
+            aes.Padding = System.Security.Cryptography.PaddingMode.PKCS7;
             using var dec = aes.CreateDecryptor();
-            var act = () => dec.TransformFinalBlock(ciphertextBytes, 0, ciphertextBytes.Length);
-            act.Should().Throw<System.Security.Cryptography.CryptographicException>(
-                "raw-shared_x must no longer decrypt — that was the bug we just fixed");
+            var roundTrip = Encoding.UTF8.GetString(dec.TransformFinalBlock(ourCiphertext, 0, ourCiphertext.Length));
+            roundTrip.Should().Be(plaintext,
+                "ciphertext we emit must be readable by raw-sharedX wallets like CoinOS");
         }
     }
 

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.8"
+version = "1.12.9"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
@@ -253,7 +253,7 @@ def _get_pubkey(secret_key: bytes) -> str:
 
 def _encrypt_content(plaintext: str, secret_key: bytes, recipient_pubkey: str) -> str:
     """
-    Encrypt content using NIP-04 (ECDH + sha256 + AES-256-CBC).
+    Encrypt content using NIP-04 (ECDH + AES-256-CBC) with raw shared-X as key.
 
     Args:
         plaintext: Content to encrypt
@@ -262,6 +262,16 @@ def _encrypt_content(plaintext: str, secret_key: bytes, recipient_pubkey: str) -
 
     Returns:
         Encrypted content in NIP-04 format: base64(ciphertext)?iv=base64(iv)
+
+    Note on the NIP-04 key derivation: the spec text is genuinely ambiguous —
+    some readings call for sha256(shared_x), others for raw shared_x. This
+    implementation uses raw shared_x to match l402-ts/src/wallets/nwc.ts (the
+    working JS NWC client confirmed against CoinOS in production) and the
+    sister .NET port. An earlier version of this file derived the key as
+    sha256(shared_x), which broke compatibility with CoinOS — symptom was a
+    silent 30s NWC timeout (request ciphertext unreadable by the wallet).
+    Don't flip back to sha256 without empirically verifying the wallets we
+    care about.
     """
     # The previous implementation had a try/except ImportError block that
     # only returned a value inside the except branch — when pycryptodome
@@ -271,20 +281,19 @@ def _encrypt_content(plaintext: str, secret_key: bytes, recipient_pubkey: str) -
     # there is no reason to branch; collapsed to a single code path.
     import base64
     import os
-    from hashlib import sha256
 
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
     from secp256k1 import PrivateKey, PublicKey  # noqa: F401  (PrivateKey not used here, kept for parity)
 
-    # Compute shared secret. Per NIP-04: AES key = sha256(shared_x).
+    # Compute ECDH shared point; AES key is the raw 32-byte X coordinate.
     recipient_bytes = bytes.fromhex(recipient_pubkey)
     if len(recipient_bytes) == 32:
         # Add prefix for compressed pubkey (assume even y-coordinate)
         recipient_bytes = b"\x02" + recipient_bytes
     pubkey = PublicKey(recipient_bytes, raw=True)
     shared_point = pubkey.tweak_mul(secret_key)
-    shared_secret = sha256(shared_point.serialize()[1:33]).digest()
+    shared_secret = shared_point.serialize()[1:33]  # raw shared-X — matches l402-ts + CoinOS
 
     # Generate IV and encrypt with AES-256-CBC + PKCS7 padding
     iv = os.urandom(16)
@@ -406,7 +415,6 @@ def _decrypt_nip04(encrypted: str, secret_key: bytes, sender_pubkey: str) -> str
         Decrypted plaintext
     """
     import base64
-    from hashlib import sha256
 
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
     from cryptography.hazmat.backends import default_backend
@@ -419,9 +427,11 @@ def _decrypt_nip04(encrypted: str, secret_key: bytes, sender_pubkey: str) -> str
     ciphertext = base64.b64decode(parts[0])
     iv = base64.b64decode(parts[1])
 
-    # Compute shared secret: SHA256 of shared x-coordinate (NIP-04 specific)
+    # AES key is the raw 32-byte shared-X — symmetric with _encrypt_nip04 and
+    # matches l402-ts/CoinOS wire format. See _encrypt_nip04 for the empirical
+    # rationale behind not using sha256(shared_x).
     shared_x = _compute_shared_x(secret_key, sender_pubkey)
-    shared_secret = sha256(shared_x).digest()
+    shared_secret = shared_x  # raw — matches l402-ts + CoinOS
 
     # Decrypt
     cipher = Cipher(algorithms.AES(shared_secret), modes.CBC(iv), backend=default_backend())

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
@@ -427,9 +427,10 @@ def _decrypt_nip04(encrypted: str, secret_key: bytes, sender_pubkey: str) -> str
     ciphertext = base64.b64decode(parts[0])
     iv = base64.b64decode(parts[1])
 
-    # AES key is the raw 32-byte shared-X — symmetric with _encrypt_nip04 and
-    # matches l402-ts/CoinOS wire format. See _encrypt_nip04 for the empirical
-    # rationale behind not using sha256(shared_x).
+    # AES key is the raw 32-byte shared-X — symmetric with _encrypt_content
+    # (the NIP-04 encrypt path) and matches l402-ts/CoinOS wire format. See
+    # _encrypt_content for the empirical rationale behind not using
+    # sha256(shared_x).
     shared_x = _compute_shared_x(secret_key, sender_pubkey)
     shared_secret = shared_x  # raw — matches l402-ts + CoinOS
 

--- a/python/lightning-enable-mcp/tests/test_nwc_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_wallet.py
@@ -44,9 +44,10 @@ def _nip04_encrypt_with_shared_x(plaintext: str, shared_x: bytes) -> str:
     Encrypt using NIP-04 with a pre-computed shared_x (bypasses ECDH).
 
     Uses raw shared_x as the AES key — matches l402-ts/CoinOS wire format and
-    the production _encrypt_nip04 implementation. Test fixtures encrypted by
-    this helper must round-trip through _decrypt_nip04, which is the contract
-    that nip-04 NWC interop with CoinOS depends on.
+    the production _encrypt_content implementation (the NIP-04 encrypt path
+    in nwc_wallet.py). Test fixtures encrypted by this helper must round-trip
+    through _decrypt_nip04, which is the contract that nip-04 NWC interop
+    with CoinOS depends on.
     """
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
     from cryptography.hazmat.backends import default_backend
@@ -229,14 +230,18 @@ class TestNIP04Decryption:
 
         l402-ts/src/wallets/nwc.ts (lines 137 + 222) uses raw shared_x as the
         AES-256-CBC key and is empirically verified working against CoinOS in
-        production. An earlier version of _encrypt_nip04 / _decrypt_nip04 used
-        sha256(shared_x) which silently broke CoinOS NIP-04 NWC — symptom was
-        a 30s "NWC request failed (no_response)" because CoinOS couldn't read
-        ciphertext we keyed with sha256.
+        production. An earlier version of _encrypt_content / _decrypt_nip04
+        used sha256(shared_x) which silently broke CoinOS NIP-04 NWC — symptom
+        was a 30s "NWC request failed (no_response)" because CoinOS couldn't
+        read ciphertext we keyed with sha256.
 
         This test is the explicit pin: anyone flipping back to sha256 must also
         delete this test, which forces them to confront why it exists.
         """
+        from cryptography.exceptions import InvalidTag
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.backends import default_backend
+
         plaintext = '{"result_type":"pay_invoice","result":{"preimage":"deadbeef"}}'
 
         # _nip04_encrypt_with_shared_x now uses raw shared_x (the contract).
@@ -252,9 +257,6 @@ class TestNIP04Decryption:
         # production decrypt must NOT round-trip. PKCS7 padding will almost
         # always reject (probability of a wrong-key padding-look-valid is
         # ~1/256, not asserted exactly — just that the round-trip fails).
-        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-        from cryptography.hazmat.backends import default_backend
-
         wrong_key = hashlib.sha256(_FIXED_SHARED_X).digest()
         wrong_iv = os.urandom(16)
         plaintext_bytes = plaintext.encode("utf-8")
@@ -263,23 +265,36 @@ class TestNIP04Decryption:
         wrong_cipher = Cipher(
             algorithms.AES(wrong_key), modes.CBC(wrong_iv), backend=default_backend()
         )
-        wrong_ct = wrong_cipher.encryptor().update(padded) + wrong_cipher.encryptor().finalize()
+        # Single encryptor instance — calling .encryptor() twice would yield two
+        # separate contexts where the first never gets finalize()'d. update()
+        # and finalize() must be on the SAME instance to produce a valid CBC
+        # ciphertext (Copilot review on PR #26).
+        encryptor = wrong_cipher.encryptor()
+        wrong_ct = encryptor.update(padded) + encryptor.finalize()
         sha256_keyed_encrypted = (
             f"{base64.b64encode(wrong_ct).decode()}?iv={base64.b64encode(wrong_iv).decode()}"
         )
 
-        # Production decrypt should NOT recover the plaintext from sha256-keyed input
+        # Production decrypt should NOT recover the plaintext from sha256-keyed
+        # input. We catch the specific exceptions the cryptography library
+        # raises on bad padding/tag — NOT bare Exception, which would also
+        # swallow an AssertionError from `assert wrong_decrypted != plaintext`
+        # and silently let a regression through (Copilot review on PR #26).
         try:
             wrong_decrypted = _decrypt_nip04(
                 sha256_keyed_encrypted, _DUMMY_SECRET_KEY, _DUMMY_PUBKEY_HEX
             )
-            assert wrong_decrypted != plaintext, (
-                "production decrypt accepted sha256-keyed ciphertext — "
-                "implementation may be using sha256(shared_x) instead of raw"
-            )
-        except Exception:
-            # Padding rejection is the expected outcome — this is the pin's contract.
-            pass
+        except (ValueError, InvalidTag):
+            # Padding/tag rejection on the wrong key is the expected outcome —
+            # this is the pin's contract.
+            return
+        # Decrypt didn't throw — make sure it didn't accidentally produce the
+        # original plaintext (which would mean the production code is using
+        # sha256(shared_x), the very regression we're guarding against).
+        assert wrong_decrypted != plaintext, (
+            "production decrypt accepted sha256-keyed ciphertext — "
+            "implementation may be using sha256(shared_x) instead of raw"
+        )
 
     def test_nip04_invalid_format_raises(self):
         """Test that NIP-04 decrypt raises on missing ?iv= separator."""

--- a/python/lightning-enable-mcp/tests/test_nwc_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_wallet.py
@@ -27,9 +27,14 @@ from lightning_enable_mcp.nwc_wallet import (
 # ---------- Deterministic test keys (no secp256k1 needed) ----------
 # We use a fixed 32-byte "shared_x" value to bypass ECDH in tests.
 # This lets us test all the symmetric crypto without the secp256k1 C library.
+# Must be exactly 32 bytes (64 hex chars) — used directly as the AES-256 key.
+# Earlier this fixture was 31 bytes; it appeared to work only because the
+# previous sha256(shared_x) key derivation hashed any input down to 32 bytes,
+# masking the size error. After the raw-shared_x fix, length matters.
 _FIXED_SHARED_X = bytes.fromhex(
-    "4b6a0c7e8f9d2e1a3c5b7d9f0e2a4c6b8d0f1e3a5c7b9d1f0e2a4c6b8d0f1e"
+    "4b6a0c7e8f9d2e1a3c5b7d9f0e2a4c6b8d0f1e3a5c7b9d1f0e2a4c6b8d0f1e3a"
 )
+assert len(_FIXED_SHARED_X) == 32, "Fixed shared_x must be exactly 32 bytes for AES-256"
 _DUMMY_SECRET_KEY = b"\x01" * 32
 _DUMMY_PUBKEY_HEX = "02" + "ab" * 32  # Won't be used for actual ECDH
 
@@ -37,11 +42,16 @@ _DUMMY_PUBKEY_HEX = "02" + "ab" * 32  # Won't be used for actual ECDH
 def _nip04_encrypt_with_shared_x(plaintext: str, shared_x: bytes) -> str:
     """
     Encrypt using NIP-04 with a pre-computed shared_x (bypasses ECDH).
+
+    Uses raw shared_x as the AES key — matches l402-ts/CoinOS wire format and
+    the production _encrypt_nip04 implementation. Test fixtures encrypted by
+    this helper must round-trip through _decrypt_nip04, which is the contract
+    that nip-04 NWC interop with CoinOS depends on.
     """
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
     from cryptography.hazmat.backends import default_backend
 
-    shared_secret = hashlib.sha256(shared_x).digest()
+    shared_secret = shared_x  # raw 32-byte X — matches l402-ts + CoinOS
     iv = os.urandom(16)
 
     plaintext_bytes = plaintext.encode("utf-8")
@@ -208,6 +218,68 @@ class TestNIP04Decryption:
         encrypted = _nip04_encrypt_with_shared_x(plaintext, _FIXED_SHARED_X)
         decrypted = _decrypt_nip04(encrypted, _DUMMY_SECRET_KEY, _DUMMY_PUBKEY_HEX)
         assert decrypted == plaintext
+
+    @patch(
+        "lightning_enable_mcp.nwc_wallet._compute_shared_x",
+        return_value=_FIXED_SHARED_X,
+    )
+    def test_nip04_decrypts_raw_sharedx_for_coinos_compat(self, mock_shared_x):
+        """
+        Pin the NIP-04 wire format: AES key is raw shared_x (NOT sha256).
+
+        l402-ts/src/wallets/nwc.ts (lines 137 + 222) uses raw shared_x as the
+        AES-256-CBC key and is empirically verified working against CoinOS in
+        production. An earlier version of _encrypt_nip04 / _decrypt_nip04 used
+        sha256(shared_x) which silently broke CoinOS NIP-04 NWC — symptom was
+        a 30s "NWC request failed (no_response)" because CoinOS couldn't read
+        ciphertext we keyed with sha256.
+
+        This test is the explicit pin: anyone flipping back to sha256 must also
+        delete this test, which forces them to confront why it exists.
+        """
+        plaintext = '{"result_type":"pay_invoice","result":{"preimage":"deadbeef"}}'
+
+        # _nip04_encrypt_with_shared_x now uses raw shared_x (the contract).
+        # Production _decrypt_nip04 must accept it.
+        encrypted = _nip04_encrypt_with_shared_x(plaintext, _FIXED_SHARED_X)
+        decrypted = _decrypt_nip04(encrypted, _DUMMY_SECRET_KEY, _DUMMY_PUBKEY_HEX)
+        assert decrypted == plaintext, (
+            "raw-shared_x ciphertext must decrypt; if this fails, the production "
+            "implementation has likely regressed back to sha256(shared_x)"
+        )
+
+        # Negative assertion: feeding sha256(shared_x)-keyed ciphertext to the
+        # production decrypt must NOT round-trip. PKCS7 padding will almost
+        # always reject (probability of a wrong-key padding-look-valid is
+        # ~1/256, not asserted exactly — just that the round-trip fails).
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.backends import default_backend
+
+        wrong_key = hashlib.sha256(_FIXED_SHARED_X).digest()
+        wrong_iv = os.urandom(16)
+        plaintext_bytes = plaintext.encode("utf-8")
+        padding_len = 16 - (len(plaintext_bytes) % 16)
+        padded = plaintext_bytes + bytes([padding_len] * padding_len)
+        wrong_cipher = Cipher(
+            algorithms.AES(wrong_key), modes.CBC(wrong_iv), backend=default_backend()
+        )
+        wrong_ct = wrong_cipher.encryptor().update(padded) + wrong_cipher.encryptor().finalize()
+        sha256_keyed_encrypted = (
+            f"{base64.b64encode(wrong_ct).decode()}?iv={base64.b64encode(wrong_iv).decode()}"
+        )
+
+        # Production decrypt should NOT recover the plaintext from sha256-keyed input
+        try:
+            wrong_decrypted = _decrypt_nip04(
+                sha256_keyed_encrypted, _DUMMY_SECRET_KEY, _DUMMY_PUBKEY_HEX
+            )
+            assert wrong_decrypted != plaintext, (
+                "production decrypt accepted sha256-keyed ciphertext — "
+                "implementation may be using sha256(shared_x) instead of raw"
+            )
+        except Exception:
+            # Padding rejection is the expected outcome — this is the pin's contract.
+            pass
 
     def test_nip04_invalid_format_raises(self):
         """Test that NIP-04 decrypt raises on missing ?iv= separator."""


### PR DESCRIPTION
## TL;DR

**v1.12.5 round-2 broke NIP-04 NWC against CoinOS.** This PR fixes it.

The May 3 2026 commit `e572f57` flipped \`EncryptNip04\`/\`DecryptNip04\` from \`aes.Key = sharedX\` (raw) to \`aes.Key = sha256(sharedX)\` under a "spec compliance" framing. That commit's claim that CoinOS uses \`sha256(shared_x)\` was wrong — never empirically tested. Symptom: 30s "NWC request failed (no_response)" timeouts when paying CoinOS via NIP-04.

## Empirical proof

\`l402-ts/src/wallets/nwc.ts\` (the working JS NWC client, verified paying CoinOS in production by user) uses **raw shared-X** as the AES-256-CBC key. See lines 137 + 222: both \`importKey("raw", sharedX, ...)\` directly, no sha256 wrapper.

User's report: their \`test-sats4ai-nwc.mjs\` (which uses l402-ts) pays CoinOS fine. The .NET MCP doesn't. The only difference is the AES key derivation.

## What this PR does

- **`.NET`**: \`NwcWalletService.cs\` — \`aes.Key = sharedX\` (was \`SHA256.HashData(sharedX)\`) on both encrypt + decrypt sites
- **Python**: \`nwc_wallet.py\` — \`shared_secret = shared_x\` (was \`sha256(shared_x).digest()\`) on both encrypt + decrypt sites
- **Pinned by new tests on both sides** that independently encrypt with raw shared-X and assert the production decrypt path reads it:
  - \`.NET\`: \`EncryptNip04_DerivesKeyAsRawSharedX_ForCoinOSAndL402TsCompat\`
  - Python: \`test_nip04_decrypts_raw_sharedx_for_coinos_compat\` (also has a negative assertion: sha256-keyed ciphertext must NOT round-trip)
- **Updated \`_nip04_encrypt_with_shared_x\` test helper** in Python to use raw shared-X (was sha256 — masked the wire-format intent of the existing round-trip tests)
- **Fixed \`_FIXED_SHARED_X\`** test fixture to be exactly 32 bytes (was 31; only worked accidentally because sha256 hashes any input length to 32 bytes)
- **Version bump**: 1.12.8 → 1.12.9 in both \`.csproj\` and \`pyproject.toml\`

## What this DOES NOT change

| Feature | Affected? |
|---|---|
| NIP-44 v2 / Alby Hub path | ❌ unaffected — separate code path |
| F-11 response sig verification (v1.12.8) | ❌ unaffected — orthogonal hardening, stays |
| INFO event auto-detect (v1.12.6) | ❌ unaffected |
| Strike, OpenNode, LND wallet paths | ❌ unaffected |

## Test results

- **.NET**: 230 / 230 passing (full suite)
- **Python**: 343 passing, 10 skipped, 3 failed
  - 3 failures are pre-existing Windows-only \`ModuleNotFoundError: No module named 'secp256k1'\` (no Windows wheel for the C library) — verified failing on main too. Unrelated to this fix; CI runs on Linux where secp256k1 is available.

## Risk + open question

The original "spec compliance" commit message claimed **Primal NWC** and **Mutiny** also use sha256. That claim was based on spec reading, not empirical testing. **If those wallets DO use sha256 (vs raw), this revert may break them.** Empirical CoinOS evidence is strong; the others are unverified.

Recommended next step (separate ticket if needed): empirically verify Primal + Mutiny + Alby-Hub-NIP-04-fallback after this ships. If any of them require sha256, we'll need a per-wallet detection mechanism (try one, fallback to the other on decrypt failure).

## Repro

The bug is reproducible from the failing test alone, before the fix:

\`\`\`
$ dotnet test --filter "EncryptNip04_DerivesKeyAsRawSharedX"
Failed!  CryptographicException at NwcWalletService.DecryptNip04, line 1315
\`\`\`

After the fix:

\`\`\`
Passed!  - Failed: 0, Passed: 1
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)