### PR TITLE
fix(mcp): funds-safety remediation (.NET + Python) — 6 fixes, review before publish

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -45,6 +45,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="NBitcoin.Secp256k1" Version="3.1.5" />
+    <!-- Battle-tested Bitcoin address parsing for on-chain send validation (C-2). -->
+    <PackageReference Include="NBitcoin" Version="7.0.42" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/src/LightningEnable.Mcp/Services/BitcoinAddressValidator.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BitcoinAddressValidator.cs
@@ -1,0 +1,33 @@
+using NBitcoin;
+
+namespace LightningEnable.Mcp.Services;
+
+/// <summary>
+/// Validates Bitcoin addresses for on-chain sends (C-2). Uses NBitcoin's
+/// battle-tested parser instead of hand-rolled bech32/base58 so an invalid or
+/// wrong-network address is rejected BEFORE an irreversible on-chain send.
+/// </summary>
+public static class BitcoinAddressValidator
+{
+    /// <summary>
+    /// True only if <paramref name="address"/> is a valid <b>mainnet</b> Bitcoin
+    /// address (P2PKH / P2SH / bech32 / bech32m). Testnet, regtest, and garbage
+    /// all return false — on-chain sends move real funds irreversibly, so anything
+    /// not provably a mainnet address is rejected.
+    /// </summary>
+    public static bool IsValidMainnet(string? address)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+            return false;
+
+        try
+        {
+            BitcoinAddress.Create(address.Trim(), Network.Main);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -335,9 +335,18 @@ public class BudgetService : IBudgetService
 
     private static string GenerateNonce()
     {
+        // C-4: cryptographically-random nonce. Previously used System.Random,
+        // which is predictable (time-seeded PRNG) — a weak basis for a payment
+        // confirmation token. NOTE: even a strong nonce does NOT protect against
+        // the agent itself, because confirm_payment is a model-callable tool; the
+        // nonce only guards against accidental auto-approval. True out-of-band
+        // confirmation (MCP elicitation / a URL the model can't read) is the
+        // deeper fix and a separate design decision.
         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        var random = new Random();
-        return new string(Enumerable.Range(0, 6).Select(_ => chars[random.Next(chars.Length)]).ToArray());
+        var buf = new char[6];
+        for (int i = 0; i < buf.Length; i++)
+            buf[i] = chars[System.Security.Cryptography.RandomNumberGenerator.GetInt32(chars.Length)];
+        return new string(buf);
     }
 
     private async Task UpdateThresholdsIfNeededAsync(CancellationToken cancellationToken)

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -157,17 +157,34 @@ public class BudgetService : IBudgetService
 
     public BudgetCheckResult CheckBudget(long amountSats)
     {
-        // Synchronous wrapper for backward compatibility
+        // Synchronous wrapper. CRITICAL: this path has NO interactive
+        // confirmation / nonce flow (unlike pay_invoice / pay_l402_challenge),
+        // and is used by send_onchain, settle_agent_service, and L402 auto-pay.
+        // So a payment the tier logic says "requires confirmation"
+        // (FormConfirm/UrlConfirm) MUST be denied here, not silently allowed —
+        // only AutoApprove/LogAndApprove may proceed. (C-1: this previously
+        // mapped any non-Deny result to Allow, silently skipping confirmation
+        // on the most dangerous tools, including irreversible on-chain sends.)
         var result = CheckApprovalLevelAsync(amountSats).GetAwaiter().GetResult();
 
+        var remaining = (long)(result.RemainingSessionBudgetUsd * 100); // rough sats
+        var maxPerRequest = _maxPerPaymentSats > 0 ? _maxPerPaymentSats : 100000;
+
+        if (result.RequiresConfirmation)
+        {
+            var detail = string.IsNullOrEmpty(result.ConfirmationMessage)
+                ? "This payment exceeds the auto-approve limit."
+                : result.ConfirmationMessage;
+            return BudgetCheckResult.Deny(
+                $"{detail} It requires explicit confirmation and cannot be auto-approved on this path. " +
+                "Use pay_invoice / pay_l402_challenge (which support the confirmation flow), or raise the " +
+                "auto-approve limit in ~/.lightning-enable/config.json.",
+                remaining, maxPerRequest);
+        }
+
         return result.CanProceed
-            ? BudgetCheckResult.Allow(
-                (long)(result.RemainingSessionBudgetUsd * 100), // Rough sats conversion
-                _maxPerPaymentSats > 0 ? _maxPerPaymentSats : 100000)
-            : BudgetCheckResult.Deny(
-                result.DenialReason ?? "Payment denied",
-                (long)(result.RemainingSessionBudgetUsd * 100),
-                _maxPerPaymentSats > 0 ? _maxPerPaymentSats : 100000);
+            ? BudgetCheckResult.Allow(remaining, maxPerRequest)
+            : BudgetCheckResult.Deny(result.DenialReason ?? "Payment denied", remaining, maxPerRequest);
     }
 
     public void RecordSpend(long amountSats)

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -167,7 +167,12 @@ public class BudgetService : IBudgetService
         // on the most dangerous tools, including irreversible on-chain sends.)
         var result = CheckApprovalLevelAsync(amountSats).GetAwaiter().GetResult();
 
-        var remaining = (long)(result.RemainingSessionBudgetUsd * 100); // rough sats
+        // Rough "remaining" figure for the caller. Clamp to avoid OverflowException
+        // when no session limit is configured (RemainingSessionBudgetUsd is then
+        // ~decimal.MaxValue, and *100 would overflow). Informational only.
+        var remaining = result.RemainingSessionBudgetUsd >= (decimal)long.MaxValue / 100m
+            ? long.MaxValue
+            : (long)(result.RemainingSessionBudgetUsd * 100);
         var maxPerRequest = _maxPerPaymentSats > 0 ? _maxPerPaymentSats : 100000;
 
         if (result.RequiresConfirmation)

--- a/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/NwcWalletService.cs
@@ -862,7 +862,10 @@ public class NwcWalletService : IWalletService, IDisposable
                                     var senderPubkeyHex = responseEvent["pubkey"]?.GetValue<string>() ?? _config.WalletPubkey;
                                     var senderPubkeyBytes = Convert.FromHexString(senderPubkeyHex);
                                     var decrypted = DecryptContent(encryptedContent, senderPubkeyBytes, _privateKey);
-                                    Console.Error.WriteLine($"[NWC] Decrypted: {decrypted}");
+                                    // H-3: NEVER log the decrypted NWC response — it contains the
+                                    // preimage and wallet balance (engineering standard #5: never log
+                                    // preimages/credentials). Log only that decryption succeeded.
+                                    Console.Error.WriteLine("[NWC] Response decrypted OK");
 
                                     var responseObj = JsonNode.Parse(decrypted)?.AsObject();
                                     var resultType = responseObj?["result_type"]?.GetValue<string>();

--- a/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
@@ -37,6 +37,11 @@ public static class SendOnChainTool
             });
         }
 
+        // Normalize once so validation and the actual send use the SAME value
+        // (the validator trims internally; without this an input like " bc1…"
+        // would pass validation but a different string would reach the wallet).
+        address = address.Trim();
+
         // C-2: validate the address before doing anything else. On-chain sends are
         // irreversible, so a typo'd, garbage, or wrong-network address must be
         // rejected here rather than risk broadcasting funds to an unrecoverable

--- a/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
@@ -37,6 +37,21 @@ public static class SendOnChainTool
             });
         }
 
+        // C-2: validate the address before doing anything else. On-chain sends are
+        // irreversible, so a typo'd, garbage, or wrong-network address must be
+        // rejected here rather than risk broadcasting funds to an unrecoverable
+        // destination. Only valid mainnet addresses pass.
+        if (!BitcoinAddressValidator.IsValidMainnet(address))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = "Invalid Bitcoin address. Provide a valid mainnet Bitcoin address " +
+                        "(starts with bc1, 1, or 3). The address failed validation and was NOT sent — " +
+                        "on-chain payments are irreversible, so a malformed or wrong-network address is rejected."
+            });
+        }
+
         if (amountSats <= 0)
         {
             return JsonSerializer.Serialize(new

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BitcoinAddressValidatorTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BitcoinAddressValidatorTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using LightningEnable.Mcp.Services;
+
+namespace LightningEnable.Mcp.Tests.Services;
+
+/// <summary>
+/// C-2: on-chain sends must reject invalid / wrong-network Bitcoin addresses
+/// before the (irreversible) send. Vectors are real BIP173/legacy mainnet
+/// addresses (accept) vs. tampered/garbage/testnet (reject).
+/// </summary>
+public class BitcoinAddressValidatorTests
+{
+    [Theory]
+    [InlineData("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")]                               // P2PKH (genesis)
+    [InlineData("3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")]                               // P2SH
+    [InlineData("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")]                       // bech32 P2WPKH
+    [InlineData("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3")]   // bech32 P2WSH
+    public void IsValidMainnet_AcceptsRealMainnetAddresses(string addr)
+    {
+        BitcoinAddressValidator.IsValidMainnet(addr).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("not-an-address")]
+    [InlineData("bc1qtest123")]                                  // bad bech32 checksum (a real value the Python tests used!)
+    [InlineData("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNX")]           // tampered base58 checksum
+    [InlineData("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx")]   // testnet — must reject on mainnet
+    [InlineData("0x1234567890abcdef1234567890abcdef12345678")]   // an Ethereum-style address
+    public void IsValidMainnet_RejectsInvalidOrWrongNetwork(string? addr)
+    {
+        BitcoinAddressValidator.IsValidMainnet(addr).Should().BeFalse();
+    }
+}

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -107,6 +107,45 @@ public class BudgetServiceTests
 
     #endregion
 
+    #region C-1 — Sync CheckBudget confirmation gate
+
+    [Fact]
+    public void CheckBudget_ConfirmationTierAmount_IsDenied_NotSilentlyAllowed()
+    {
+        // C-1 regression. The synchronous CheckBudget path is used by
+        // send_onchain, settle_agent_service, and L402 auto-pay — none of which
+        // have a confirmation/nonce flow. A payment the tier logic says
+        // "requires confirmation" (FormConfirm/UrlConfirm) must therefore be
+        // DENIED here, not silently allowed. Before the fix, CheckBudget mapped
+        // any non-Deny result to Allow, so a $5 (FormConfirm-tier) payment was
+        // auto-approved with no confirmation at all.
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        // 500,000 sats = $5.00 at 100k USD/BTC → FormConfirm tier (>$1, <=$10).
+        var result = service.CheckBudget(500_000);
+
+        result.Allowed.Should().BeFalse(
+            "a payment requiring confirmation must not be auto-approved on the synchronous budget path (C-1)");
+    }
+
+    [Fact]
+    public void CheckBudget_AutoApproveTierAmount_StillAllowed()
+    {
+        // Regression guard for the C-1 fix: auto-approve-tier payments must
+        // still proceed on the sync path (we only deny the confirmation tiers).
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        // 5,000 sats = $0.05 at 100k USD/BTC → AutoApprove tier (<=$0.10).
+        var result = service.CheckBudget(5_000);
+
+        result.Allowed.Should().BeTrue(
+            "auto-approve-tier payments still proceed without interactive confirmation");
+    }
+
+    #endregion
+
     #region Approval Level Tests
 
     [Fact]

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -18,7 +18,9 @@ public class BudgetServiceTests
         // Default configuration
         SetupDefaultConfiguration();
 
-        // Default price service (100k USD/BTC)
+        // Mock price service — a fixed, deterministic conversion of 100,000 sats = $1.00.
+        // This is a SIMPLIFIED test rate chosen so the tier math is easy to read; it is
+        // NOT a real BTC price. All "$X (mock rate)" comments below refer to this rate.
         _priceServiceMock.Setup(p => p.SatsToUsdAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((long sats, CancellationToken _) => sats / 100000m);
         _priceServiceMock.Setup(p => p.UsdToSatsAsync(It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
@@ -122,7 +124,7 @@ public class BudgetServiceTests
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
-        // 500,000 sats = $5.00 at 100k USD/BTC → FormConfirm tier (>$1, <=$10).
+        // 500,000 sats = $5.00 (mock rate) → FormConfirm tier (>$1, <=$10).
         var result = service.CheckBudget(500_000);
 
         result.Allowed.Should().BeFalse(
@@ -137,11 +139,42 @@ public class BudgetServiceTests
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
-        // 5,000 sats = $0.05 at 100k USD/BTC → AutoApprove tier (<=$0.10).
+        // 5,000 sats = $0.05 (mock rate) → AutoApprove tier (<=$0.10).
         var result = service.CheckBudget(5_000);
 
         result.Allowed.Should().BeTrue(
             "auto-approve-tier payments still proceed without interactive confirmation");
+    }
+
+    [Fact]
+    public void CheckBudget_NoSessionLimit_DoesNotOverflow()
+    {
+        // Regression guard: with no session limit configured, the remaining-session
+        // budget is ~decimal.MaxValue, and the old "rough sats" conversion (* 100)
+        // overflowed when cast to long (Copilot review of PR #30). The clamp must
+        // keep CheckBudget from throwing and still allow an auto-approve-tier spend.
+        _configServiceMock.Setup(c => c.Configuration).Returns(new UserBudgetConfiguration
+        {
+            Currency = "USD",
+            Tiers = new TierThresholds
+            {
+                AutoApprove = 0.10m,
+                LogAndApprove = 1.00m,
+                FormConfirm = 10.00m,
+                UrlConfirm = 100.00m
+            },
+            Limits = new PaymentLimits { MaxPerPayment = null, MaxPerSession = null },
+            Session = new SessionSettings { RequireApprovalForFirstPayment = false, CooldownSeconds = 0 }
+        });
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        // 5,000 sats = $0.05 (mock rate) → AutoApprove; must not throw despite no limits.
+        BudgetCheckResult result = null!;
+        var act = () => result = service.CheckBudget(5_000);
+
+        act.Should().NotThrow();
+        result.Allowed.Should().BeTrue();
+        result.RemainingSessionBudget.Should().BeGreaterThan(0);
     }
 
     #endregion
@@ -155,7 +188,7 @@ public class BudgetServiceTests
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
-        // 5 sats = $0.00005 at 100k/BTC - well below $0.10 auto-approve
+        // 5 sats = $0.00005 (mock rate) - well below $0.10 auto-approve
         // Act
         var result = await service.CheckApprovalLevelAsync(5);
 
@@ -171,7 +204,7 @@ public class BudgetServiceTests
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
-        // 50000 sats = $0.50 at 100k/BTC - above $0.10, below $1.00
+        // 50000 sats = $0.50 (mock rate) - above $0.10, below $1.00
         // Act
         var result = await service.CheckApprovalLevelAsync(50000);
 
@@ -187,7 +220,7 @@ public class BudgetServiceTests
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
-        // 500000 sats = $5.00 at 100k/BTC - above $1.00, below $10.00
+        // 500000 sats = $5.00 (mock rate) - above $1.00, below $10.00
         // Act
         var result = await service.CheckApprovalLevelAsync(500000);
 
@@ -203,7 +236,7 @@ public class BudgetServiceTests
         SetupConfigurationWithLimits(1.00m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
-        // 200000 sats = $2.00 at 100k/BTC - exceeds $1.00 limit
+        // 200000 sats = $2.00 (mock rate) - exceeds $1.00 limit
         // Act
         var result = await service.CheckApprovalLevelAsync(200000);
 
@@ -221,7 +254,7 @@ public class BudgetServiceTests
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
         // Record some spending first
-        service.RecordSpend(3000); // $0.03 at 100k/BTC
+        service.RecordSpend(3000); // $0.03 (mock rate)
 
         // Now try to spend 5000 more sats ($0.05) - would exceed $0.05 session limit
         // Act
@@ -260,7 +293,7 @@ public class BudgetServiceTests
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
         // Act
-        var result = service.CheckBudget(5000); // $0.05 at 100k/BTC
+        var result = service.CheckBudget(5000); // $0.05 (mock rate)
 
         // Assert
         result.Allowed.Should().BeTrue();
@@ -275,7 +308,7 @@ public class BudgetServiceTests
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 
         // Act
-        var result = service.CheckBudget(5000); // $0.05 at 100k/BTC - exceeds $0.01
+        var result = service.CheckBudget(5000); // $0.05 (mock rate) - exceeds $0.01
 
         // Assert
         result.Allowed.Should().BeFalse();
@@ -431,7 +464,7 @@ public class BudgetServiceTests
     [Fact]
     public async Task IsBudgetExhausted_WhenExhausted_ReturnsTrue()
     {
-        // Arrange - set max session to $0.01 (1000 sats at 100k/BTC)
+        // Arrange - set max session to $0.01 (= 1000 sats at the mock rate)
         SetupConfigurationWithLimits(500m, 0.01m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/bitcoin_address.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/bitcoin_address.py
@@ -1,0 +1,68 @@
+"""
+Mainnet Bitcoin address validation for on-chain sends (PY-C2).
+
+On-chain sends are irreversible, so a typo'd, garbage, or wrong-network address
+must be rejected BEFORE broadcasting. Uses the ``bech32`` library for segwit
+(BIP173/350) and an inline base58check verifier for legacy P2PKH/P2SH so an
+invalid address can never reach the wallet.
+"""
+
+import hashlib
+
+try:
+    from bech32 import decode as _segwit_decode
+except Exception:  # pragma: no cover - bech32 is a declared dependency
+    _segwit_decode = None
+
+_B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _base58check_ok(address: str, valid_version_bytes: tuple) -> bool:
+    """Verify a legacy base58check address (version byte + 20-byte hash + 4-byte checksum)."""
+    num = 0
+    for ch in address:
+        idx = _B58_ALPHABET.find(ch)
+        if idx == -1:
+            return False
+        num = num * 58 + idx
+
+    raw = num.to_bytes((num.bit_length() + 7) // 8, "big") if num else b""
+    # Leading '1' characters encode leading zero bytes.
+    pad = len(address) - len(address.lstrip("1"))
+    raw = (b"\x00" * pad) + raw
+
+    if len(raw) != 25:  # 1 version + 20 hash + 4 checksum
+        return False
+
+    payload, checksum = raw[:-4], raw[-4:]
+    if payload[0] not in valid_version_bytes:
+        return False
+
+    digest = hashlib.sha256(hashlib.sha256(payload).digest()).digest()
+    return digest[:4] == checksum
+
+
+def is_valid_mainnet(address) -> bool:
+    """
+    Return True only if ``address`` is a valid MAINNET Bitcoin address
+    (P2PKH / P2SH / bech32 / bech32m). Testnet, regtest, and garbage all
+    return False — on-chain sends move real funds irreversibly.
+    """
+    if not isinstance(address, str):
+        return False
+    addr = address.strip()
+    if not addr:
+        return False
+
+    low = addr.lower()
+    if low.startswith("bc1"):
+        if _segwit_decode is None:
+            return False
+        witver, witprog = _segwit_decode("bc", addr)
+        return witver is not None and witprog is not None
+
+    if addr[0] in ("1", "3"):
+        # P2PKH version byte 0x00, P2SH version byte 0x05.
+        return _base58check_ok(addr, (0x00, 0x05))
+
+    return False

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -339,6 +339,14 @@ class LightningEnableServer:
                                 "type": "integer",
                                 "description": "Amount to send in satoshis",
                             },
+                            "confirmed": {
+                                "type": "boolean",
+                                "description": (
+                                    "Set to true to confirm this irreversible on-chain send. "
+                                    "The first call returns requiresConfirmation; call again with "
+                                    "confirmed=true to proceed."
+                                ),
+                            },
                         },
                         "required": ["address", "amount_sats"],
                     },
@@ -566,6 +574,7 @@ class LightningEnableServer:
                     result = await send_onchain(
                         address=arguments.get("address", ""),
                         amount_sats=arguments.get("amount_sats", 0),
+                        confirmed=arguments.get("confirmed", False),
                         wallet=onchain_wallet,
                         budget_service=self.budget_service,
                     )

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/budget.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/budget.py
@@ -57,7 +57,32 @@ async def configure_budget(
                 }
             )
 
-        # Update limits
+        # SECURITY (PY-CONFIGURE): an agent must NOT be able to RAISE its own
+        # spending caps — that would let a prompt-injected agent loosen the limits
+        # and then drain the wallet. configure_budget may only TIGHTEN (lower)
+        # limits, never increase them above the operator-set values (from
+        # ~/.lightning-enable/config.json / env). To raise limits, the operator
+        # edits the config file.
+        current = budget_manager.get_status().get("limits", {})
+        current_per_request = current.get("per_request")
+        current_per_session = current.get("per_session")
+        if (current_per_request is not None and per_request > current_per_request) or (
+            current_per_session is not None and per_session > current_per_session
+        ):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        "configure_budget can only LOWER spending limits, not raise them. "
+                        f"Current caps: {current_per_request} sats/request, "
+                        f"{current_per_session} sats/session. To increase limits, the operator "
+                        "must edit ~/.lightning-enable/config.json — an agent cannot raise its "
+                        "own spending authority."
+                    ),
+                }
+            )
+
+        # Update limits (tighten-only, validated above)
         limits = budget_manager.configure(
             per_request=per_request,
             per_session=per_session,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
@@ -21,6 +21,7 @@ logger = logging.getLogger("lightning-enable-mcp.tools.send_onchain")
 async def send_onchain(
     address: str,
     amount_sats: int,
+    confirmed: bool = False,
     wallet: "Union[StrikeWallet, LndWallet, None]" = None,
     budget_service: "BudgetService | None" = None,
 ) -> str:
@@ -33,6 +34,9 @@ async def send_onchain(
     Args:
         address: Bitcoin address to send to (e.g., bc1q...)
         amount_sats: Amount to send in satoshis
+        confirmed: Set to True to confirm this irreversible on-chain send.
+            On-chain payments cannot be undone, so the first call always returns
+            requiresConfirmation; call again with confirmed=True to proceed.
         wallet: Strike or LND wallet instance
         budget_service: BudgetService for spending limits
 
@@ -43,6 +47,19 @@ async def send_onchain(
         return json.dumps({
             "success": False,
             "error": "Bitcoin address is required"
+        })
+
+    # PY-C2: validate the address before anything else. On-chain sends are
+    # irreversible, so a typo'd, garbage, or wrong-network address must be
+    # rejected here rather than risk broadcasting funds to an unrecoverable
+    # destination. Only valid mainnet addresses pass.
+    from ..bitcoin_address import is_valid_mainnet
+    if not is_valid_mainnet(address):
+        return json.dumps({
+            "success": False,
+            "error": "Invalid Bitcoin address. Provide a valid mainnet Bitcoin address "
+                     "(starts with bc1, 1, or 3). The address failed validation and was "
+                     "NOT sent — on-chain payments are irreversible."
         })
 
     if amount_sats <= 0:
@@ -69,18 +86,39 @@ async def send_onchain(
             "hint": "Set STRIKE_API_KEY or LND_REST_HOST+LND_MACAROON_HEX for on-chain payments."
         })
 
-    # Check budget if configured
+    # Budget check — FAIL CLOSED (PY-FAILOPEN fix). Previously an exception here
+    # was swallowed and the payment proceeded with NO budget enforcement; for an
+    # irreversible on-chain send that is unacceptable, so a budget-check error
+    # now REFUSES the send.
     if budget_service:
         try:
             budget_result = await budget_service.check_approval_level(amount_sats)
-            from ..config import ApprovalLevel
-            if budget_result.level == ApprovalLevel.DENY:
-                return json.dumps({
-                    "success": False,
-                    "error": f"Budget check failed: {budget_result.denial_reason}",
-                })
         except Exception as e:
-            logger.warning(f"Budget check failed: {e}")
+            logger.warning(f"Budget check error; refusing on-chain send (fail-closed): {e}")
+            return json.dumps({
+                "success": False,
+                "error": "Could not verify spending budget, so the on-chain send was refused "
+                         "(fail-closed). Check the wallet / price service and try again.",
+            })
+
+        from ..config import ApprovalLevel
+        if budget_result.level == ApprovalLevel.DENY:
+            return json.dumps({
+                "success": False,
+                "error": f"Budget check failed: {budget_result.denial_reason}",
+            })
+
+    # PY-C1: on-chain sends are irreversible, so ALWAYS require explicit
+    # confirmation regardless of amount/tier. (Previously the requires_confirmation
+    # tiers fell through and paid with no confirmation at all.)
+    if not confirmed:
+        return json.dumps({
+            "success": False,
+            "requiresConfirmation": True,
+            "error": "On-chain sends are irreversible and require explicit confirmation.",
+            "message": f"Confirm sending {amount_sats:,} sats to {address}? This cannot be undone.",
+            "howToConfirm": f'Call: send_onchain(address="{address}", amount_sats={amount_sats}, confirmed=True)',
+        })
 
     try:
         result = await wallet.send_onchain(address.strip(), amount_sats)

--- a/python/lightning-enable-mcp/tests/test_bitcoin_address.py
+++ b/python/lightning-enable-mcp/tests/test_bitcoin_address.py
@@ -1,0 +1,34 @@
+"""
+Tests for mainnet Bitcoin address validation (PY-C2).
+
+Real BIP173 / legacy mainnet addresses must be accepted; tampered, garbage,
+and testnet addresses must be rejected before an irreversible on-chain send.
+"""
+
+import pytest
+
+from lightning_enable_mcp.bitcoin_address import is_valid_mainnet
+
+
+@pytest.mark.parametrize("addr", [
+    "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",                                # P2PKH (genesis)
+    "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",                                # P2SH
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",                        # bech32 P2WPKH
+    "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",    # bech32 P2WSH
+])
+def test_accepts_real_mainnet_addresses(addr):
+    assert is_valid_mainnet(addr) is True
+
+
+@pytest.mark.parametrize("addr", [
+    "",
+    "   ",
+    None,
+    "not-an-address",
+    "bc1qtest123",                                  # bad bech32 checksum (the stub the old tests used!)
+    "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNX",           # tampered base58 checksum
+    "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",   # testnet — must reject on mainnet
+    "0x1234567890abcdef1234567890abcdef12345678",   # Ethereum-style
+])
+def test_rejects_invalid_or_wrong_network(addr):
+    assert is_valid_mainnet(addr) is False

--- a/python/lightning-enable-mcp/tests/test_configure_budget_tighten_only.py
+++ b/python/lightning-enable-mcp/tests/test_configure_budget_tighten_only.py
@@ -1,0 +1,42 @@
+"""
+PY-CONFIGURE: the configure_budget tool must let an agent only TIGHTEN (lower)
+its spending caps, never RAISE them — otherwise a prompt-injected agent could
+loosen its own limits and then drain the wallet.
+"""
+
+import json
+import pytest
+
+from lightning_enable_mcp.tools.budget import configure_budget
+from lightning_enable_mcp.budget import BudgetManager
+
+
+@pytest.mark.asyncio
+async def test_can_lower_limits():
+    mgr = BudgetManager(max_per_request=10000, max_per_session=100000)
+    result = await configure_budget(per_request=500, per_session=5000, budget_manager=mgr)
+    parsed = json.loads(result)
+    assert parsed["success"] is True
+    assert mgr.max_per_request == 500
+    assert mgr.max_per_session == 5000
+
+
+@pytest.mark.asyncio
+async def test_cannot_raise_per_request():
+    mgr = BudgetManager(max_per_request=1000, max_per_session=100000)
+    # 50000 > current 1000/request; still <= session so the ordering check passes.
+    result = await configure_budget(per_request=50000, per_session=100000, budget_manager=mgr)
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert "only LOWER" in parsed["error"]
+    assert mgr.max_per_request == 1000  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_cannot_raise_per_session():
+    mgr = BudgetManager(max_per_request=1000, max_per_session=10000)
+    result = await configure_budget(per_request=1000, per_session=50000, budget_manager=mgr)
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert "only LOWER" in parsed["error"]
+    assert mgr.max_per_session == 10000  # unchanged

--- a/python/lightning-enable-mcp/tests/test_send_onchain.py
+++ b/python/lightning-enable-mcp/tests/test_send_onchain.py
@@ -1,5 +1,10 @@
 """
-Tests for send_onchain tool
+Tests for send_onchain tool.
+
+Funds-safety (PY-FAILOPEN / PY-C1 / PY-C2):
+  - the address is validated before any send (a real mainnet address is required),
+  - on-chain sends ALWAYS require explicit confirmation (irreversible),
+  - the budget check fails CLOSED (a budget error refuses the send).
 """
 
 import json
@@ -8,6 +13,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 from lightning_enable_mcp.tools.send_onchain import send_onchain
 from lightning_enable_mcp.strike_wallet import StrikeWallet
+
+# A real BIP173 mainnet P2WPKH address (passes validation).
+VALID_ADDR = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
 
 
 def _make_strike_wallet_mock(**kwargs):
@@ -21,7 +29,6 @@ class TestSendOnchain:
 
     @pytest.mark.asyncio
     async def test_missing_address_returns_error(self):
-        """Test that empty address returns an error."""
         result = await send_onchain(address="", amount_sats=1000)
         parsed = json.loads(result)
         assert parsed["success"] is False
@@ -29,60 +36,86 @@ class TestSendOnchain:
 
     @pytest.mark.asyncio
     async def test_whitespace_address_returns_error(self):
-        """Test that whitespace-only address returns an error."""
         result = await send_onchain(address="   ", amount_sats=1000)
         parsed = json.loads(result)
         assert parsed["success"] is False
         assert "Bitcoin address is required" in parsed["error"]
 
     @pytest.mark.asyncio
-    async def test_zero_amount_returns_error(self):
-        """Test that zero amount returns an error."""
+    async def test_invalid_address_is_rejected_and_not_sent(self):
+        """PY-C2: an invalid/garbage address must be rejected before any send."""
+        wallet = _make_strike_wallet_mock()
+        wallet.send_onchain = AsyncMock()
+
         result = await send_onchain(
-            address="bc1qtest123", amount_sats=0
+            address="bc1qtest123", amount_sats=1000, confirmed=True, wallet=wallet
         )
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "Invalid Bitcoin address" in parsed["error"]
+        wallet.send_onchain.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_zero_amount_returns_error(self):
+        result = await send_onchain(address=VALID_ADDR, amount_sats=0)
         parsed = json.loads(result)
         assert parsed["success"] is False
         assert "Amount must be greater than 0" in parsed["error"]
 
     @pytest.mark.asyncio
     async def test_negative_amount_returns_error(self):
-        """Test that negative amount returns an error."""
-        result = await send_onchain(
-            address="bc1qtest123", amount_sats=-500
-        )
+        result = await send_onchain(address=VALID_ADDR, amount_sats=-500)
         parsed = json.loads(result)
         assert parsed["success"] is False
         assert "Amount must be greater than 0" in parsed["error"]
 
     @pytest.mark.asyncio
     async def test_no_wallet_returns_error(self):
-        """Test that missing wallet returns an error."""
-        result = await send_onchain(
-            address="bc1qtest123", amount_sats=1000, wallet=None
-        )
+        result = await send_onchain(address=VALID_ADDR, amount_sats=1000, wallet=None)
         parsed = json.loads(result)
         assert parsed["success"] is False
         assert "Wallet not configured" in parsed["error"]
 
     @pytest.mark.asyncio
     async def test_non_strike_wallet_returns_error(self):
-        """Test that non-Strike wallet returns unsupported error."""
-        wallet = AsyncMock()  # Not spec'd as StrikeWallet
-
-        result = await send_onchain(
-            address="bc1qtest123", amount_sats=1000, wallet=wallet
-        )
+        wallet = AsyncMock()  # Not spec'd as StrikeWallet/LndWallet
+        result = await send_onchain(address=VALID_ADDR, amount_sats=1000, wallet=wallet)
         parsed = json.loads(result)
-
         assert parsed["success"] is False
         assert "does not support on-chain" in parsed["error"]
 
     @pytest.mark.asyncio
-    async def test_successful_completed_payment(self):
-        """Test successful completed on-chain payment."""
+    async def test_requires_confirmation_without_confirmed_flag(self):
+        """PY-C1: on-chain is irreversible — first call must require confirmation, not send."""
         wallet = _make_strike_wallet_mock()
+        wallet.send_onchain = AsyncMock()
 
+        result = await send_onchain(address=VALID_ADDR, amount_sats=50000, wallet=wallet)
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert parsed.get("requiresConfirmation") is True
+        wallet.send_onchain.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_budget_check_exception_fails_closed(self):
+        """PY-FAILOPEN: a budget-check error must REFUSE the send, not pay anyway."""
+        wallet = _make_strike_wallet_mock()
+        wallet.send_onchain = AsyncMock()
+        budget = MagicMock()
+        budget.check_approval_level = AsyncMock(side_effect=Exception("price service down"))
+
+        result = await send_onchain(
+            address=VALID_ADDR, amount_sats=50000, confirmed=True,
+            wallet=wallet, budget_service=budget,
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "fail-closed" in parsed["error"].lower()
+        wallet.send_onchain.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_completed_payment(self):
+        wallet = _make_strike_wallet_mock()
         onchain_result = MagicMock()
         onchain_result.success = True
         onchain_result.payment_id = "pay-001"
@@ -90,14 +123,12 @@ class TestSendOnchain:
         onchain_result.state = "COMPLETED"
         onchain_result.amount_sats = 50000
         onchain_result.fee_sats = 500
-
         wallet.send_onchain = AsyncMock(return_value=onchain_result)
 
         result = await send_onchain(
-            address="bc1qtest123", amount_sats=50000, wallet=wallet
+            address=VALID_ADDR, amount_sats=50000, confirmed=True, wallet=wallet
         )
         parsed = json.loads(result)
-
         assert parsed["success"] is True
         assert parsed["provider"] == "Strike"
         assert parsed["payment"]["id"] == "pay-001"
@@ -108,9 +139,7 @@ class TestSendOnchain:
 
     @pytest.mark.asyncio
     async def test_pending_payment(self):
-        """Test on-chain payment in pending state."""
         wallet = _make_strike_wallet_mock()
-
         onchain_result = MagicMock()
         onchain_result.success = True
         onchain_result.payment_id = "pay-002"
@@ -118,50 +147,40 @@ class TestSendOnchain:
         onchain_result.state = "PENDING"
         onchain_result.amount_sats = 10000
         onchain_result.fee_sats = 200
-
         wallet.send_onchain = AsyncMock(return_value=onchain_result)
 
         result = await send_onchain(
-            address="bc1qtest456", amount_sats=10000, wallet=wallet
+            address=VALID_ADDR, amount_sats=10000, confirmed=True, wallet=wallet
         )
         parsed = json.loads(result)
-
         assert parsed["success"] is True
         assert parsed["payment"]["state"] == "PENDING"
         assert "initiated" in parsed["message"].lower()
 
     @pytest.mark.asyncio
     async def test_failed_payment(self):
-        """Test failed on-chain payment from wallet."""
         wallet = _make_strike_wallet_mock()
-
         onchain_result = MagicMock()
         onchain_result.success = False
         onchain_result.error_message = "Insufficient funds"
         onchain_result.error_code = "INSUFFICIENT_FUNDS"
-
         wallet.send_onchain = AsyncMock(return_value=onchain_result)
 
         result = await send_onchain(
-            address="bc1qtest123", amount_sats=50000, wallet=wallet
+            address=VALID_ADDR, amount_sats=50000, confirmed=True, wallet=wallet
         )
         parsed = json.loads(result)
-
         assert parsed["success"] is False
         assert "Insufficient funds" in parsed["error"]
 
     @pytest.mark.asyncio
     async def test_exception_handling(self):
-        """Test that exceptions are caught and returned as errors."""
         wallet = _make_strike_wallet_mock()
-        wallet.send_onchain = AsyncMock(
-            side_effect=Exception("Timeout")
-        )
+        wallet.send_onchain = AsyncMock(side_effect=Exception("Timeout"))
 
         result = await send_onchain(
-            address="bc1qtest123", amount_sats=1000, wallet=wallet
+            address=VALID_ADDR, amount_sats=1000, confirmed=True, wallet=wallet
         )
         parsed = json.loads(result)
-
         assert parsed["success"] is False
         assert "Timeout" in parsed["error"]


### PR DESCRIPTION
## Funds-safety remediation for the Lightning Enable MCP (.NET + Python)

Closes a batch of **pre-existing** money-path holes found by an adversarial review (2026-06-06). These are in the **already-published** MCP (v1.12.9), independent of the remote/HTTP-transport work (PRs #28/#29 — kept frozen). Tracker with full detail: `F:\Vault\projects\lightning-enable\mcp-funds-safety-remediation.md`.

**Do not merge or bump the version yet** — please review; the remaining items below should be decided before the next publish.

### ✅ Fixed here (each test-first, full suite green)

| Commit | Fix | Severity |
|---|---|---|
| `008d3ce` | **.NET C-1** — sync `CheckBudget` no longer collapses "requires confirmation" into "allowed"; `send_onchain`/`settle`/L402-auto-pay can't silently skip confirmation | CRITICAL |
| `dbc1efe` | **.NET C-2a** — `send_onchain` validates the Bitcoin address (NBitcoin, mainnet-only) before the irreversible send | CRITICAL |
| `66c789d` | **Python `send_onchain`** — budget check now **fails closed** (was fail-open: swallowed the error and paid anyway), **always requires confirmation** (irreversible), and **validates the address** (bech32 + base58check) | CRITICAL |
| `503cd01` | **.NET H-3** — stop logging the decrypted NWC response (it contained the **preimage**) to stderr; **C-4** — crypto-random nonce (was `System.Random`) | HIGH / MED |
| `c04b387` | **Python `configure_budget`** — tighten-only; an agent can lower but **never raise** its own spending caps (was: no ceiling → self-loosening drain) | HIGH |

.NET suite: **244 passed**. Python suite: **360 passed** (see note on 3 pre-existing failures below).

### ☐ Remaining (NOT done — documented for your call)

- **.NET C-2b** — give `send_onchain` an always-confirm flow (mirror Python). Residual gap is small post-C-1 (it already denies confirmation-tier amounts). *Do next.*
- **.NET C-3** — bind the confirmation nonce to the amount on consume (touches the interface + 2 call sites). Defense-in-depth.
- **⚠️ DESIGN DECISION — out-of-band confirmation.** `confirm_payment` / `confirmed=True` are **model-callable**, so the confirmation gate does not stop a malicious/injected agent — only accidental auto-approval. The real fix is out-of-band confirmation (MCP elicitation, or a URL/secret the model can't read). This is your architecture call. Python's `confirm_payment` is also **dead code** (no `validate_confirmation` exists) → delete or implement.
- **.NET H-1/H-2 + Python H-1/H-2/dual-budget** — unify divergent default-config sources; enforce a non-overridable **hard ceiling** (the `HardMax*` fields exist but are unenforced despite a comment claiming otherwise); **fail-closed when BTC price is unknown**; collapse Python's two budget systems (USD `BudgetService` vs legacy sats `BudgetManager`). Architectural — best done together.
- M/L: rate-limit the other money tools, SSRF DNS-fail-open, error-message sanitization, config-perms on user-created files.

### Note (separate, not funds-safety)
The Python suite has **3 pre-existing failures** in `test_server.py` (they reach a private MCP-SDK internal `_tool_handlers` removed by SDK drift). Verified failing on the base branch with these changes stashed — not caused by this PR. Needs its own cleanup.

### Posture
Remote/mobile rollout stays frozen until the money paths are sound. Even an authenticated remote endpoint is unsafe while the confirmation/ceiling holes (the remaining items) exist.
