### PR TITLE
feat(mcp): HTTP transport auth — Bearer gate + fail-closed (FROZEN until funds-safety lands)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -257,7 +257,20 @@ public class Program
             // non-loopback address (reachable beyond this machine) AND no
             // MCP_AUTH_TOKEN is set, REFUSE to start rather than silently run an
             // open, money-moving endpoint. A warning is not enough.
-            var listenUrls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+            // Resolve the listen address from ALL of ASP.NET Core's binding sources, not
+            // just the ASPNETCORE_URLS env var. A non-loopback bind can also arrive via the
+            // --urls command-line arg or the "urls" config key (both surface as
+            // Configuration["urls"]), or a Kestrel:Endpoints config section. Gather them all
+            // so the fail-closed check below can't be bypassed by a non-env binding source.
+            var urlSources = new List<string?>
+            {
+                app.Configuration["urls"],
+                Environment.GetEnvironmentVariable("ASPNETCORE_URLS")
+            };
+            foreach (var ep in app.Configuration.GetSection("Kestrel:Endpoints").GetChildren())
+                urlSources.Add(ep["Url"]);
+            var listenUrls = string.Join(';', urlSources.Where(u => !string.IsNullOrWhiteSpace(u)));
+
             if (string.IsNullOrEmpty(authToken) && IsNonLoopbackBind(listenUrls))
             {
                 Console.Error.WriteLine(
@@ -338,11 +351,12 @@ public class Program
     }
 
     /// <summary>
-    /// Returns true if the configured listen address (ASPNETCORE_URLS) is reachable
-    /// beyond this machine (any host other than localhost / 127.0.0.1 / ::1 — e.g.
-    /// 0.0.0.0, +, *, a real IP, or a hostname). Unset URLs mean the framework's
-    /// default localhost bind, which is loopback-only (safe). Biased fail-closed:
-    /// anything not provably loopback is treated as non-loopback.
+    /// Returns true if any configured listen address (gathered from ASPNETCORE_URLS,
+    /// the --urls / "urls" config key, and Kestrel:Endpoints — joined with ';') is
+    /// reachable beyond this machine (any host other than localhost / 127.0.0.1 / ::1
+    /// — e.g. 0.0.0.0, +, *, a real IP, or a hostname). An empty value means the
+    /// framework's default localhost bind, which is loopback-only (safe). Biased
+    /// fail-closed: anything not provably loopback is treated as non-loopback.
     /// </summary>
     private static bool IsNonLoopbackBind(string? aspnetcoreUrls)
     {

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -246,6 +246,11 @@ public class Program
             // proxy / for controlled clients); full OAuth — what Claude's connector UI
             // uses for a polished remote connect — is the next increment.
             var authToken = Environment.GetEnvironmentVariable("MCP_AUTH_TOKEN");
+            // Treat a whitespace-only token as NOT set — otherwise a value like " "
+            // would satisfy the fail-closed check below and enable the auth middleware
+            // with a trivially guessable token. Trim so an env var carrying a stray
+            // trailing newline still matches the token the client sends.
+            authToken = string.IsNullOrWhiteSpace(authToken) ? null : authToken.Trim();
 
             // FAIL-CLOSED. The single most important guard against a misconfigured
             // deploy draining a wallet: if the server is set to listen on a
@@ -280,8 +285,11 @@ public class Program
                 {
                     var header = context.Request.Headers.Authorization.ToString();
                     const string prefix = "Bearer ";
-                    var presented = header.StartsWith(prefix, StringComparison.Ordinal)
-                        ? header[prefix.Length..]
+                    // RFC 9110: the auth scheme is case-insensitive. Accept Bearer/bearer/…
+                    // and trim the token so a trailing space/newline in the header doesn't
+                    // cause a spurious 401.
+                    var presented = header.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                        ? header[prefix.Length..].Trim()
                         : null;
                     if (presented is null || !ConstantTimeEquals(presented, authToken))
                     {

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -246,6 +246,34 @@ public class Program
             // proxy / for controlled clients); full OAuth — what Claude's connector UI
             // uses for a polished remote connect — is the next increment.
             var authToken = Environment.GetEnvironmentVariable("MCP_AUTH_TOKEN");
+
+            // FAIL-CLOSED. The single most important guard against a misconfigured
+            // deploy draining a wallet: if the server is set to listen on a
+            // non-loopback address (reachable beyond this machine) AND no
+            // MCP_AUTH_TOKEN is set, REFUSE to start rather than silently run an
+            // open, money-moving endpoint. A warning is not enough.
+            var listenUrls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+            if (string.IsNullOrEmpty(authToken) && IsNonLoopbackBind(listenUrls))
+            {
+                Console.Error.WriteLine(
+                    $"[Lightning Enable MCP] FATAL: refusing to start. HTTP transport is set to listen on a " +
+                    $"non-loopback address (ASPNETCORE_URLS={listenUrls}) with NO authentication.");
+                Console.Error.WriteLine(
+                    "[Lightning Enable MCP] This would expose money-moving tools (pay_invoice, send_onchain, " +
+                    "settle_agent_service, ...) to anyone who can reach the endpoint.");
+                Console.Error.WriteLine(
+                    "[Lightning Enable MCP] Fix: set MCP_AUTH_TOKEN to a strong secret AND terminate TLS in front; " +
+                    "or bind to localhost only (unset ASPNETCORE_URLS / use 127.0.0.1) for local-only use.");
+                Environment.Exit(78); // EX_CONFIG
+                return;
+            }
+            if (!string.IsNullOrEmpty(authToken) && IsNonLoopbackBind(listenUrls))
+            {
+                Console.Error.WriteLine(
+                    "[Lightning Enable MCP] NOTE: serving on a non-loopback address. Ensure TLS terminates in " +
+                    "front of this endpoint — the Bearer token and all traffic must never cross the network in cleartext.");
+            }
+
             if (!string.IsNullOrEmpty(authToken))
             {
                 app.Use(async (context, next) =>
@@ -299,5 +327,45 @@ public class Program
         var ba = System.Text.Encoding.UTF8.GetBytes(a);
         var bb = System.Text.Encoding.UTF8.GetBytes(b);
         return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(ba, bb);
+    }
+
+    /// <summary>
+    /// Returns true if the configured listen address (ASPNETCORE_URLS) is reachable
+    /// beyond this machine (any host other than localhost / 127.0.0.1 / ::1 — e.g.
+    /// 0.0.0.0, +, *, a real IP, or a hostname). Unset URLs mean the framework's
+    /// default localhost bind, which is loopback-only (safe). Biased fail-closed:
+    /// anything not provably loopback is treated as non-loopback.
+    /// </summary>
+    private static bool IsNonLoopbackBind(string? aspnetcoreUrls)
+    {
+        if (string.IsNullOrWhiteSpace(aspnetcoreUrls))
+            return false; // default bind is localhost (loopback)
+
+        foreach (var raw in aspnetcoreUrls.Split(';',
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var s = raw;
+            var schemeIdx = s.IndexOf("://", StringComparison.Ordinal);
+            if (schemeIdx >= 0) s = s[(schemeIdx + 3)..];
+
+            string host;
+            if (s.StartsWith('['))
+            {
+                // IPv6 literal, e.g. [::1]:5000
+                var end = s.IndexOf(']');
+                host = end > 0 ? s[1..end] : s;
+            }
+            else
+            {
+                var cut = s.IndexOfAny(new[] { ':', '/' });
+                host = cut >= 0 ? s[..cut] : s;
+            }
+            host = host.Trim().ToLowerInvariant();
+
+            var loopback = host is "localhost" or "127.0.0.1" or "::1";
+            if (!loopback)
+                return true; // any non-loopback entry in the list = network-exposed
+        }
+        return false;
     }
 }

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -1,5 +1,6 @@
 using LightningEnable.Mcp.Services;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Server;
@@ -233,16 +234,51 @@ public class Program
 
         if (transport == "http")
         {
-            // Streamable HTTP — for remote hosting (mobile, Connectors Directory).
+            // Streamable HTTP — for remote hosting (self-host remote / mobile).
             // Listen address via ASPNETCORE_URLS (defaults to http://localhost:5000).
-            // WARNING: there is NO authentication here yet. This is for local/dev use
-            // only — OAuth + per-user wallet connection must land before any networked
-            // deployment, since these tools move money.
             var app = webBuilder!.Build();
+
+            // Auth gate. These tools move money, so a network-exposed endpoint must
+            // not be open. If MCP_AUTH_TOKEN is set, require a matching Bearer token
+            // (constant-time compare — engineering standard #7). If it's NOT set, run
+            // open but log a loud local/dev-only warning. This Bearer gate is the
+            // safety floor (never ship an open money endpoint; usable behind an auth
+            // proxy / for controlled clients); full OAuth — what Claude's connector UI
+            // uses for a polished remote connect — is the next increment.
+            var authToken = Environment.GetEnvironmentVariable("MCP_AUTH_TOKEN");
+            if (!string.IsNullOrEmpty(authToken))
+            {
+                app.Use(async (context, next) =>
+                {
+                    var header = context.Request.Headers.Authorization.ToString();
+                    const string prefix = "Bearer ";
+                    var presented = header.StartsWith(prefix, StringComparison.Ordinal)
+                        ? header[prefix.Length..]
+                        : null;
+                    if (presented is null || !ConstantTimeEquals(presented, authToken))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                        context.Response.Headers.WWWAuthenticate = "Bearer";
+                        await context.Response.WriteAsJsonAsync(new
+                        {
+                            error = "unauthorized",
+                            message = "A valid Bearer token is required. Set MCP_AUTH_TOKEN on the server and send 'Authorization: Bearer <token>'."
+                        });
+                        return;
+                    }
+                    await next();
+                });
+                Console.Error.WriteLine("[Lightning Enable MCP] HTTP auth: Bearer token required (MCP_AUTH_TOKEN set).");
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    "[Lightning Enable MCP] WARNING: HTTP transport is UNAUTHENTICATED (MCP_AUTH_TOKEN not set). " +
+                    "These tools move money — local/dev ONLY; never expose this to a network without auth.");
+            }
+
             app.MapMcp();
-            Console.Error.WriteLine(
-                "[Lightning Enable MCP] Transport: Streamable HTTP (MapMcp). " +
-                "No auth configured — local/dev use only until auth lands.");
+            Console.Error.WriteLine("[Lightning Enable MCP] Transport: Streamable HTTP (MapMcp).");
             await app.RunAsync();
         }
         else
@@ -250,5 +286,18 @@ public class Program
             var host = hostBuilder!.Build();
             await host.RunAsync();
         }
+    }
+
+    /// <summary>
+    /// Constant-time comparison for the HTTP auth token. Uses
+    /// <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals"/>
+    /// so a wrong token cannot be reconstructed via timing (engineering standard #7).
+    /// Returns false on a length mismatch without leaking via content comparison.
+    /// </summary>
+    private static bool ConstantTimeEquals(string a, string b)
+    {
+        var ba = System.Text.Encoding.UTF8.GetBytes(a);
+        var bb = System.Text.Encoding.UTF8.GetBytes(b);
+        return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(ba, bb);
     }
 }


### PR DESCRIPTION
Stacked on #29. Part of the **remote/mobile** stream, which stays **frozen** until the funds-safety remediation (#30) lands — even an authed remote endpoint is unsafe while the money-path holes exist.

## What
- **Constant-time Bearer-token gate** on the HTTP transport (`MCP_AUTH_TOKEN`): 401 without/with-wrong token, 200 with correct. Uses `CryptographicOperations.FixedTimeEquals` (eng. standard #7).
- **Fail-closed**: if `MCP_TRANSPORT=http` is set to listen on a **non-loopback** address (0.0.0.0 / a real IP / hostname) **without** `MCP_AUTH_TOKEN`, the server **refuses to start** (exit 78) instead of silently exposing money-moving tools to the network. Loopback-only still runs for local dev. Non-loopback + token logs a TLS reminder.

## Verified live
- no token → 401, wrong token → 401, correct token → 200 + all 22 tools.
- 0.0.0.0 bind + no token → refuses to start (FATAL); 127.0.0.1 + no token → runs (warns).
- Full .NET MCP suite: 230 passed.

## Not done (next, gated)
Full **OAuth** (what Claude's connector UI uses, and the Connectors Directory requires) is the larger next step — this Bearer gate is the safety floor + usable behind an auth proxy. And per the funds-safety review, the money-path guards (#30 + its remaining items) must be sound before any networked deployment.