### PR TITLE
ci: add Test workflow — dotnet test + pytest on PR + push to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,94 @@
+name: Test
+
+# Functional test gate for both ports. Runs on every PR + push to main so
+# regressions can't ship silently the way the v1.12.5 NIP-04 key-derivation
+# bug did (broke CoinOS compat for ~5 days; not caught because no CI ran the
+# test suite before publish).
+#
+# Two parallel jobs: .NET (dotnet test against the solution) + Python (pytest
+# with secp256k1 + dev extras). Linux runners only — secp256k1 has no Windows
+# wheel and we don't ship a Windows-specific test surface.
+#
+# Companion to the security scans (CodeQL, Semgrep, gitleaks). Those catch
+# safety regressions; this catches functional regressions.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dotnet-test:
+    name: .NET
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        working-directory: dotnet
+        run: dotnet restore LightningEnable.Mcp.sln
+
+      - name: Build (Release)
+        working-directory: dotnet
+        run: dotnet build LightningEnable.Mcp.sln --configuration Release --no-restore
+
+      - name: Test
+        working-directory: dotnet
+        # --no-build to surface compile errors in the build step (clearer than a
+        # collapsed test+build step), --logger console;verbosity=normal to make
+        # individual test failures grep-able in the workflow log.
+        run: dotnet test LightningEnable.Mcp.sln --configuration Release --no-build --logger "console;verbosity=normal"
+
+  python-test:
+    name: Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      # Don't fast-fail across the matrix — if 3.10 fails for an interpreter-
+      # specific reason, we still want to see whether 3.12 is also affected.
+      fail-fast: false
+      matrix:
+        # Lower bound (3.10 — pyproject.toml requires-python) + the version we
+        # use locally for development (3.12). Skip 3.11 — covered by the
+        # shape of the bookends.
+        python-version: ['3.10', '3.12']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + dev extras
+        working-directory: python/lightning-enable-mcp
+        # `-e .[dev]` installs the package in editable mode pulling pytest,
+        # pytest-asyncio, pytest-cov, mypy, ruff (per pyproject.toml). secp256k1
+        # is a hard runtime dependency so it lands automatically. PyPI has
+        # manylinux wheels so no compile step is needed on ubuntu-latest.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Run pytest
+        working-directory: python/lightning-enable-mcp
+        # --tb=short keeps stack traces grep-able without truncating to one
+        # line. -q quiet mode trims per-test progress dots; failure detail
+        # still surfaces in full.
+        run: pytest --tb=short -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Run pytest
         working-directory: python/lightning-enable-mcp
         # --tb=short keeps stack traces grep-able without truncating to one
-        # line. -q quiet mode trims per-test progress dots; failure detail
-        # still surfaces in full.
-        run: pytest --tb=short -q
+        # line. We deliberately don't pass -q: pyproject.toml's [tool.pytest]
+        # addopts already pins `-v --cov=... --cov-report=term-missing`, which
+        # overrides -q anyway and emits coverage regardless. Letting coverage
+        # surface in CI logs is intentional — a per-PR view of coverage drift
+        # is worth the longer log.
+        run: pytest --tb=short

--- a/python/lightning-enable-mcp/tests/test_discover_api.py
+++ b/python/lightning-enable-mcp/tests/test_discover_api.py
@@ -6,6 +6,20 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+# Reach the SUBMODULE explicitly via importlib, NOT via attribute access on
+# the parent package. The package's __init__.py does
+# `from .discover_api import discover_api`, which binds the FUNCTION to the
+# `tools.discover_api` attribute — shadowing the submodule. So both
+# `patch("lightning_enable_mcp.tools.discover_api.httpx")` and
+# `import lightning_enable_mcp.tools.discover_api as alias` resolve to the
+# function (which has no `httpx` attribute → AttributeError on Python 3.10;
+# 3.12's mock.patch handles it differently and happens to pass).
+# `importlib.import_module` looks the submodule up in `sys.modules` and
+# returns the genuine module object regardless of what name the parent
+# package binds. patch.object on that reference works on every supported
+# Python version.
+import importlib
+discover_api_module = importlib.import_module("lightning_enable_mcp.tools.discover_api")
 from lightning_enable_mcp.tools.discover_api import (
     discover_api,
     _get_registry_base_url,
@@ -141,7 +155,7 @@ class TestDiscoverApi:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("lightning_enable_mcp.tools.discover_api.httpx") as mock_httpx:
+        with patch.object(discover_api_module, "httpx") as mock_httpx:
             mock_httpx.AsyncClient.return_value = mock_client
 
             result = await discover_api(query="weather")
@@ -164,7 +178,7 @@ class TestDiscoverApi:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("lightning_enable_mcp.tools.discover_api.httpx") as mock_httpx:
+        with patch.object(discover_api_module, "httpx") as mock_httpx:
             mock_httpx.AsyncClient.return_value = mock_client
 
             result = await discover_api(query="test")
@@ -193,7 +207,7 @@ class TestDiscoverApi:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("lightning_enable_mcp.tools.discover_api.httpx") as mock_httpx:
+        with patch.object(discover_api_module, "httpx") as mock_httpx:
             mock_httpx.AsyncClient.return_value = mock_client
 
             result = await discover_api(url="https://api.example.com")
@@ -215,7 +229,7 @@ class TestDiscoverApi:
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("lightning_enable_mcp.tools.discover_api.httpx") as mock_httpx:
+        with patch.object(discover_api_module, "httpx") as mock_httpx:
             mock_httpx.AsyncClient.return_value = mock_client
 
             result = await discover_api(url="https://no-manifest.example.com")
@@ -228,7 +242,7 @@ class TestDiscoverApi:
     @pytest.mark.asyncio
     async def test_httpx_not_available(self):
         """Test error when httpx is not installed."""
-        with patch("lightning_enable_mcp.tools.discover_api.httpx", None):
+        with patch.object(discover_api_module, "httpx", None):
             result = await discover_api(query="test")
             parsed = json.loads(result)
             assert parsed["success"] is False

--- a/python/lightning-enable-mcp/tests/test_nwc_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_wallet.py
@@ -801,7 +801,10 @@ class TestNWCEncryptionDefault:
 
     @staticmethod
     def _new_keypair():
-        pytest.importorskip("secp256k1")
+        # importorskip returns the imported module — earlier code dropped the
+        # binding and then referenced bare `secp` (NameError). The test was
+        # never run in CI before so the bug went unnoticed.
+        secp = pytest.importorskip("secp256k1")
         privkey_bytes = b"\x01" + b"\x42" * 31  # deterministic but valid scalar
         pk = secp.PrivateKey(privkey_bytes)
         # x-only pubkey (drop the leading 02/03 byte from compressed form)
@@ -843,7 +846,7 @@ class TestNWCEncryptionDefault:
     def test_verify_nostr_event_signature_wrong_signature_returns_false(self):
         # Substitute a signature from a different keypair — pubkey unchanged
         # but sig signed by attacker's key. Must fail.
-        pytest.importorskip("secp256k1")
+        secp = pytest.importorskip("secp256k1")
         from lightning_enable_mcp.nwc_wallet import (
             _sign_event,
             _verify_nostr_event_signature,

--- a/python/lightning-enable-mcp/tests/test_server.py
+++ b/python/lightning-enable-mcp/tests/test_server.py
@@ -23,16 +23,28 @@ class TestLightningEnableServer:
 
     @pytest.mark.asyncio
     async def test_list_tools_returns_all_tools(self):
-        """Test that list_tools returns all expected tools."""
+        """Test that the list_tools handler is registered on the underlying MCP Server."""
         server = LightningEnableServer()
 
-        # Get the list_tools handler
-        handlers = server.server._tool_handlers
-        assert "list_tools" in [h for h in dir(server.server)]
-
-        # The tools should be registered
-        # We can check this by examining the server's internal state
-        # or by calling the handler if exposed
+        # The @self.server.list_tools() decorator in _setup_handlers registers
+        # a handler in the underlying mcp Server's request_handlers dict.
+        # An earlier version of this test referenced a private `_tool_handlers`
+        # attribute that doesn't exist on the current mcp library — that test
+        # never actually ran in CI (no test workflow existed), so the bug
+        # went unnoticed. Now we just smoke-test that list_tools is exposed
+        # on the server (the decorator method is what the @ above hangs off
+        # of, so its presence confirms the library shape we depend on).
+        assert "list_tools" in dir(server.server), (
+            "list_tools decorator method must be exposed on the underlying mcp Server"
+        )
+        # And confirm at least one request handler was registered by
+        # _setup_handlers (the list_tools decorator stores its handler there).
+        assert hasattr(server.server, "request_handlers"), (
+            "underlying mcp Server should expose request_handlers"
+        )
+        assert len(server.server.request_handlers) > 0, (
+            "_setup_handlers should have registered at least one request handler"
+        )
 
     @pytest.mark.asyncio
     async def test_services_not_initialized_without_nwc(self):


### PR DESCRIPTION
## Closes the gap that let the v1.12.5 NIP-04 bug ship

The MCP repo currently has **no automated test gate**. CI only runs security scans (CodeQL, Semgrep, gitleaks) and the publish pipeline — neither runs \`dotnet test\` or \`pytest\`. That's how the v1.12.5 NIP-04 key-derivation bug shipped to PyPI/NuGet/Docker/MCP-Registry without any test verifying the wire-format compatibility we just fixed in #26.

This PR adds a \`test.yml\` workflow that runs both test suites on every PR + push to main, on Linux runners (where \`secp256k1\` has prebuilt wheels — no Windows surface to support).

## Two parallel jobs

\`\`\`
.NET    (ubuntu-latest)  →  dotnet test on the solution
Python  (ubuntu-latest)  →  pytest with [dev] extras × 3.10 + 3.12
\`\`\`

- **`.NET`**: setup-dotnet 9.0.x, restore + build (Release, --no-restore), test --no-build with console verbosity normal so per-test failures are grep-able
- **Python**: setup-python matrix (3.10 = pyproject lower bound, 3.12 = local dev version), \`pip install -e .[dev]\`, \`pytest --tb=short -q\`. Skip 3.11 — covered by the bookends.
- Linux only — \`secp256k1\` Python package has no Windows wheel; we don't ship a Windows-specific test surface.
- 10-minute timeout per job (current local suite runs in ~7s .NET / ~6s Python; lots of headroom for cold start).

## What this catches

A regression like the one in #26: a change touched encrypt + decrypt symmetrically, so internal round-trip tests still passed. The new tests I added in #26 (\`EncryptNip04_DerivesKeyAsRawSharedX_ForCoinOSAndL402TsCompat\` and \`test_nip04_decrypts_raw_sharedx_for_coinos_compat\`) encrypt **independently** with raw shared-X to simulate an external wallet's wire format — which would have failed on the bad code regardless. With this CI gate, those tests block PRs.

## What this doesn't change

- Existing CodeQL / Semgrep / gitleaks workflows — unaffected
- Publish workflow — unaffected (still runs on push to main, not gated on tests yet; could chain after this lands)

## Future improvements (out of scope)

- **Gate publish on test pass** — small \`needs: [dotnet-test, python-test]\` change to publish-mcp.yml. Worth doing as a follow-up once this is verified stable on a few PR cycles.
- **Coverage reporting** — pytest already has coverage configured per pyproject.toml, .NET could add coverlet. Skipping for now; the test gate is the high-value piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)