### PR TITLE
fix(py): make secp256k1 optional so pip install works on Windows (1.12.11)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.10</Version>
+    <Version>1.12.11</Version>
     <AssemblyVersion>1.9.0.0</AssemblyVersion>
     <FileVersion>1.9.0.0</FileVersion>
     <Authors>Lightning Enable</Authors>
@@ -24,7 +24,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- <PackageIcon>icon.png</PackageIcon> -->
 
-    <PackageReleaseNotes>v1.12.10: Funds-safety hardening of the agent payment path. (1) Out-of-band confirmation — the confirmation code for above-threshold payments is now printed only to the server console/stderr (visible to the human operator), never returned in a tool result, so a prompt-injected agent cannot read and self-approve its own payment. (2) send_onchain (irreversible) ALWAYS requires confirmation and fails closed if the budget service is unavailable. (3) Confirmation codes are bound to the exact amount AND tool they approved (no cross-tool / cross-amount replay). (4) configure_budget added to .NET, tighten-only — an agent can lower its caps but never raise them above the operator's ~/.lightning-enable/config.json limits. (5) Budget checks fail closed when the BTC price feed is unavailable (3 sources, no stale fallback). (6) NWC response preimage no longer logged.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.12.11: (Python packaging) secp256k1 is now an OPTIONAL dependency — `pip install lightning-enable-mcp` works on every platform with no build toolchain (it was failing on Windows because secp256k1 is a C-extension with no Windows wheel). NWC wallet users add the extra: `pip install lightning-enable-mcp[nwc]`. .NET is unaffected (managed crypto). No functional change vs 1.12.10. — v1.12.10: Funds-safety hardening of the agent payment path. (1) Out-of-band confirmation — the confirmation code for above-threshold payments is now printed only to the server console/stderr (visible to the human operator), never returned in a tool result, so a prompt-injected agent cannot read and self-approve its own payment. (2) send_onchain (irreversible) ALWAYS requires confirmation and fails closed if the budget service is unavailable. (3) Confirmation codes are bound to the exact amount AND tool they approved (no cross-tool / cross-amount replay). (4) configure_budget added to .NET, tighten-only — an agent can lower its caps but never raise them above the operator's ~/.lightning-enable/config.json limits. (5) Budget checks fail closed when the BTC price feed is unavailable (3 sources, no stale fallback). (6) NWC response preimage no longer logged.</PackageReleaseNotes>
 
     <!-- MIT License -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.10"
+version = "1.12.11"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"
@@ -44,13 +44,21 @@ dependencies = [
     "aiohttp>=3.13.4",
     "pydantic>=2.0.0",
     "bolt11>=2.0.0",
-    "secp256k1>=0.14.0",
     "websockets>=12.0",
     "bech32>=1.2.0",
     "cryptography>=46.0.7",
 ]
 
 [project.optional-dependencies]
+# NWC (Nostr Wallet Connect) wallets need secp256k1 for pubkey derivation + Schnorr/ECDH.
+# It is a C-extension with no prebuilt Windows wheel, so it is OPTIONAL here: a plain
+# `pip install lightning-enable-mcp` then works on every platform with no build toolchain.
+# Add this extra only if you use an NWC wallet:  pip install lightning-enable-mcp[nwc]
+# (LND, Strike and OpenNode wallets do not need it). The code raises a clear error if an
+# NWC wallet is used without it.
+nwc = [
+    "secp256k1>=0.14.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
@@ -227,7 +227,10 @@ def _sign_event(event: dict[str, Any], secret_key: bytes) -> str:
         sig = privkey.schnorr_sign(event_id_bytes, None, raw=True)
         return sig.hex()
     except ImportError:
-        raise ImportError("secp256k1 library required for signing")
+        raise ImportError(
+            "secp256k1 is required for NWC (Nostr Wallet Connect) signing. "
+            "Install it with:  pip install lightning-enable-mcp[nwc]"
+        )
 
 
 def _get_pubkey(secret_key: bytes) -> str:
@@ -248,7 +251,10 @@ def _get_pubkey(secret_key: bytes) -> str:
         # Return x-only pubkey (skip the prefix byte)
         return pubkey[1:33].hex() if len(pubkey) == 33 else pubkey[:32].hex()
     except ImportError:
-        raise ImportError("secp256k1 library required")
+        raise ImportError(
+            "secp256k1 is required for NWC (Nostr Wallet Connect) wallets. "
+            "Install it with:  pip install lightning-enable-mcp[nwc]"
+        )
 
 
 def _encrypt_content(plaintext: str, secret_key: bytes, recipient_pubkey: str) -> str:


### PR DESCRIPTION
Smoke-testing published 1.12.10 found 'pip install lightning-enable-mcp' fails on Windows/no-toolchain machines because secp256k1 (a C-extension, NWC-only) is a hard dependency with no Windows wheel. Pre-existing. The code already lazy-imports it, so it's now an optional [nwc] extra — plain install works everywhere; NWC users run pip install lightning-enable-mcp[nwc]. Clear ImportError points to the extra. 1.12.11; Python suite 364 green without secp256k1.