### PR TITLE
fix(mcp): funds-safety Phase 2 — confirmation hardening + configure_budget + fail-closed price

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/Models/BudgetConfig.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/BudgetConfig.cs
@@ -43,14 +43,17 @@ public class BudgetConfig
     public bool IsBudgetExhausted => SessionSpent >= MaxSatsPerSession;
 
     /// <summary>
-    /// Hard maximum satoshis allowed per individual request.
-    /// This is a system-enforced limit that cannot be exceeded at runtime.
+    /// Informational mirror of the effective per-request cap in sats (NOT a separate,
+    /// independently enforced ceiling — that claim used to be here and was false). The
+    /// real protections are the USD per-payment / per-session limits, the approval
+    /// tiers, out-of-band confirmation for large amounts, the tighten-only runtime caps,
+    /// and fail-closed-when-no-BTC-price.
     /// </summary>
     public long HardMaxSatsPerRequest { get; set; } = 10000;
 
     /// <summary>
-    /// Hard maximum satoshis allowed for the entire session.
-    /// This is a system-enforced limit that cannot be exceeded at runtime.
+    /// Informational mirror of the effective per-session cap in sats. See the note on
+    /// <see cref="HardMaxSatsPerRequest"/> — this is not a separately enforced ceiling.
     /// </summary>
     public long HardMaxSatsPerSession { get; set; } = 100000;
 

--- a/dotnet/src/LightningEnable.Mcp/Models/BudgetConfig.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/BudgetConfig.cs
@@ -43,17 +43,20 @@ public class BudgetConfig
     public bool IsBudgetExhausted => SessionSpent >= MaxSatsPerSession;
 
     /// <summary>
-    /// Informational mirror of the effective per-request cap in sats (NOT a separate,
-    /// independently enforced ceiling — that claim used to be here and was false). The
-    /// real protections are the USD per-payment / per-session limits, the approval
-    /// tiers, out-of-band confirmation for large amounts, the tighten-only runtime caps,
-    /// and fail-closed-when-no-BTC-price.
+    /// Informational mirror of the CONFIG-derived per-request sats cap (the USD
+    /// maxPerPayment converted to sats). NOTE: this is NOT a separate, independently
+    /// enforced ceiling, and it does NOT reflect any tighter runtime cap set via
+    /// configure_budget (see <see cref="RuntimeMaxPerRequestSats"/>) — the actual
+    /// effective cap is the most-restrictive of this and the runtime cap. Real
+    /// protections are the USD limits, approval tiers, out-of-band confirmation,
+    /// the tighten-only runtime caps, and fail-closed-when-no-BTC-price.
     /// </summary>
     public long HardMaxSatsPerRequest { get; set; } = 10000;
 
     /// <summary>
-    /// Informational mirror of the effective per-session cap in sats. See the note on
-    /// <see cref="HardMaxSatsPerRequest"/> — this is not a separately enforced ceiling.
+    /// Informational mirror of the CONFIG-derived per-session sats cap. See the note on
+    /// <see cref="HardMaxSatsPerRequest"/> — not a separately enforced ceiling, and does
+    /// not reflect a tighter runtime cap (<see cref="RuntimeMaxPerSessionSats"/>).
     /// </summary>
     public long HardMaxSatsPerSession { get; set; } = 100000;
 

--- a/dotnet/src/LightningEnable.Mcp/Models/BudgetConfig.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/BudgetConfig.cs
@@ -53,6 +53,43 @@ public class BudgetConfig
     /// This is a system-enforced limit that cannot be exceeded at runtime.
     /// </summary>
     public long HardMaxSatsPerSession { get; set; } = 100000;
+
+    /// <summary>
+    /// Runtime per-request cap (sats) set by the agent via configure_budget.
+    /// Null when no runtime cap is in effect. Can only TIGHTEN (lower) the
+    /// effective limit — never raise it above the operator's config-file limits.
+    /// </summary>
+    public long? RuntimeMaxPerRequestSats { get; set; }
+
+    /// <summary>
+    /// Runtime per-session cap (sats) set by the agent via configure_budget.
+    /// Null when no runtime cap is in effect. Tighten-only.
+    /// </summary>
+    public long? RuntimeMaxPerSessionSats { get; set; }
+}
+
+/// <summary>
+/// Result of a configure_budget (tighten-only) operation.
+/// </summary>
+public record ConfigureBudgetResult
+{
+    /// <summary>Whether the new (tighter) limits were applied.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Reason the request was rejected (e.g. an attempt to raise limits).</summary>
+    public string? Error { get; init; }
+
+    /// <summary>Effective per-request cap (sats) after the operation.</summary>
+    public long EffectivePerRequestSats { get; init; }
+
+    /// <summary>Effective per-session cap (sats) after the operation.</summary>
+    public long EffectivePerSessionSats { get; init; }
+
+    public static ConfigureBudgetResult Ok(long perRequest, long perSession) =>
+        new() { Success = true, EffectivePerRequestSats = perRequest, EffectivePerSessionSats = perSession };
+
+    public static ConfigureBudgetResult Fail(string error) =>
+        new() { Success = false, Error = error };
 }
 
 /// <summary>

--- a/dotnet/src/LightningEnable.Mcp/README.md
+++ b/dotnet/src/LightningEnable.Mcp/README.md
@@ -2,7 +2,7 @@
 
 # Lightning Enable MCP Server
 
-A Model Context Protocol (MCP) server that enables AI agents to make Lightning Network payments. 15 consumer tools are free with no subscription required. 2 producer tools (`create_l402_challenge`, `verify_l402_payment`) require an [Agentic Commerce subscription](https://lightningenable.com) (from $99/mo) and `LIGHTNING_ENABLE_API_KEY`.
+A Model Context Protocol (MCP) server that enables AI agents to make Lightning Network payments. 15 tools work out of the box (free, no subscription). 8 tools require an [Agentic Commerce subscription](https://lightningenable.com) (from $99/mo) and `LIGHTNING_ENABLE_API_KEY`: 2 producer tools (`create_l402_challenge`, `verify_l402_payment`) and 6 Agent Service Agreement tools for agent-to-agent commerce over Nostr.
 
 ## Overview
 
@@ -61,8 +61,6 @@ dotnet build src/LightningEnable.Mcp
 | `NWC_CONNECTION_STRING` | If using NWC | - | Nostr Wallet Connect URI |
 | `LND_REST_HOST` | If using LND | - | LND REST API host |
 | `LND_MACAROON_HEX` | If using LND | - | LND admin macaroon in hex |
-| `L402_MAX_SATS_PER_REQUEST` | No | 1000 | Maximum sats per single request |
-| `L402_MAX_SATS_PER_SESSION` | No | 10000 | Maximum sats for entire session |
 | `LIGHTNING_ENABLE_API_KEY` | For producer tools | - | API key for `create_l402_challenge` and `verify_l402_payment`. Requires Agentic Commerce subscription. |
 
 Configure one wallet provider. If multiple are set, priority order is: LND > NWC > Strike > OpenNode.
@@ -212,12 +210,15 @@ View current budget configuration and session spending (read-only).
 
 ### configure_budget
 
-Sets spending limits for the session.
+Tightens the session spending limits. **Tighten-only:** an agent can only LOWER its
+caps — it can never raise them above the operator's `~/.lightning-enable/config.json`
+limits (or an existing tighter runtime cap). To raise limits, the operator edits the
+config file. This prevents a prompt-injected agent from loosening its own caps and
+then draining the wallet.
 
 **Parameters:**
-- `perRequest`: Max sats per request. Default: 1000
-- `perSession`: Max sats for session. Default: 10000
-- `resetSession`: Reset session spending. Default: false
+- `perRequest`: Max sats per single request. Default: 1000
+- `perSession`: Max total sats for the session. Default: 10000
 
 ### create_invoice
 

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -398,7 +398,7 @@ public class BudgetService : IBudgetService
         }
     }
 
-    public PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats)
+    public PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats, string expectedToolName)
     {
         if (string.IsNullOrWhiteSpace(nonce))
             return null;
@@ -414,15 +414,17 @@ public class BudgetService : IBudgetService
                 return null;
             }
 
-            // C-3: bind the approval to the EXACT amount it was created for. A code
-            // approved for X sats must not authorize a payment of a different amount
-            // (a small approval could otherwise be reused for a large payment within
-            // the 2-minute window). On mismatch we do NOT consume — the nonce stays
-            // valid so a correct-amount retry still works, but THIS amount is refused.
+            // C-3: bind the approval to the EXACT amount AND tool it was created for.
+            // A code approved for X sats on pay_invoice must not authorize a different
+            // amount, NOR a different tool (e.g. send_onchain) even if the sats match.
+            // On mismatch we do NOT consume — the nonce stays valid so the correct
+            // (amount, tool) retry still works, but this request is refused.
             if (confirmation.AmountSats != expectedAmountSats)
                 return null;
+            if (!string.Equals(confirmation.ToolName, expectedToolName, StringComparison.Ordinal))
+                return null;
 
-            // Amount matches — consume (one-time use).
+            // Amount + tool match — consume (one-time use).
             _pendingConfirmations.Remove(nonce);
             return confirmation;
         }

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -52,6 +52,29 @@ public class BudgetService : IBudgetService
         long amountSats,
         CancellationToken cancellationToken = default)
     {
+        // FAIL CLOSED on a price outage. The budget limits/tiers are USD-denominated,
+        // so without a BTC price we cannot evaluate the payment safely. Three sources
+        // are tried in parallel (first wins) and there is no stale-price fallback, so
+        // all-down is rare — but when it happens we REFUSE the payment rather than
+        // guess. Priming the price here (60s cache) means the conversions below reuse
+        // the same value instead of re-hitting the network.
+        try
+        {
+            await _priceService.GetBtcPriceAsync(cancellationToken);
+        }
+        catch (PriceUnavailableException)
+        {
+            return new ApprovalCheckResult
+            {
+                Level = ApprovalLevel.Deny,
+                AmountSats = amountSats,
+                AmountUsd = 0,
+                DenialReason = "BTC price is currently unavailable (all price sources failed), so this " +
+                               "payment cannot be checked against your budget and was refused. Please retry shortly.",
+                RemainingSessionBudgetUsd = 0
+            };
+        }
+
         await UpdateThresholdsIfNeededAsync(cancellationToken);
 
         var config = _configService.Configuration;

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -398,7 +398,7 @@ public class BudgetService : IBudgetService
         }
     }
 
-    public PendingConfirmation? ValidateAndConsumeConfirmation(string nonce)
+    public PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats)
     {
         if (string.IsNullOrWhiteSpace(nonce))
             return null;
@@ -408,12 +408,22 @@ public class BudgetService : IBudgetService
             if (!_pendingConfirmations.TryGetValue(nonce, out var confirmation))
                 return null;
 
-            // Always remove - one-time use
-            _pendingConfirmations.Remove(nonce);
-
             if (confirmation.IsExpired)
+            {
+                _pendingConfirmations.Remove(nonce);
+                return null;
+            }
+
+            // C-3: bind the approval to the EXACT amount it was created for. A code
+            // approved for X sats must not authorize a payment of a different amount
+            // (a small approval could otherwise be reused for a large payment within
+            // the 2-minute window). On mismatch we do NOT consume — the nonce stays
+            // valid so a correct-amount retry still works, but THIS amount is refused.
+            if (confirmation.AmountSats != expectedAmountSats)
                 return null;
 
+            // Amount matches — consume (one-time use).
+            _pendingConfirmations.Remove(nonce);
             return confirmation;
         }
     }

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -30,6 +30,12 @@ public class BudgetService : IBudgetService
     private long _maxPerSessionSats;
     private DateTime _thresholdsCacheExpiry;
 
+    // Tighten-only runtime caps (sats) set by the agent via configure_budget.
+    // Null = no runtime cap. Enforced in addition to the USD config limits
+    // (most-restrictive-wins). An agent can only ever LOWER these.
+    private long? _runtimeMaxPerRequestSats;
+    private long? _runtimeMaxPerSessionSats;
+
     public BudgetService(
         IBudgetConfigurationService configService,
         IPriceService priceService)
@@ -84,6 +90,33 @@ public class BudgetService : IBudgetService
                     AmountUsd = amountUsd,
                     DenialReason = $"Payment of {amountUsd:C} exceeds maximum per-payment limit of {config.Limits.MaxPerPayment.Value:C}. " +
                                    "Edit ~/.lightning-enable/config.json to change limits.",
+                    RemainingSessionBudgetUsd = Math.Max(0, remainingSessionUsd)
+                };
+            }
+
+            // Runtime tighten-only caps (set via configure_budget). Sats-based, enforced
+            // on top of the USD config limits above — most-restrictive-wins.
+            if (_runtimeMaxPerRequestSats.HasValue && amountSats > _runtimeMaxPerRequestSats.Value)
+            {
+                return new ApprovalCheckResult
+                {
+                    Level = ApprovalLevel.Deny,
+                    AmountSats = amountSats,
+                    AmountUsd = amountUsd,
+                    DenialReason = $"Payment of {amountSats:N0} sats exceeds the runtime per-request cap of " +
+                                   $"{_runtimeMaxPerRequestSats.Value:N0} sats set via configure_budget.",
+                    RemainingSessionBudgetUsd = Math.Max(0, remainingSessionUsd)
+                };
+            }
+            if (_runtimeMaxPerSessionSats.HasValue && _sessionSpentSats + amountSats > _runtimeMaxPerSessionSats.Value)
+            {
+                return new ApprovalCheckResult
+                {
+                    Level = ApprovalLevel.Deny,
+                    AmountSats = amountSats,
+                    AmountUsd = amountUsd,
+                    DenialReason = $"Payment of {amountSats:N0} sats would exceed the runtime per-session cap of " +
+                                   $"{_runtimeMaxPerSessionSats.Value:N0} sats (already spent {_sessionSpentSats:N0}) set via configure_budget.",
                     RemainingSessionBudgetUsd = Math.Max(0, remainingSessionUsd)
                 };
             }
@@ -205,6 +238,49 @@ public class BudgetService : IBudgetService
         }
     }
 
+    public async Task<ConfigureBudgetResult> ConfigureBudgetAsync(
+        long perRequestSats, long perSessionSats, CancellationToken cancellationToken = default)
+    {
+        if (perRequestSats <= 0)
+            return ConfigureBudgetResult.Fail("per_request must be a positive number of sats.");
+        if (perSessionSats <= 0)
+            return ConfigureBudgetResult.Fail("per_session must be a positive number of sats.");
+        if (perRequestSats > perSessionSats)
+            return ConfigureBudgetResult.Fail("per_request cannot exceed per_session.");
+
+        // Make sure the config-derived sats caps are current before we compare.
+        await UpdateThresholdsIfNeededAsync(cancellationToken);
+
+        lock (_lock)
+        {
+            // Effective cap = most restrictive of the operator's config-file limit
+            // (USD→sats) and any existing runtime cap. A 0 config cap means "no
+            // config limit set" → treat as unlimited for this comparison.
+            long configReq = _maxPerPaymentSats > 0 ? _maxPerPaymentSats : long.MaxValue;
+            long configSess = _maxPerSessionSats > 0 ? _maxPerSessionSats : long.MaxValue;
+            long effReq = Math.Min(configReq, _runtimeMaxPerRequestSats ?? long.MaxValue);
+            long effSess = Math.Min(configSess, _runtimeMaxPerSessionSats ?? long.MaxValue);
+
+            // TIGHTEN-ONLY. An agent may only LOWER its caps. Refusing to raise them
+            // above the current effective limit is the whole point: a prompt-injected
+            // agent must not be able to loosen its own spending authority and then
+            // drain the wallet. To raise limits, the operator edits config.json.
+            if (perRequestSats > effReq || perSessionSats > effSess)
+            {
+                string Fmt(long v) => v == long.MaxValue ? "unlimited" : $"{v:N0} sats";
+                return ConfigureBudgetResult.Fail(
+                    "configure_budget can only LOWER spending limits, not raise them. " +
+                    $"Current effective caps: {Fmt(effReq)}/request, {Fmt(effSess)}/session. " +
+                    "To increase limits, the operator must edit ~/.lightning-enable/config.json — " +
+                    "an agent cannot raise its own spending authority.");
+            }
+
+            _runtimeMaxPerRequestSats = perRequestSats;
+            _runtimeMaxPerSessionSats = perSessionSats;
+            return ConfigureBudgetResult.Ok(perRequestSats, perSessionSats);
+        }
+    }
+
     public BudgetConfig GetConfig()
     {
         lock (_lock)
@@ -217,7 +293,9 @@ public class BudgetService : IBudgetService
                 RequestCount = _requestCount,
                 SessionStarted = _sessionStarted,
                 HardMaxSatsPerRequest = _maxPerPaymentSats,
-                HardMaxSatsPerSession = _maxPerSessionSats
+                HardMaxSatsPerSession = _maxPerSessionSats,
+                RuntimeMaxPerRequestSats = _runtimeMaxPerRequestSats,
+                RuntimeMaxPerSessionSats = _runtimeMaxPerSessionSats
             };
         }
     }

--- a/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
@@ -91,12 +91,17 @@ public interface IBudgetService
     PendingConfirmation? ValidateConfirmation(string nonce);
 
     /// <summary>
-    /// Validates a nonce, checks expiry, and consumes it (one-time use).
-    /// Returns null if the nonce is invalid, expired, or already consumed.
+    /// Validates a nonce, checks expiry, verifies the approved amount matches the
+    /// amount about to be paid (C-3 binding), and consumes it (one-time use).
+    /// Returns null if the nonce is invalid, expired, already consumed, OR the amount
+    /// does not match what was approved. On an amount mismatch the nonce is NOT
+    /// consumed (a correct-amount retry can still succeed); only an exact match is
+    /// consumed and returned.
     /// </summary>
-    /// <param name="nonce">The 6-character confirmation nonce.</param>
-    /// <returns>The confirmed pending confirmation, or null if invalid.</returns>
-    PendingConfirmation? ValidateAndConsumeConfirmation(string nonce);
+    /// <param name="nonce">The confirmation code.</param>
+    /// <param name="expectedAmountSats">The amount about to be paid; must equal the approved amount.</param>
+    /// <returns>The confirmed pending confirmation, or null if invalid / amount-mismatched.</returns>
+    PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats);
 
     /// <summary>
     /// Purges expired pending confirmations from memory.

--- a/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
@@ -100,8 +100,9 @@ public interface IBudgetService
     /// </summary>
     /// <param name="nonce">The confirmation code.</param>
     /// <param name="expectedAmountSats">The amount about to be paid; must equal the approved amount.</param>
-    /// <returns>The confirmed pending confirmation, or null if invalid / amount-mismatched.</returns>
-    PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats);
+    /// <param name="expectedToolName">The tool consuming the code; must equal the tool the confirmation was created for (prevents cross-tool replay).</param>
+    /// <returns>The confirmed pending confirmation, or null if invalid / amount- or tool-mismatched.</returns>
+    PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats, string expectedToolName);
 
     /// <summary>
     /// Purges expired pending confirmations from memory.

--- a/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
@@ -32,6 +32,19 @@ public interface IBudgetService
     void RecordSpend(long amountSats);
 
     /// <summary>
+    /// Applies tighten-only runtime spending caps (sats). An agent may only LOWER
+    /// its effective per-request / per-session limits, never raise them above the
+    /// operator-set config-file limits (or an existing tighter runtime cap). This is
+    /// the .NET counterpart of the Python configure_budget tool — a prompt-injected
+    /// agent must not be able to loosen its own caps and then drain the wallet.
+    /// </summary>
+    /// <param name="perRequestSats">Requested per-request cap in satoshis.</param>
+    /// <param name="perSessionSats">Requested per-session cap in satoshis.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result indicating success (and the new effective caps) or rejection.</returns>
+    Task<ConfigureBudgetResult> ConfigureBudgetAsync(long perRequestSats, long perSessionSats, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the current budget configuration (runtime state).
     /// </summary>
     BudgetConfig GetConfig();

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -122,7 +122,7 @@ public static class AccessL402ResourceTool
                 // Check if a confirmed nonce was provided
                 if (!string.IsNullOrWhiteSpace(confirmationNonce))
                 {
-                    var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant());
+                    var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats);
                     if (confirmation == null)
                     {
                         return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -157,15 +157,25 @@ public static class AccessL402ResourceTool
                             "access_l402_resource",
                             urlDisplay);
 
+                        // OUT-OF-BAND CONFIRMATION: code to STDERR only (human sees the server
+                        // console/logs; the model only sees tool results). An injected agent
+                        // can't read it to self-approve. The code MUST NOT appear in the result.
+                        Console.Error.WriteLine(
+                            "[Lightning Enable] *** L402 PAYMENT CONFIRMATION REQUIRED ***\n" +
+                            $"  access_l402_resource — up to {approvalResult.AmountUsd:C} ({maxSats:N0} sats), {urlDisplay}\n" +
+                            $"  Confirmation code: {pending.Nonce}\n" +
+                            "  To approve, give this code to the agent. Expires in 120s.");
+
                         return JsonSerializer.Serialize(new
                         {
                             success = false,
                             requiresConfirmation = true,
-                            error = "L402 payment requires your confirmation",
-                            message = $"This L402 request may cost up to {approvalResult.AmountUsd:C} ({maxSats:N0} sats), which exceeds the auto-approve threshold.",
-                            nonce = pending.Nonce,
-                            howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
-                                           $"Step 2: Call access_l402_resource(url=\"{url}\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
+                            error = "L402 payment requires human confirmation",
+                            message = $"This L402 request may cost up to {approvalResult.AmountUsd:C} ({maxSats:N0} sats), which exceeds the auto-approve threshold. " +
+                                      "A confirmation code was printed to the server console/logs — visible to the human operator, NOT to you. " +
+                                      "Ask the human to read that code and give it to you.",
+                            howToConfirm = "Ask the human operator for the confirmation code shown in the server console, then call " +
+                                           "access_l402_resource(url=\"...\", confirmationNonce=\"<code-from-human>\").",
                             expiresInSeconds = 120,
                             amount = new
                             {
@@ -175,7 +185,7 @@ public static class AccessL402ResourceTool
                             thresholds = new
                             {
                                 autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
-                                note = "Payments above this require confirmation via confirm_payment tool"
+                                note = "Payments above this require a human-supplied confirmation code"
                             }
                         });
                     }

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -122,7 +122,7 @@ public static class AccessL402ResourceTool
                 // Check if a confirmed nonce was provided
                 if (!string.IsNullOrWhiteSpace(confirmationNonce))
                 {
-                    var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats);
+                    var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "access_l402_resource");
                     if (confirmation == null)
                     {
                         return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -128,9 +128,10 @@ public static class AccessL402ResourceTool
                         return JsonSerializer.Serialize(new
                         {
                             success = false,
-                            error = "Invalid, expired, or already-used confirmation nonce",
-                            message = "The nonce may have expired (2 minute limit) or was already used. " +
-                                      "Request a new confirmation by calling access_l402_resource without a nonce."
+                            error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
+                                    "request's amount and tool. Codes are bound to the exact amount + tool approved.",
+                            message = "The code may have expired (2-minute limit), been used already, or been issued for a " +
+                                      "different amount/tool. Request a new confirmation by calling access_l402_resource without a confirmationNonce."
                         });
                     }
 

--- a/dotnet/src/LightningEnable.Mcp/Tools/ConfigureBudgetTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/ConfigureBudgetTool.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using System.Text.Json;
+using LightningEnable.Mcp.Services;
+using ModelContextProtocol.Server;
+
+namespace LightningEnable.Mcp.Tools;
+
+/// <summary>
+/// MCP tool to TIGHTEN (lower) the session's spending limits at runtime.
+/// An agent can only reduce its caps — it can never raise them above the
+/// operator's config-file limits (or an existing tighter runtime cap). To raise
+/// limits, the operator edits ~/.lightning-enable/config.json. This mirrors the
+/// Python package's configure_budget so the two implementations expose the same
+/// tool surface.
+/// </summary>
+[McpServerToolType]
+public static class ConfigureBudgetTool
+{
+    /// <summary>
+    /// Tightens the per-request / per-session spending caps (sats). Tighten-only.
+    /// </summary>
+    /// <param name="perRequest">Maximum sats per single request.</param>
+    /// <param name="perSession">Maximum total sats for the whole session.</param>
+    /// <param name="budgetService">Injected budget service.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>JSON result with the new effective caps, or an error.</returns>
+    [McpServerTool(Name = "configure_budget"), Description("Tighten (lower) the session spending limits in sats. Can ONLY lower caps, never raise them above the operator's config — to raise limits, edit ~/.lightning-enable/config.json.")]
+    public static async Task<string> ConfigureBudget(
+        [Description("Maximum sats per single request (must be <= current effective cap and <= perSession)")] long perRequest = 1000,
+        [Description("Maximum total sats for the whole session (must be <= current effective cap)")] long perSession = 10000,
+        IBudgetService? budgetService = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (budgetService == null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = "Budget service not available"
+            });
+        }
+
+        try
+        {
+            var result = await budgetService.ConfigureBudgetAsync(perRequest, perSession, cancellationToken);
+            if (!result.Success)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = result.Error
+                });
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                limits = new
+                {
+                    perRequestSats = result.EffectivePerRequestSats,
+                    perSessionSats = result.EffectivePerSessionSats
+                },
+                message = $"Budget tightened to {result.EffectivePerRequestSats:N0} sats/request and " +
+                          $"{result.EffectivePerSessionSats:N0} sats/session. These runtime caps can only be " +
+                          "lowered further; raising them requires editing ~/.lightning-enable/config.json."
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = ex.Message
+            });
+        }
+    }
+}

--- a/dotnet/src/LightningEnable.Mcp/Tools/ConfirmPaymentTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/ConfirmPaymentTool.cs
@@ -14,12 +14,14 @@ namespace LightningEnable.Mcp.Tools;
 public static class ConfirmPaymentTool
 {
     /// <summary>
-    /// Confirms a pending payment using the 6-character nonce code.
-    /// Call this after a payment tool returns requiresConfirmation=true with a nonce.
+    /// Confirms a pending payment using the confirmation code that the SERVER printed to
+    /// its console/stderr (visible to the human operator, not to the model). The model
+    /// must obtain this code from the human — it never appears in any tool result — which
+    /// is what stops a prompt-injected agent from self-approving a payment.
     /// </summary>
-    [McpServerTool(Name = "confirm_payment"), Description("Confirm a pending payment using the nonce code from a previous payment request")]
+    [McpServerTool(Name = "confirm_payment"), Description("Confirm a pending payment using the code the human operator read from the server console. This code is NOT in any tool result — you must ask the human for it.")]
     public static string ConfirmPayment(
-        [Description("The 6-character confirmation code from the payment request")] string nonce,
+        [Description("The confirmation code the human read from the server console/logs")] string nonce,
         IBudgetService? budgetService = null)
     {
         if (string.IsNullOrWhiteSpace(nonce))

--- a/dotnet/src/LightningEnable.Mcp/Tools/ConfirmPaymentTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/ConfirmPaymentTool.cs
@@ -15,11 +15,12 @@ public static class ConfirmPaymentTool
 {
     /// <summary>
     /// Confirms a pending payment using the confirmation code that the SERVER printed to
-    /// its console/stderr (visible to the human operator, not to the model). The model
-    /// must obtain this code from the human — it never appears in any tool result — which
-    /// is what stops a prompt-injected agent from self-approving a payment.
+    /// its console/stderr (visible to the human operator, not to the model). The
+    /// payment-request tools (pay_invoice, send_onchain, ...) never return the code — the
+    /// model must obtain it from the human — which is what stops a prompt-injected agent
+    /// from self-approving. (This tool does echo the code back once you supply it.)
     /// </summary>
-    [McpServerTool(Name = "confirm_payment"), Description("Confirm a pending payment using the code the human operator read from the server console. This code is NOT in any tool result — you must ask the human for it.")]
+    [McpServerTool(Name = "confirm_payment"), Description("Confirm a pending payment using the code the human operator read from the server console. The payment-request tools never return this code — you must ask the human for it.")]
     public static string ConfirmPayment(
         [Description("The confirmation code the human read from the server console/logs")] string nonce,
         IBudgetService? budgetService = null)

--- a/dotnet/src/LightningEnable.Mcp/Tools/GetBudgetStatusTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/GetBudgetStatusTool.cs
@@ -104,7 +104,12 @@ public static class GetBudgetStatusTool
                 limits = new
                 {
                     maxPerPaymentUsd = config.Limits.MaxPerPayment,
-                    maxPerSessionUsd = config.Limits.MaxPerSession
+                    maxPerSessionUsd = config.Limits.MaxPerSession,
+                    runtimeMaxPerRequestSats = runtimeConfig.RuntimeMaxPerRequestSats,
+                    runtimeMaxPerSessionSats = runtimeConfig.RuntimeMaxPerSessionSats,
+                    runtimeCapsNote = (runtimeConfig.RuntimeMaxPerRequestSats.HasValue || runtimeConfig.RuntimeMaxPerSessionSats.HasValue)
+                        ? "Tighter sats caps are set via configure_budget (enforced on top of the USD limits, most-restrictive-wins; can only be lowered further)."
+                        : "No runtime caps set; configure_budget can tighten spending further but never raise it above these limits."
                 },
                 session = new
                 {

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
@@ -130,9 +130,10 @@ public static class PayInvoiceTool
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
-                                error = "Invalid, expired, or already-used confirmation nonce",
-                                message = "The nonce may have expired (2 minute limit) or was already used. " +
-                                          "Request a new confirmation by calling pay_invoice without a nonce."
+                                error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
+                                        "payment's amount and tool. Codes are bound to the exact amount + tool approved.",
+                                message = "The code may have expired (2-minute limit), been used already, or been issued for a " +
+                                          "different amount/tool. Request a new confirmation by calling pay_invoice without a confirmationNonce."
                             });
                         }
 

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
@@ -160,15 +160,27 @@ public static class PayInvoiceTool
                                 "pay_invoice",
                                 invoicePrefix);
 
+                            // OUT-OF-BAND CONFIRMATION: the code is written to STDERR only —
+                            // the human sees the server console/logs; the model does NOT (it
+                            // only sees tool results). So a prompt-injected agent cannot read
+                            // the code to self-approve; only a human watching the output can
+                            // relay it. The code MUST NEVER appear in the tool result below.
+                            Console.Error.WriteLine(
+                                "[Lightning Enable] *** PAYMENT CONFIRMATION REQUIRED ***\n" +
+                                $"  pay_invoice — {approvalResult.AmountUsd:C} ({amountSats.Value:N0} sats), invoice {invoicePrefix}\n" +
+                                $"  Confirmation code: {pending.Nonce}\n" +
+                                "  To approve, give this code to the agent. Expires in 120s.");
+
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
                                 requiresConfirmation = true,
-                                error = "Payment requires your confirmation",
-                                message = $"This payment of {approvalResult.AmountUsd:C} ({amountSats.Value:N0} sats) exceeds the auto-approve threshold.",
-                                nonce = pending.Nonce,
-                                howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
-                                               $"Step 2: Call pay_invoice(invoice=\"...\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
+                                error = "Payment requires human confirmation",
+                                message = $"This payment of {approvalResult.AmountUsd:C} ({amountSats.Value:N0} sats) exceeds the auto-approve threshold. " +
+                                          "A confirmation code was printed to the server console/logs — visible to the human operator, NOT to you. " +
+                                          "Ask the human to read that code and give it to you.",
+                                howToConfirm = "Ask the human operator for the confirmation code shown in the server console, then call " +
+                                               "pay_invoice(invoice=\"...\", confirmationNonce=\"<code-from-human>\").",
                                 expiresInSeconds = 120,
                                 amount = new
                                 {
@@ -178,7 +190,7 @@ public static class PayInvoiceTool
                                 thresholds = new
                                 {
                                     autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
-                                    note = "Payments above this require confirmation via confirm_payment tool"
+                                    note = "Payments above this require a human-supplied confirmation code"
                                 }
                             });
                         }

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
@@ -124,7 +124,7 @@ public static class PayInvoiceTool
                     // Check if a confirmed nonce was provided
                     if (!string.IsNullOrWhiteSpace(confirmationNonce))
                     {
-                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant());
+                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats);
                         if (confirmation == null)
                         {
                             return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
@@ -124,7 +124,7 @@ public static class PayInvoiceTool
                     // Check if a confirmed nonce was provided
                     if (!string.IsNullOrWhiteSpace(confirmationNonce))
                     {
-                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats);
+                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "pay_invoice");
                         if (confirmation == null)
                         {
                             return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -127,15 +127,25 @@ public static class PayL402ChallengeTool
                                 "pay_l402_challenge",
                                 invoicePrefix);
 
+                            // OUT-OF-BAND CONFIRMATION: code to STDERR only (human sees the server
+                            // console/logs; the model only sees tool results). An injected agent
+                            // can't read it to self-approve. The code MUST NOT appear in the result.
+                            Console.Error.WriteLine(
+                                "[Lightning Enable] *** L402 CHALLENGE PAYMENT CONFIRMATION REQUIRED ***\n" +
+                                $"  pay_l402_challenge — {approvalResult.AmountUsd:C} ({budgetCheckAmount:N0} sats), invoice {invoicePrefix}\n" +
+                                $"  Confirmation code: {pending.Nonce}\n" +
+                                "  To approve, give this code to the agent. Expires in 120s.");
+
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
                                 requiresConfirmation = true,
-                                error = "L402 challenge payment requires your confirmation",
-                                message = $"This payment of {approvalResult.AmountUsd:C} ({budgetCheckAmount:N0} sats) exceeds the auto-approve threshold.",
-                                nonce = pending.Nonce,
-                                howToConfirm = $"Step 1: Call confirm_payment(nonce: \"{pending.Nonce}\") to approve.\n" +
-                                               $"Step 2: Call pay_l402_challenge(invoice=\"...\", macaroon=\"...\", confirmationNonce=\"{pending.Nonce}\") to proceed.",
+                                error = "L402 challenge payment requires human confirmation",
+                                message = $"This payment of {approvalResult.AmountUsd:C} ({budgetCheckAmount:N0} sats) exceeds the auto-approve threshold. " +
+                                          "A confirmation code was printed to the server console/logs — visible to the human operator, NOT to you. " +
+                                          "Ask the human to read that code and give it to you.",
+                                howToConfirm = "Ask the human operator for the confirmation code shown in the server console, then call " +
+                                               "pay_l402_challenge(invoice=\"...\", macaroon=\"...\", confirmationNonce=\"<code-from-human>\").",
                                 expiresInSeconds = 120,
                                 amount = new
                                 {
@@ -145,7 +155,7 @@ public static class PayL402ChallengeTool
                                 thresholds = new
                                 {
                                     autoApprove = budgetService.GetUserConfiguration().Tiers.AutoApprove,
-                                    note = "Payments above this require confirmation via confirm_payment tool"
+                                    note = "Payments above this require a human-supplied confirmation code"
                                 }
                             });
                         }

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -92,7 +92,7 @@ public static class PayL402ChallengeTool
                     // Check if a confirmed nonce was provided
                     if (!string.IsNullOrWhiteSpace(confirmationNonce))
                     {
-                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats);
+                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "pay_l402_challenge");
                         if (confirmation == null)
                         {
                             return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -92,7 +92,7 @@ public static class PayL402ChallengeTool
                     // Check if a confirmed nonce was provided
                     if (!string.IsNullOrWhiteSpace(confirmationNonce))
                     {
-                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant());
+                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats);
                         if (confirmation == null)
                         {
                             return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -98,9 +98,10 @@ public static class PayL402ChallengeTool
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
-                                error = "Invalid, expired, or already-used confirmation nonce",
-                                message = "The nonce may have expired (2 minute limit) or was already used. " +
-                                          "Request a new confirmation by calling pay_l402_challenge without a nonce."
+                                error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
+                                        "payment's amount and tool. Codes are bound to the exact amount + tool approved.",
+                                message = "The code may have expired (2-minute limit), been used already, or been issued for a " +
+                                          "different amount/tool. Request a new confirmation by calling pay_l402_challenge without a confirmationNonce."
                             });
                         }
 

--- a/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
@@ -91,7 +91,18 @@ public static class SendOnChainTool
         // code is printed to stderr, never to the model). Budget limits are still
         // enforced: an over-limit amount (or a price outage) is refused outright, since
         // confirmation must not authorize a payment beyond the configured ceiling.
-        if (budgetService != null)
+        // FAIL CLOSED: an irreversible on-chain send must never bypass the confirmation
+        // gate. If the budget/confirmation service isn't available, refuse rather than send.
+        if (budgetService == null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = "Budget/confirmation service is unavailable, so this on-chain send was refused " +
+                        "(fail-closed). On-chain payments are irreversible and must go through the confirmation gate."
+            });
+        }
+
         {
             var approval = await budgetService.CheckApprovalLevelAsync(amountSats, cancellationToken);
             if (approval.Level == ApprovalLevel.Deny)
@@ -112,8 +123,9 @@ public static class SendOnChainTool
                     return JsonSerializer.Serialize(new
                     {
                         success = false,
-                        error = "Invalid, expired, already-used, or amount-mismatched confirmation code",
-                        message = "Request a fresh confirmation by calling send_onchain again without a confirmationNonce."
+                        error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
+                                "send's amount and tool. Codes are bound to the exact amount + tool they were approved for.",
+                        message = "Request a fresh confirmation by calling send_onchain again without a confirmationNonce, then supply the new code."
                     });
                 }
                 Console.Error.WriteLine($"[Lightning Enable] On-chain send of {amountSats:N0} sats to {address} confirmed.");

--- a/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
@@ -106,7 +106,7 @@ public static class SendOnChainTool
             if (!string.IsNullOrWhiteSpace(confirmationNonce))
             {
                 var confirmation = budgetService.ValidateAndConsumeConfirmation(
-                    confirmationNonce.Trim().ToUpperInvariant(), amountSats);
+                    confirmationNonce.Trim().ToUpperInvariant(), amountSats, "send_onchain");
                 if (confirmation == null)
                 {
                     return JsonSerializer.Serialize(new

--- a/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using LightningEnable.Mcp.Models;
 using LightningEnable.Mcp.Services;
 using ModelContextProtocol.Server;
 
@@ -24,6 +25,7 @@ public static class SendOnChainTool
     public static async Task<string> SendOnChain(
         [Description("Bitcoin address to send to (e.g., bc1q...)")] string address,
         [Description("Amount to send in satoshis")] long amountSats,
+        [Description("Confirmation code the human operator read from the server console. Required to actually send — on-chain payments are irreversible and ALWAYS require confirmation. Omit on the first call to request one.")] string? confirmationNonce = null,
         IWalletService? walletService = null,
         IBudgetService? budgetService = null,
         CancellationToken cancellationToken = default)
@@ -84,16 +86,62 @@ public static class SendOnChainTool
             });
         }
 
-        // Check budget if configured
+        // C-2b: on-chain sends are IRREVERSIBLE, so they ALWAYS require explicit human
+        // confirmation — regardless of amount/tier — via the out-of-band code flow (the
+        // code is printed to stderr, never to the model). Budget limits are still
+        // enforced: an over-limit amount (or a price outage) is refused outright, since
+        // confirmation must not authorize a payment beyond the configured ceiling.
         if (budgetService != null)
         {
-            var budgetCheck = budgetService.CheckBudget(amountSats);
-            if (!budgetCheck.Allowed)
+            var approval = await budgetService.CheckApprovalLevelAsync(amountSats, cancellationToken);
+            if (approval.Level == ApprovalLevel.Deny)
             {
                 return JsonSerializer.Serialize(new
                 {
                     success = false,
-                    error = $"Budget check failed: {budgetCheck.DenialReason}"
+                    error = $"Budget check failed: {approval.DenialReason}"
+                });
+            }
+
+            if (!string.IsNullOrWhiteSpace(confirmationNonce))
+            {
+                var confirmation = budgetService.ValidateAndConsumeConfirmation(
+                    confirmationNonce.Trim().ToUpperInvariant(), amountSats);
+                if (confirmation == null)
+                {
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = false,
+                        error = "Invalid, expired, already-used, or amount-mismatched confirmation code",
+                        message = "Request a fresh confirmation by calling send_onchain again without a confirmationNonce."
+                    });
+                }
+                Console.Error.WriteLine($"[Lightning Enable] On-chain send of {amountSats:N0} sats to {address} confirmed.");
+            }
+            else
+            {
+                var pending = budgetService.CreatePendingConfirmation(
+                    amountSats, approval.AmountUsd, "send_onchain", address);
+
+                // Code to STDERR only — the human sees it; the model never does.
+                Console.Error.WriteLine(
+                    "[Lightning Enable] *** ON-CHAIN SEND CONFIRMATION REQUIRED (irreversible) ***\n" +
+                    $"  send_onchain — {amountSats:N0} sats to {address}\n" +
+                    $"  Confirmation code: {pending.Nonce}\n" +
+                    "  To approve, give this code to the agent. Expires in 120s.");
+
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    requiresConfirmation = true,
+                    error = "On-chain send requires human confirmation",
+                    message = $"On-chain sends are irreversible, so this {amountSats:N0}-sat send to {address} requires confirmation. " +
+                              "A confirmation code was printed to the server console/logs — visible to the human operator, NOT to you. " +
+                              "Ask the human to read that code and give it to you.",
+                    howToConfirm = "Ask the human operator for the confirmation code shown in the server console, then call " +
+                                   "send_onchain(address=\"...\", amountSats=..., confirmationNonce=\"<code-from-human>\").",
+                    expiresInSeconds = 120,
+                    amount = new { sats = amountSats, usd = Math.Round(approval.AmountUsd, 2) }
                 });
             }
         }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -25,6 +25,10 @@ public class BudgetServiceTests
             .ReturnsAsync((long sats, CancellationToken _) => sats / 100000m);
         _priceServiceMock.Setup(p => p.UsdToSatsAsync(It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((decimal usd, CancellationToken _) => (long)(usd * 100000));
+        // A live price is required by the fail-closed guard at the top of
+        // CheckApprovalLevelAsync; default to "available" so existing tests run.
+        _priceServiceMock.Setup(p => p.GetBtcPriceAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(100000m);
     }
 
     private void SetupDefaultConfiguration()
@@ -269,6 +273,39 @@ public class BudgetServiceTests
         var result = await service.ConfigureBudgetAsync(perRequest, perSession);
 
         result.Success.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region fail-closed when BTC price is unavailable (H-1)
+
+    [Fact]
+    public async Task CheckApprovalLevel_PriceUnavailable_FailsClosed_Denies()
+    {
+        SetupConfigurationWithLimits(500m, 100m);
+        _priceServiceMock.Setup(p => p.GetBtcPriceAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PriceUnavailableException("all sources failed"));
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        var result = await service.CheckApprovalLevelAsync(5000);
+
+        result.Level.Should().Be(ApprovalLevel.Deny);
+        result.CanProceed.Should().BeFalse();
+        result.DenialReason.Should().Contain("price");
+    }
+
+    [Fact]
+    public void CheckBudget_PriceUnavailable_FailsClosed_NotAllowed()
+    {
+        // The sync path (send_onchain / L402 auto-pay) must also refuse, not throw.
+        SetupConfigurationWithLimits(500m, 100m);
+        _priceServiceMock.Setup(p => p.GetBtcPriceAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PriceUnavailableException("all sources failed"));
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        var result = service.CheckBudget(5000);
+
+        result.Allowed.Should().BeFalse();
     }
 
     #endregion

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -179,6 +179,100 @@ public class BudgetServiceTests
 
     #endregion
 
+    #region configure_budget — tighten-only runtime caps (decision C)
+
+    [Fact]
+    public async Task ConfigureBudget_TightensBelowConfig_Succeeds()
+    {
+        // Config caps are large ($500/$100 → 50M/10M sats at the mock rate), so
+        // tightening to 1000/5000 sats is allowed.
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        var result = await service.ConfigureBudgetAsync(1000, 5000);
+
+        result.Success.Should().BeTrue();
+        result.EffectivePerRequestSats.Should().Be(1000);
+        result.EffectivePerSessionSats.Should().Be(5000);
+        var cfg = service.GetConfig();
+        cfg.RuntimeMaxPerRequestSats.Should().Be(1000);
+        cfg.RuntimeMaxPerSessionSats.Should().Be(5000);
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_AttemptToRaiseAboveConfig_IsRejected()
+    {
+        // Config caps $0.01/$0.01 → 1000 sats each at the mock rate. Asking for 5000
+        // tries to RAISE above the operator's limit — must be refused.
+        SetupConfigurationWithLimits(0.01m, 0.01m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        var result = await service.ConfigureBudgetAsync(5000, 5000);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("can only LOWER");
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_CannotRaiseAboveExistingRuntimeCap()
+    {
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        (await service.ConfigureBudgetAsync(2000, 4000)).Success.Should().BeTrue();
+        // Now try to raise the per-request cap back up to 3000 — must be refused.
+        var result = await service.ConfigureBudgetAsync(3000, 4000);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("can only LOWER");
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_PerRequestCap_IsEnforcedInApprovalCheck()
+    {
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+        await service.ConfigureBudgetAsync(1000, 5000);
+
+        // 2000 sats exceeds the 1000-sat runtime per-request cap → Deny.
+        var result = await service.CheckApprovalLevelAsync(2000);
+
+        result.Level.Should().Be(ApprovalLevel.Deny);
+        result.DenialReason.Should().Contain("runtime per-request cap");
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_PerSessionCap_IsEnforcedInApprovalCheck()
+    {
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+        await service.ConfigureBudgetAsync(10000, 10000);
+        service.RecordSpend(7000);
+
+        // 7000 already spent + 5000 = 12000 > 10000 runtime session cap → Deny.
+        var result = await service.CheckApprovalLevelAsync(5000);
+
+        result.Level.Should().Be(ApprovalLevel.Deny);
+        result.DenialReason.Should().Contain("runtime per-session cap");
+    }
+
+    [Theory]
+    [InlineData(0, 5000)]      // per_request must be positive
+    [InlineData(-1, 5000)]     // per_request must be positive
+    [InlineData(1000, 0)]      // per_session must be positive
+    [InlineData(6000, 5000)]   // per_request cannot exceed per_session
+    public async Task ConfigureBudget_InvalidInputs_AreRejected(long perRequest, long perSession)
+    {
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+
+        var result = await service.ConfigureBudgetAsync(perRequest, perSession);
+
+        result.Success.Should().BeFalse();
+    }
+
+    #endregion
+
     #region Approval Level Tests
 
     [Fact]

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -665,25 +665,29 @@ public class BudgetServiceTests
 
     #endregion
 
-    #region C-3 — confirmation is bound to the approved amount
+    #region C-3 — confirmation is bound to the approved amount AND tool
 
     [Fact]
-    public void Confirmation_AmountMismatch_IsRejected_AndNonceNotConsumed()
+    public void Confirmation_BoundToAmountAndTool_RejectsMismatches_AndNonceNotConsumed()
     {
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
         var pending = service.CreatePendingConfirmation(1000, 0.01m, "pay_invoice", "inv...");
 
-        // A code approved for 1,000 sats must NOT authorize a 1,000,000-sat payment...
-        service.ValidateAndConsumeConfirmation(pending.Nonce, 1_000_000).Should().BeNull();
+        // Wrong AMOUNT (right tool) → rejected; a 1,000-sat approval can't authorize 1,000,000.
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1_000_000, "pay_invoice").Should().BeNull();
 
-        // ...and the mismatch must NOT have consumed it — the correct amount still works.
-        var ok = service.ValidateAndConsumeConfirmation(pending.Nonce, 1000);
+        // Wrong TOOL (right amount) → rejected; a pay_invoice code can't authorize send_onchain
+        // (no cross-tool replay).
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "send_onchain").Should().BeNull();
+
+        // Neither mismatch consumed the nonce — the correct (amount, tool) still works.
+        var ok = service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice");
         ok.Should().NotBeNull();
         ok!.AmountSats.Should().Be(1000);
 
-        // One-time use: a second consume (even correct amount) fails.
-        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000).Should().BeNull();
+        // One-time use: a second consume fails.
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice").Should().BeNull();
     }
 
     #endregion

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -664,4 +664,27 @@ public class BudgetServiceTests
     }
 
     #endregion
+
+    #region C-3 — confirmation is bound to the approved amount
+
+    [Fact]
+    public void Confirmation_AmountMismatch_IsRejected_AndNonceNotConsumed()
+    {
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+        var pending = service.CreatePendingConfirmation(1000, 0.01m, "pay_invoice", "inv...");
+
+        // A code approved for 1,000 sats must NOT authorize a 1,000,000-sat payment...
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1_000_000).Should().BeNull();
+
+        // ...and the mismatch must NOT have consumed it — the correct amount still works.
+        var ok = service.ValidateAndConsumeConfirmation(pending.Nonce, 1000);
+        ok.Should().NotBeNull();
+        ok!.AmountSats.Should().Be(1000);
+
+        // One-time use: a second consume (even correct amount) fails.
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000).Should().BeNull();
+    }
+
+    #endregion
 }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/ConfigureBudgetToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/ConfigureBudgetToolTests.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using LightningEnable.Mcp.Models;
+using LightningEnable.Mcp.Services;
+using LightningEnable.Mcp.Tools;
+using Moq;
+using FluentAssertions;
+
+namespace LightningEnable.Mcp.Tests.Tools;
+
+public class ConfigureBudgetToolTests
+{
+    [Fact]
+    public async Task ConfigureBudget_NullBudgetService_ReturnsError()
+    {
+        var result = await ConfigureBudgetTool.ConfigureBudget(
+            perRequest: 200, perSession: 2000, budgetService: null);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetString().Should().Contain("Budget service not available");
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_Success_ReturnsEffectiveCapsJson()
+    {
+        var budget = new Mock<IBudgetService>();
+        budget.Setup(b => b.ConfigureBudgetAsync(200, 2000, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ConfigureBudgetResult.Ok(200, 2000));
+
+        var result = await ConfigureBudgetTool.ConfigureBudget(
+            perRequest: 200, perSession: 2000, budgetService: budget.Object);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        var limits = json.RootElement.GetProperty("limits");
+        limits.GetProperty("perRequestSats").GetInt64().Should().Be(200);
+        limits.GetProperty("perSessionSats").GetInt64().Should().Be(2000);
+        json.RootElement.GetProperty("message").GetString().Should().Contain("lowered");
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_TightenOnlyRejection_SurfacesErrorJson()
+    {
+        // The service refuses an attempt to RAISE limits; the tool must surface that.
+        var budget = new Mock<IBudgetService>();
+        budget.Setup(b => b.ConfigureBudgetAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ConfigureBudgetResult.Fail("configure_budget can only LOWER spending limits, not raise them."));
+
+        var result = await ConfigureBudgetTool.ConfigureBudget(
+            perRequest: 9_999_999, perSession: 9_999_999, budgetService: budget.Object);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetString().Should().Contain("can only LOWER");
+    }
+
+    [Fact]
+    public async Task ConfigureBudget_InvalidInputRejection_SurfacesErrorJson()
+    {
+        var budget = new Mock<IBudgetService>();
+        budget.Setup(b => b.ConfigureBudgetAsync(It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ConfigureBudgetResult.Fail("per_request cannot exceed per_session."));
+
+        var result = await ConfigureBudgetTool.ConfigureBudget(
+            perRequest: 6000, perSession: 5000, budgetService: budget.Object);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetString().Should().Contain("exceed");
+    }
+}

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
@@ -212,15 +212,16 @@ public class L402ToolsTests
             budgetService: budgetServiceMock.Object,
             priceService: priceServiceMock.Object);
 
-        // Assert — should return nonce-based fallback
+        // Assert — confirmation requested, but the code must NOT leak into the result
+        // (it goes to stderr only — the core out-of-band security property).
         var json = JsonDocument.Parse(result);
         json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
         json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
-        json.RootElement.GetProperty("nonce").GetString().Should().Be("L4C123");
+        json.RootElement.TryGetProperty("nonce", out _).Should().BeFalse("the code must never be in the result");
+        result.Should().NotContain("L4C123", "the confirmation code must not leak into the model-visible result");
         json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
         json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
         json.RootElement.GetProperty("amount").GetProperty("maxSats").GetInt32().Should().Be(1000);
-        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(5.00m);
     }
 
     [Fact]
@@ -261,11 +262,12 @@ public class L402ToolsTests
             budgetService: budgetServiceMock.Object,
             priceService: priceServiceMock.Object);
 
-        // Assert — should return nonce-based fallback
+        // Assert — confirmation requested, but the code must NOT leak into the result.
         var json = JsonDocument.Parse(result);
         json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
         json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
-        json.RootElement.GetProperty("nonce").GetString().Should().Be("PLC456");
+        json.RootElement.TryGetProperty("nonce", out _).Should().BeFalse("the code must never be in the result");
+        result.Should().NotContain("PLC456", "the confirmation code must not leak into the model-visible result");
         json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
         json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
         json.RootElement.GetProperty("amount").GetProperty("sats").GetInt64().Should().Be(50); // lnbc500n = 50 sats

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
@@ -222,6 +222,7 @@ public class L402ToolsTests
         json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
         json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
         json.RootElement.GetProperty("amount").GetProperty("maxSats").GetInt32().Should().Be(1000);
+        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(5.00m); // contract: USD still surfaced
     }
 
     [Fact]

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
@@ -577,6 +577,7 @@ public class PayInvoiceToolTests
         json.RootElement.GetProperty("howToConfirm").GetString().Should().NotContain("ABC123");
         json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
         json.RootElement.GetProperty("amount").GetProperty("sats").GetInt64().Should().Be(100); // lnbc1000n = 100 sats
+        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(5.00m); // contract: USD still surfaced
     }
 
     #endregion

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
@@ -528,10 +528,10 @@ public class PayInvoiceToolTests
 
     #endregion
 
-    #region Nonce Fallback Tests
+    #region Out-of-band confirmation Tests
 
     [Fact]
-    public async Task PayInvoice_RequiresConfirmation_ElicitationFails_ReturnsNonceFallback()
+    public async Task PayInvoice_RequiresConfirmation_DoesNotLeakCodeInResult()
     {
         // Arrange — budget says RequiresConfirmation, elicitation unavailable (no server)
         _walletServiceMock.Setup(w => w.IsConfigured).Returns(true);
@@ -558,22 +558,25 @@ public class PayInvoiceToolTests
         _budgetServiceMock.Setup(b => b.GetUserConfiguration())
             .Returns(new UserBudgetConfiguration());
 
-        // Act — no McpServer, so elicitation can't work
+        // Act — no McpServer, so elicitation can't work → out-of-band (stderr) path
         var result = await PayInvoiceTool.PayInvoice(
             invoice: TestInvoice,
             walletService: _walletServiceMock.Object,
             budgetService: _budgetServiceMock.Object,
             priceService: _priceServiceMock.Object);
 
-        // Assert — should return nonce-based fallback, not an error
+        // Assert — confirmation is requested, but the CODE must NOT appear anywhere in
+        // the model-visible result (it goes to stderr only). This is the core security
+        // property: a prompt-injected agent can't read its own confirmation code.
         var json = JsonDocument.Parse(result);
         json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
         json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
-        json.RootElement.GetProperty("nonce").GetString().Should().Be("ABC123");
+        json.RootElement.TryGetProperty("nonce", out _).Should().BeFalse("the code must never be in the result");
+        result.Should().NotContain("ABC123", "the confirmation code must not leak into the model-visible result");
         json.RootElement.TryGetProperty("howToConfirm", out _).Should().BeTrue();
+        json.RootElement.GetProperty("howToConfirm").GetString().Should().NotContain("ABC123");
         json.RootElement.GetProperty("expiresInSeconds").GetInt32().Should().Be(120);
         json.RootElement.GetProperty("amount").GetProperty("sats").GetInt64().Should().Be(100); // lnbc1000n = 100 sats
-        json.RootElement.GetProperty("amount").GetProperty("usd").GetDecimal().Should().Be(5.00m);
     }
 
     #endregion

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/SendOnChainToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/SendOnChainToolTests.cs
@@ -95,4 +95,23 @@ public class SendOnChainToolTests
         json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
         json.RootElement.GetProperty("error").GetString().Should().Contain("Invalid Bitcoin address");
     }
+
+    [Fact]
+    public async Task SendOnChain_NullBudgetService_FailsClosed_DoesNotSend()
+    {
+        // On-chain is irreversible: with no budget/confirmation service, refuse rather than
+        // bypass the gate and send.
+        var wallet = ConfiguredWallet();
+
+        var result = await SendOnChainTool.SendOnChain(
+            address: ValidAddress,
+            amountSats: 5000,
+            walletService: wallet.Object,
+            budgetService: null);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetString().Should().Contain("fail-closed");
+        wallet.Verify(w => w.SendOnChainAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/SendOnChainToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/SendOnChainToolTests.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using LightningEnable.Mcp.Models;
+using LightningEnable.Mcp.Services;
+using LightningEnable.Mcp.Tools;
+using Moq;
+using FluentAssertions;
+
+namespace LightningEnable.Mcp.Tests.Tools;
+
+public class SendOnChainToolTests
+{
+    // Standard valid mainnet bech32 test address.
+    private const string ValidAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+    private static Mock<IWalletService> ConfiguredWallet()
+    {
+        var wallet = new Mock<IWalletService>();
+        wallet.Setup(w => w.IsConfigured).Returns(true);
+        return wallet;
+    }
+
+    [Fact]
+    public async Task SendOnChain_NoConfirmation_AlwaysRequiresIt_AndDoesNotLeakCode()
+    {
+        // Even an AUTO-APPROVE-tier amount must require confirmation — on-chain is irreversible (C-2b).
+        var wallet = ConfiguredWallet();
+        var budget = new Mock<IBudgetService>();
+        budget.Setup(b => b.CheckApprovalLevelAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApprovalCheckResult { Level = ApprovalLevel.AutoApprove, AmountSats = 5000, AmountUsd = 0.05m });
+        budget.Setup(b => b.CreatePendingConfirmation(
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(new PendingConfirmation
+            {
+                Nonce = "ONCH99",
+                AmountSats = 5000,
+                AmountUsd = 0.05m,
+                ToolName = "send_onchain",
+                Description = ValidAddress,
+                CreatedAt = DateTime.UtcNow,
+                ExpiresAt = DateTime.UtcNow.AddMinutes(2)
+            });
+
+        var result = await SendOnChainTool.SendOnChain(
+            address: ValidAddress,
+            amountSats: 5000,
+            walletService: wallet.Object,
+            budgetService: budget.Object);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("requiresConfirmation").GetBoolean().Should().BeTrue();
+        json.RootElement.TryGetProperty("nonce", out _).Should().BeFalse("the code must never be in the result");
+        result.Should().NotContain("ONCH99", "the confirmation code must not leak into the model-visible result");
+        wallet.Verify(w => w.SendOnChainAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendOnChain_BudgetDenied_DoesNotSend_EvenWithACode()
+    {
+        // An over-limit amount is refused before confirmation — a code cannot authorize
+        // a payment beyond the configured ceiling (or during a price outage → Deny).
+        var wallet = ConfiguredWallet();
+        var budget = new Mock<IBudgetService>();
+        budget.Setup(b => b.CheckApprovalLevelAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ApprovalCheckResult
+            {
+                Level = ApprovalLevel.Deny,
+                AmountSats = 5000,
+                DenialReason = "Exceeds per-payment limit"
+            });
+
+        var result = await SendOnChainTool.SendOnChain(
+            address: ValidAddress,
+            amountSats: 5000,
+            confirmationNonce: "ANYCODE",
+            walletService: wallet.Object,
+            budgetService: budget.Object);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        wallet.Verify(w => w.SendOnChainAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendOnChain_InvalidAddress_Rejected_BeforeAnyConfirmation()
+    {
+        var wallet = ConfiguredWallet();
+
+        var result = await SendOnChainTool.SendOnChain(
+            address: "not-a-bitcoin-address",
+            amountSats: 5000,
+            walletService: wallet.Object);
+
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetString().Should().Contain("Invalid Bitcoin address");
+    }
+}


### PR DESCRIPTION
## Phase 2 — funds-safety remediation (the freeze-blocker)

Second batch of MCP funds-safety fixes (PR #30 was the first). All **test-first**, all on branch off `main`. **Full .NET suite: 260 passed.** Functional smoke (real MCP stdio handshake → tools/list → money-path tool) **PASS on both .NET and Python.**

### What's in it

1. **`configure_budget` added to .NET (decision C — converge to 23 tools).** Tighten-only: an agent can LOWER its per-request/per-session caps at runtime but can never raise them above the operator's config limits. Sats-based runtime cap enforced in the approval path; surfaced in `get_budget_status`. Brings .NET to parity with Python. *(Smoke confirms .NET now lists 23 tools incl. `configure_budget`.)*

2. **H-1 fail-closed on BTC price outage (no arbitrary hard ceiling).** Per review: rather than invent a sats "hard ceiling" (which would reject legit USD-limited payments as BTC price moves), rely on the price service's existing design — 3 sources in parallel, first wins, throws when all fail with **no stale-price fallback**. The approval path now returns a clean **Deny** when price is unavailable (sync + async paths). Removed the misleading "HardMax… cannot be exceeded" claim (there was never an enforced ceiling).

3. **Out-of-band confirmation — the core self-approval fix.** Previously the confirmation code was returned **in** the pay tool's result, so a prompt-injected agent could read its own code and call `confirm_payment` itself. Now the code is written **only to stderr** (visible to the human operator, never to the model — which only sees tool results). Fixed across **all three** payment paths: `pay_invoice`, `access_l402_resource`, `pay_l402_challenge`. *(Universal stderr floor only; MCP elicitation + a hosted click-URL are deferred UX layers.)*

4. **C-2b — `send_onchain` ALWAYS requires confirmation.** On-chain is irreversible, so every send now routes through the out-of-band flow regardless of amount/tier. Over-limit (or price-outage) is refused outright — a code can't authorize beyond the ceiling.

5. **C-3 — confirmation bound to the approved amount.** `ValidateAndConsumeConfirmation` now verifies the amount about to be paid equals the approved amount; a code approved for X sats can no longer authorize a different amount within the window. Mismatch doesn't burn the code (correct retry still works).

### Deferred (with reasons)
- **Unify `RequireApprovalForFirstPayment` default** → it's a confirmation-flow concern; minor, not a hole. Follow-up.
- **Collapse Python's dual budget system** → safe as-is (most-restrictive-wins); a clarity refactor, not a vulnerability.
- **Hard sats ceiling** → dropped on purpose (see #2).

### Notes for review
- **Smoke observation:** .NET lists **23** tools without an API key; Python lists **17** (its ASA/producer tools gate on `LIGHTNING_ENABLE_API_KEY`). A per-package gating difference relevant to the docs (#32/#170), not to this PR.
- **Do not bump the version / publish** until this is reviewed — the publish gate is the version number, deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
