### PR TITLE
chore(deps): bump MCP SDK 0.6.0-preview.1 → 1.4.0 (stable)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="0.6.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />


### PR DESCRIPTION
Moves the .NET MCP server off a ~5-month-old preview onto the stable 1.x line (current 1.4.0), ahead of adding Streamable HTTP transport.

**Verified the stdio authoring surface is unchanged across the jump:**
- Build clean (0 errors; 3 pre-existing nullable warnings unrelated to the bump).
- Full .NET MCP test suite: **230 passed / 0 failed**.
- Runtime `tools/list` over stdio confirms **all 22 implemented tools still register** (server starts, JSON-RPC handshake completes, tools enumerate).

The 1.x breaking changes are HTTP/SSE-transport or client-side only and don't touch this stdio, attribute-registered, tool-only server.

**Doc note (pre-existing, not from this PR):** CLAUDE.md + the MCP README claim 23 tools; the real count is **22** — `configure_budget` is documented but has no `[McpServerTool]` in source. Separate cleanup.

One line changed (the package reference). This is the foundation for the upcoming HTTP-transport work that enables remote hosting + Connectors-Directory eligibility.