### PR TITLE
feat(mcp): Streamable HTTP transport behind MCP_TRANSPORT flag

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -41,8 +41,13 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
-    <!-- Streamable HTTP server transport, opt-in via MCP_TRANSPORT=http. Brings the
-         ASP.NET Core shared framework, used by the WebApplication host path below. -->
+    <!-- Streamable HTTP server transport, opt-in at runtime via MCP_TRANSPORT=http.
+         NOTE: the FrameworkReference below makes the ASP.NET Core shared runtime a
+         HARD requirement for EVERY install of this tool — including stdio-only users
+         who never set MCP_TRANSPORT=http. The HTTP host code is only *executed* on the
+         opt-in path, but the runtime must be *present* regardless. This is an accepted
+         tradeoff of shipping both transports in one package; splitting HTTP into a
+         separate package would be the way to avoid it if the stdio footprint matters. -->
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />

--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -41,6 +41,10 @@
 
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <!-- Streamable HTTP server transport, opt-in via MCP_TRANSPORT=http. Brings the
+         ASP.NET Core shared framework, used by the WebApplication host path below. -->
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -1,4 +1,5 @@
 using LightningEnable.Mcp.Services;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Server;
@@ -68,17 +69,38 @@ public class Program
             }
         });
 
-        var builder = Host.CreateApplicationBuilder(args);
+        // Transport selection. Default is stdio (local / Claude Desktop / Claude Code).
+        // Opt into Streamable HTTP — for remote hosting (mobile, Connectors Directory) —
+        // with MCP_TRANSPORT=http. Both transports register the SAME services; only the
+        // host type, the MCP transport, and the run call differ. We register through a
+        // shared IServiceCollection so the wallet/L402/agent/budget wiring below is
+        // byte-identical for both paths.
+        var transport = (Environment.GetEnvironmentVariable("MCP_TRANSPORT") ?? "stdio")
+            .Trim().ToLowerInvariant();
+
+        WebApplicationBuilder? webBuilder = null;
+        HostApplicationBuilder? hostBuilder = null;
+        IServiceCollection services;
+        if (transport == "http")
+        {
+            webBuilder = WebApplication.CreateBuilder(args);
+            services = webBuilder.Services;
+        }
+        else
+        {
+            hostBuilder = Host.CreateApplicationBuilder(args);
+            services = hostBuilder.Services;
+        }
 
         // Register budget configuration FIRST (needed by wallet services for config file fallback)
-        builder.Services.AddSingleton<IBudgetConfigurationService, BudgetConfigurationService>();
+        services.AddSingleton<IBudgetConfigurationService, BudgetConfigurationService>();
 
         // Load config to check for wallet settings
         var configService = new BudgetConfigurationService();
         var config = configService.Configuration;
 
         // Register HTTP client for L402
-        builder.Services.AddHttpClient<IL402HttpClient, L402HttpClient>();
+        services.AddHttpClient<IL402HttpClient, L402HttpClient>();
 
         // Register wallet service
         // Default priority for L402: LND > NWC > Strike > OpenNode
@@ -113,21 +135,21 @@ public class Program
         {
             Console.Error.WriteLine("Using LND wallet backend (priority override)");
             Console.Error.WriteLine("LND always returns preimage - L402 fully supported");
-            builder.Services.AddHttpClient<IWalletService, LndWalletService>();
+            services.AddHttpClient<IWalletService, LndWalletService>();
             walletRegistered = true;
         }
         else if (walletPriority == "nwc" && !string.IsNullOrEmpty(nwcConnection))
         {
             Console.Error.WriteLine("Using NWC wallet backend (priority override)");
             Console.Error.WriteLine("NWC returns preimage - L402 fully supported");
-            builder.Services.AddHttpClient<IWalletService, NwcWalletService>();
+            services.AddHttpClient<IWalletService, NwcWalletService>();
             walletRegistered = true;
         }
         else if (walletPriority == "strike" && !string.IsNullOrEmpty(strikeApiKey))
         {
             Console.Error.WriteLine("Using Strike wallet backend (priority override)");
             Console.Error.WriteLine("Strike returns preimage - L402 fully supported");
-            builder.Services.AddHttpClient<IWalletService, StrikeWalletService>();
+            services.AddHttpClient<IWalletService, StrikeWalletService>();
             walletRegistered = true;
         }
         else if (walletPriority == "opennode" && !string.IsNullOrEmpty(openNodeApiKey))
@@ -135,7 +157,7 @@ public class Program
             var environment = Environment.GetEnvironmentVariable("OPENNODE_ENVIRONMENT") ?? "production";
             Console.Error.WriteLine($"Using OpenNode wallet backend ({environment}) (priority override)");
             Console.Error.WriteLine("WARNING: OpenNode does NOT return preimage - L402 will not work");
-            builder.Services.AddHttpClient<IWalletService, OpenNodeWalletService>();
+            services.AddHttpClient<IWalletService, OpenNodeWalletService>();
             walletRegistered = true;
         }
 
@@ -147,26 +169,26 @@ public class Program
             {
                 Console.Error.WriteLine("Using LND wallet backend");
                 Console.Error.WriteLine("LND always returns preimage - L402 fully supported");
-                builder.Services.AddHttpClient<IWalletService, LndWalletService>();
+                services.AddHttpClient<IWalletService, LndWalletService>();
             }
             else if (!string.IsNullOrEmpty(nwcConnection))
             {
                 Console.Error.WriteLine("Using NWC wallet backend");
                 Console.Error.WriteLine("NWC returns preimage - L402 fully supported");
-                builder.Services.AddHttpClient<IWalletService, NwcWalletService>();
+                services.AddHttpClient<IWalletService, NwcWalletService>();
             }
             else if (!string.IsNullOrEmpty(strikeApiKey))
             {
                 Console.Error.WriteLine("Using Strike wallet backend");
                 Console.Error.WriteLine("Strike returns preimage - L402 fully supported");
-                builder.Services.AddHttpClient<IWalletService, StrikeWalletService>();
+                services.AddHttpClient<IWalletService, StrikeWalletService>();
             }
             else if (!string.IsNullOrEmpty(openNodeApiKey))
             {
                 var environment = Environment.GetEnvironmentVariable("OPENNODE_ENVIRONMENT") ?? "production";
                 Console.Error.WriteLine($"Using OpenNode wallet backend ({environment})");
                 Console.Error.WriteLine("WARNING: OpenNode does NOT return preimage - L402 will not work");
-                builder.Services.AddHttpClient<IWalletService, OpenNodeWalletService>();
+                services.AddHttpClient<IWalletService, OpenNodeWalletService>();
             }
             else
             {
@@ -183,31 +205,50 @@ public class Program
                 Console.Error.WriteLine("Note: For L402 auto-pay, use LND, NWC, or Strike (they return preimage).");
                 Console.Error.WriteLine("      OpenNode works for direct payments but not L402.");
                 // Register a default that will report "not configured" errors
-                builder.Services.AddHttpClient<IWalletService, NwcWalletService>();
+                services.AddHttpClient<IWalletService, NwcWalletService>();
             }
         }
 
         // Register Lightning Enable API service for L402 producer tools
-        builder.Services.AddHttpClient<ILightningEnableApiService, LightningEnableApiService>();
+        services.AddHttpClient<ILightningEnableApiService, LightningEnableApiService>();
 
         // Register price service for USD/sats conversion
-        builder.Services.AddHttpClient<IPriceService, PriceService>();
+        services.AddHttpClient<IPriceService, PriceService>();
 
         // Register agent service for ASA (Agent Service Agreement) operations
-        builder.Services.AddHttpClient<IAgentService, AgentService>();
+        services.AddHttpClient<IAgentService, AgentService>();
 
         // Register singleton services
-        builder.Services.AddSingleton<IBudgetService, BudgetService>();
-        builder.Services.AddSingleton<IPaymentHistoryService, PaymentHistoryService>();
-        builder.Services.AddSingleton<IRateLimiter, RateLimiter>();
+        services.AddSingleton<IBudgetService, BudgetService>();
+        services.AddSingleton<IPaymentHistoryService, PaymentHistoryService>();
+        services.AddSingleton<IRateLimiter, RateLimiter>();
 
-        // Configure MCP server with stdio transport
-        builder.Services
-            .AddMcpServer()
-            .WithStdioServerTransport()
-            .WithToolsFromAssembly();
+        // Configure the MCP server. Tools are identical across transports; only the
+        // transport differs (stdio for local, Streamable HTTP for remote).
+        var mcp = services.AddMcpServer().WithToolsFromAssembly();
+        if (transport == "http")
+            mcp.WithHttpTransport();
+        else
+            mcp.WithStdioServerTransport();
 
-        var host = builder.Build();
-        await host.RunAsync();
+        if (transport == "http")
+        {
+            // Streamable HTTP — for remote hosting (mobile, Connectors Directory).
+            // Listen address via ASPNETCORE_URLS (defaults to http://localhost:5000).
+            // WARNING: there is NO authentication here yet. This is for local/dev use
+            // only — OAuth + per-user wallet connection must land before any networked
+            // deployment, since these tools move money.
+            var app = webBuilder!.Build();
+            app.MapMcp();
+            Console.Error.WriteLine(
+                "[Lightning Enable MCP] Transport: Streamable HTTP (MapMcp). " +
+                "No auth configured — local/dev use only until auth lands.");
+            await app.RunAsync();
+        }
+        else
+        {
+            var host = hostBuilder!.Build();
+            await host.RunAsync();
+        }
     }
 }

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -78,6 +78,20 @@ public class Program
         var transport = (Environment.GetEnvironmentVariable("MCP_TRANSPORT") ?? "stdio")
             .Trim().ToLowerInvariant();
 
+        // Fail fast on a typo'd transport rather than silently running stdio. Setting
+        // MCP_TRANSPORT=htt (meaning http) would otherwise start a local-only server
+        // with no error — a confusing, hard-to-detect misconfiguration for someone
+        // who intended a remote endpoint.
+        if (transport != "stdio" && transport != "http")
+        {
+            Console.Error.WriteLine(
+                $"[Lightning Enable MCP] FATAL: unrecognized MCP_TRANSPORT='{transport}'. " +
+                "Valid values: 'stdio' (default, local) or 'http' (Streamable HTTP, remote). " +
+                "Refusing to start rather than silently falling back to a transport you did not request.");
+            Environment.Exit(78); // EX_CONFIG
+            return;
+        }
+
         WebApplicationBuilder? webBuilder = null;
         HostApplicationBuilder? hostBuilder = null;
         IServiceCollection services;


### PR DESCRIPTION
**Keystone for remote hosting** (mobile + Claude Connectors Directory). Stdio stays the default; HTTP is opt-in via `MCP_TRANSPORT=http`, so every existing local / Claude Desktop / Claude Code install is unchanged.

Stacked on #28 (the SDK 1.4.0 bump).

## What
- New `MCP_TRANSPORT=http|stdio` env flag (default `stdio`).
- HTTP path: `WebApplication` + `ModelContextProtocol.AspNetCore` (`WithHttpTransport` + `app.MapMcp`). Stdio path unchanged (`Host` + `WithStdioServerTransport`).
- The ~130 lines of wallet/L402/agent/budget DI register through a shared `IServiceCollection` so both transports wire **identical** services — only host + transport + run differ.

## Verified live (same dll, both transports)
- **stdio:** `tools/list` → all 22 tools (default path intact).
- **HTTP:** server boots, MCP session negotiated, `initialize → initialized → tools/list` round-trips over real Streamable HTTP → same 22 tools.
- Full .NET MCP suite: **230 passed / 0 failed**.

## ⚠️ Security
The HTTP path has **no auth yet** and logs a local/dev-only warning on startup. OAuth/token auth + the wallet story must land before any networked deployment (these tools move money). That's the next PR.

**Tradeoff:** HTTP pulls in the ASP.NET Core shared framework, so the packaged tool now needs that runtime present. Acceptable while HTTP is opt-in.