### PR TITLE
chore(release): MCP 1.12.10 — funds-safety hardening

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.9</Version>
+    <Version>1.12.10</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.9: Fix NIP-04 NWC compatibility with CoinOS (and any wallet using raw shared-X for the AES-256-CBC key). v1.12.5 round-2 introduced sha256(shared_x) as the AES key derivation under the framing of "spec compliance" — but that was wrong about CoinOS. Empirically verified by the working l402-ts JS NWC client (lines 137 + 222 of src/wallets/nwc.ts use raw shared_x and the path pays CoinOS in production). The bug surface was that NIP-04 NWC payments to CoinOS silently timed out at 30s ("NWC request failed (no_response)") because CoinOS couldn't decrypt our sha256-keyed ciphertext. Reverted both .NET and Python ports to raw shared_x; pinned by EncryptNip04_DerivesKeyAsRawSharedX_ForCoinOSAndL402TsCompat (.NET) + test_nip04_decrypts_raw_sharedx_for_coinos_compat (Python).</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.10: Funds-safety hardening of the agent payment path. (1) Out-of-band confirmation — the confirmation code for above-threshold payments is now printed only to the server console/stderr (visible to the human operator), never returned in a tool result, so a prompt-injected agent cannot read and self-approve its own payment. (2) send_onchain (irreversible) ALWAYS requires confirmation and fails closed if the budget service is unavailable. (3) Confirmation codes are bound to the exact amount AND tool they approved (no cross-tool / cross-amount replay). (4) configure_budget added to .NET, tighten-only — an agent can lower its caps but never raise them above the operator's ~/.lightning-enable/config.json limits. (5) Budget checks fail closed when the BTC price feed is unavailable (3 sources, no stale fallback). (6) NWC response preimage no longer logged.</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.9"
+version = "1.12.10"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps version to publish the funds-safety remediation (#30 + #35) to NuGet/PyPI/Docker. Release notes in the csproj summarize the 6 user-facing changes. Merging this triggers the publish workflow.