### PR TITLE
fix(py): swap secp256k1 → coincurve — NWC works out-of-the-box on Windows/macOS/Linux

### DIFF
--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -47,18 +47,18 @@ dependencies = [
     "websockets>=12.0",
     "bech32>=1.2.0",
     "cryptography>=46.0.7",
+    # NWC (Nostr Wallet Connect) pubkey derivation + BIP340 Schnorr + ECDH.
+    # coincurve ships prebuilt wheels for Linux, macOS AND Windows, so NWC works
+    # out of the box on every platform with no build toolchain — no extra needed.
+    # (Replaced the old `secp256k1` C-extension, which had no Windows wheel.)
+    "coincurve>=20.0.0",
 ]
 
 [project.optional-dependencies]
-# NWC (Nostr Wallet Connect) wallets need secp256k1 for pubkey derivation + Schnorr/ECDH.
-# It is a C-extension with no prebuilt Windows wheel, so it is OPTIONAL here: a plain
-# `pip install lightning-enable-mcp` then works on every platform with no build toolchain.
-# Add this extra only if you use an NWC wallet:  pip install lightning-enable-mcp[nwc]
-# (LND, Strike and OpenNode wallets do not need it). The code raises a clear error if an
-# NWC wallet is used without it.
-nwc = [
-    "secp256k1>=0.14.0",
-]
+# Back-compat no-op: `pip install lightning-enable-mcp[nwc]` still resolves. NWC
+# support is now in the base dependencies (coincurve), so this extra is empty and
+# exists only so existing install commands don't break.
+nwc = []
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
@@ -228,7 +228,8 @@ def _sign_event(event: dict[str, Any], secret_key: bytes) -> str:
     except ImportError:
         raise ImportError(
             "coincurve is required for NWC (Nostr Wallet Connect) signing. "
-            "Install it with:  pip install coincurve"
+            "It ships with this package — reinstall via:  pip install --upgrade lightning-enable-mcp "
+            "(or install it directly:  pip install 'coincurve>=20.0.0')."
         )
 
 
@@ -252,7 +253,8 @@ def _get_pubkey(secret_key: bytes) -> str:
     except ImportError:
         raise ImportError(
             "coincurve is required for NWC (Nostr Wallet Connect) wallets. "
-            "Install it with:  pip install coincurve"
+            "It ships with this package — reinstall via:  pip install --upgrade lightning-enable-mcp "
+            "(or install it directly:  pip install 'coincurve>=20.0.0')."
         )
 
 
@@ -289,17 +291,11 @@ def _encrypt_content(plaintext: str, secret_key: bytes, recipient_pubkey: str) -
 
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-    from coincurve import PublicKey
 
-    # Compute ECDH shared point; AES key is the raw 32-byte X coordinate.
-    recipient_bytes = bytes.fromhex(recipient_pubkey)
-    if len(recipient_bytes) == 32:
-        # Add prefix for compressed pubkey (assume even y-coordinate)
-        recipient_bytes = b"\x02" + recipient_bytes
-    pubkey = PublicKey(recipient_bytes)
-    shared_point = pubkey.multiply(secret_key)
-    # Uncompressed point is 0x04 || X || Y; take raw X — matches l402-ts + CoinOS.
-    shared_secret = shared_point.format(compressed=False)[1:33]
+    # AES key is the raw 32-byte ECDH shared-X. Single source of truth for the
+    # curve math (shared with the decrypt path) so the two can't drift — matches
+    # l402-ts + CoinOS.
+    shared_secret = _compute_shared_x(secret_key, recipient_pubkey)
 
     # Generate IV and encrypt with AES-256-CBC + PKCS7 padding
     iv = os.urandom(16)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/nwc_wallet.py
@@ -191,18 +191,16 @@ def _verify_nostr_event_signature(event: dict[str, Any]) -> bool:
         if recomputed_id.lower() != id_hex.lower():
             return False
 
-        from secp256k1 import PublicKey
+        from coincurve import PublicKeyXOnly
 
         pubkey_bytes = bytes.fromhex(pubkey_hex)
         sig_bytes = bytes.fromhex(sig_hex)
         id_bytes = bytes.fromhex(id_hex)
 
-        # secp256k1.PublicKey takes a 33-byte compressed pubkey; x-only pubkey is
-        # 32 bytes so we prefix 0x02 (assume even y, NIP-340 convention).
-        compressed = b"\x02" + pubkey_bytes
-        pubkey = PublicKey(compressed, raw=True)
-        # schnorr_verify takes (msg, sig, raw=True). Returns True iff valid.
-        return bool(pubkey.schnorr_verify(id_bytes, sig_bytes, None, raw=True))
+        # BIP340 verification takes the 32-byte x-only pubkey directly.
+        pubkey = PublicKeyXOnly(pubkey_bytes)
+        # verify(signature, message) — message is the raw 32-byte event id (not hashed).
+        return bool(pubkey.verify(sig_bytes, id_bytes))
     except Exception:
         # Defensive: any parsing/crypto exception → treat as unverified.
         return False
@@ -210,7 +208,7 @@ def _verify_nostr_event_signature(event: dict[str, Any]) -> bool:
 
 def _sign_event(event: dict[str, Any], secret_key: bytes) -> str:
     """
-    Sign a Nostr event using secp256k1.
+    Sign a Nostr event using BIP340 Schnorr (coincurve).
 
     Args:
         event: Event dict with id field set
@@ -220,16 +218,17 @@ def _sign_event(event: dict[str, Any], secret_key: bytes) -> str:
         Hex-encoded signature
     """
     try:
-        from secp256k1 import PrivateKey
+        from coincurve import PrivateKey
 
         privkey = PrivateKey(secret_key)
         event_id_bytes = bytes.fromhex(event["id"])
-        sig = privkey.schnorr_sign(event_id_bytes, None, raw=True)
+        # BIP340 schnorr over the raw 32-byte event id (coincurve does not hash it).
+        sig = privkey.sign_schnorr(event_id_bytes)
         return sig.hex()
     except ImportError:
         raise ImportError(
-            "secp256k1 is required for NWC (Nostr Wallet Connect) signing. "
-            "Install it with:  pip install lightning-enable-mcp[nwc]"
+            "coincurve is required for NWC (Nostr Wallet Connect) signing. "
+            "Install it with:  pip install coincurve"
         )
 
 
@@ -244,16 +243,16 @@ def _get_pubkey(secret_key: bytes) -> str:
         Hex-encoded public key (x-only, 32 bytes)
     """
     try:
-        from secp256k1 import PrivateKey
+        from coincurve import PrivateKey
 
         privkey = PrivateKey(secret_key)
-        pubkey = privkey.pubkey.serialize()
-        # Return x-only pubkey (skip the prefix byte)
-        return pubkey[1:33].hex() if len(pubkey) == 33 else pubkey[:32].hex()
+        # 33-byte compressed pubkey (prefix || X); return x-only (drop the prefix).
+        pubkey = privkey.public_key.format(compressed=True)
+        return pubkey[1:33].hex()
     except ImportError:
         raise ImportError(
-            "secp256k1 is required for NWC (Nostr Wallet Connect) wallets. "
-            "Install it with:  pip install lightning-enable-mcp[nwc]"
+            "coincurve is required for NWC (Nostr Wallet Connect) wallets. "
+            "Install it with:  pip install coincurve"
         )
 
 
@@ -290,16 +289,17 @@ def _encrypt_content(plaintext: str, secret_key: bytes, recipient_pubkey: str) -
 
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-    from secp256k1 import PrivateKey, PublicKey  # noqa: F401  (PrivateKey not used here, kept for parity)
+    from coincurve import PublicKey
 
     # Compute ECDH shared point; AES key is the raw 32-byte X coordinate.
     recipient_bytes = bytes.fromhex(recipient_pubkey)
     if len(recipient_bytes) == 32:
         # Add prefix for compressed pubkey (assume even y-coordinate)
         recipient_bytes = b"\x02" + recipient_bytes
-    pubkey = PublicKey(recipient_bytes, raw=True)
-    shared_point = pubkey.tweak_mul(secret_key)
-    shared_secret = shared_point.serialize()[1:33]  # raw shared-X — matches l402-ts + CoinOS
+    pubkey = PublicKey(recipient_bytes)
+    shared_point = pubkey.multiply(secret_key)
+    # Uncompressed point is 0x04 || X || Y; take raw X — matches l402-ts + CoinOS.
+    shared_secret = shared_point.format(compressed=False)[1:33]
 
     # Generate IV and encrypt with AES-256-CBC + PKCS7 padding
     iv = os.urandom(16)
@@ -398,14 +398,15 @@ def _compute_shared_x(secret_key: bytes, pubkey_hex: str) -> bytes:
     Returns:
         32-byte shared x-coordinate
     """
-    from secp256k1 import PrivateKey, PublicKey
+    from coincurve import PublicKey
 
     pubkey_bytes = bytes.fromhex(pubkey_hex)
     if len(pubkey_bytes) == 32:
         pubkey_bytes = b"\x02" + pubkey_bytes
-    pubkey = PublicKey(pubkey_bytes, raw=True)
-    shared_point = pubkey.tweak_mul(secret_key)
-    return shared_point.serialize()[1:33]
+    pubkey = PublicKey(pubkey_bytes)
+    shared_point = pubkey.multiply(secret_key)
+    # Uncompressed point is 0x04 || X || Y; take raw X.
+    return shared_point.format(compressed=False)[1:33]
 
 
 def _decrypt_nip04(encrypted: str, secret_key: bytes, sender_pubkey: str) -> str:

--- a/python/lightning-enable-mcp/tests/test_nwc_coincurve_vectors.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_coincurve_vectors.py
@@ -1,0 +1,120 @@
+"""
+Golden-vector tests for the NWC secp256k1 -> coincurve swap (task B).
+
+These pin the THREE curve operations in nwc_wallet.py against INDEPENDENT ground
+truth, so a green run proves coincurve produces byte-correct output — not merely
+that it's self-consistent (round-trip tests would pass even if the raw shared-X
+diverged and silently broke CoinOS):
+
+  1. Pubkey derivation  -> the canonical BIP340 test vector (seckey 3).
+  2. Raw shared-X ECDH  -> cross-checked against `cryptography`'s SECP256K1 ECDH
+                           (a second, unrelated implementation) AND symmetry.
+  3. Schnorr sign/verify -> round-trips through the production verify gate, and a
+                           one-bit-flipped signature is rejected (the F-11 INFO-
+                           event forgery gate must stay sound).
+
+coincurve and the `secp256k1` package both wrap the same libsecp256k1 C library,
+so the crypto is identical; the only swap risk is HOW we call coincurve. That is
+exactly what these vectors pin.
+"""
+
+import time
+
+import pytest
+
+from lightning_enable_mcp.nwc_wallet import (
+    _compute_event_id,
+    _compute_shared_x,
+    _decrypt_nip04,
+    _encrypt_content,
+    _get_pubkey,
+    _sign_event,
+    _verify_nostr_event_signature,
+)
+
+# --- BIP340 canonical vector: secret scalar 3 -> known x-only pubkey ----------
+SECKEY_3 = (3).to_bytes(32, "big")
+BIP340_PUBKEY_X_FOR_3 = (
+    "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+)
+
+# A second deterministic, valid scalar for ECDH tests.
+SECKEY_A = b"\x01" + b"\x42" * 31
+
+
+def _crypto_ecdh_shared_x(priv_bytes: bytes, pub_x_hex: str) -> bytes:
+    """Independent raw shared-X via `cryptography`'s SECP256K1 ECDH.
+
+    Reconstructs the peer point as 02||X (even-Y) — the same NIP-04 convention
+    the production code uses — and returns the X coordinate of priv*peer.
+    """
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    priv = ec.derive_private_key(int.from_bytes(priv_bytes, "big"), ec.SECP256K1())
+    comp = bytes.fromhex("02" + pub_x_hex)
+    peer = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), comp)
+    # exchange() returns the shared point's X coordinate, big-endian 32 bytes.
+    return priv.exchange(ec.ECDH(), peer)
+
+
+def test_get_pubkey_matches_bip340_vector():
+    assert _get_pubkey(SECKEY_3) == BIP340_PUBKEY_X_FOR_3
+
+
+def test_compute_shared_x_matches_independent_cryptography_ecdh():
+    # priv = A, peer = BIP340 vector pubkey (even-Y x-only).
+    got = _compute_shared_x(SECKEY_A, BIP340_PUBKEY_X_FOR_3)
+    expected = _crypto_ecdh_shared_x(SECKEY_A, BIP340_PUBKEY_X_FOR_3)
+    assert got == expected, "raw shared-X must match an independent ECDH impl (CoinOS path)"
+    assert len(got) == 32
+
+
+def test_compute_shared_x_is_symmetric():
+    # ECDH(a, B) and ECDH(b, A) yield the same shared-X (even-Y convention on both).
+    a_pub = _get_pubkey(SECKEY_A)
+    b_pub = BIP340_PUBKEY_X_FOR_3
+    ab = _compute_shared_x(SECKEY_A, b_pub)
+    ba = _compute_shared_x(SECKEY_3, a_pub)
+    assert ab == ba
+
+
+def _build_signed_event(secret_key: bytes, pubkey_hex: str, content: str) -> dict:
+    event = {
+        "kind": 13194,
+        "pubkey": pubkey_hex,
+        "created_at": int(time.time()),
+        "tags": [["encryption", "nip04 nip44_v2"]],
+        "content": content,
+    }
+    event["id"] = _compute_event_id(event)
+    event["sig"] = _sign_event(event, secret_key)
+    return event
+
+
+def test_sign_then_verify_round_trip():
+    pub = _get_pubkey(SECKEY_3)
+    event = _build_signed_event(SECKEY_3, pub, "hello world")
+    assert _verify_nostr_event_signature(event) is True
+
+
+def test_one_bit_flipped_signature_is_rejected():
+    pub = _get_pubkey(SECKEY_3)
+    event = _build_signed_event(SECKEY_3, pub, "hello world")
+    # Flip the last nibble of the signature — a valid-length but wrong sig.
+    sig = event["sig"]
+    flipped = sig[:-1] + ("0" if sig[-1] != "0" else "1")
+    event["sig"] = flipped
+    assert _verify_nostr_event_signature(event) is False
+
+
+def test_nip04_encrypt_decrypt_round_trip():
+    # Alice encrypts to Bob; Bob decrypts with his secret + Alice's pubkey.
+    alice_sec = SECKEY_A
+    alice_pub = _get_pubkey(alice_sec)
+    bob_sec = SECKEY_3
+    bob_pub = _get_pubkey(bob_sec)
+
+    ciphertext = _encrypt_content("the magic words are squeamish ossifrage", alice_sec, bob_pub)
+    assert "?iv=" in ciphertext
+    plaintext = _decrypt_nip04(ciphertext, bob_sec, alice_pub)
+    assert plaintext == "the magic words are squeamish ossifrage"

--- a/python/lightning-enable-mcp/tests/test_nwc_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_wallet.py
@@ -24,9 +24,9 @@ from lightning_enable_mcp.nwc_wallet import (
 )
 
 
-# ---------- Deterministic test keys (no secp256k1 needed) ----------
+# ---------- Deterministic test keys (no elliptic-curve lib needed) ----------
 # We use a fixed 32-byte "shared_x" value to bypass ECDH in tests.
-# This lets us test all the symmetric crypto without the secp256k1 C library.
+# This lets us test all the symmetric crypto without the elliptic-curve library.
 # Must be exactly 32 bytes (64 hex chars) — used directly as the AES-256 key.
 # Earlier this fixture was 31 bytes; it appeared to work only because the
 # previous sha256(shared_x) key derivation hashed any input down to 32 bytes,
@@ -801,19 +801,16 @@ class TestNWCEncryptionDefault:
 
     @staticmethod
     def _new_keypair():
-        # importorskip returns the imported module — earlier code dropped the
-        # binding and then referenced bare `secp` (NameError). The test was
-        # never run in CI before so the bug went unnoticed.
-        secp = pytest.importorskip("secp256k1")
+        cc = pytest.importorskip("coincurve")
         privkey_bytes = b"\x01" + b"\x42" * 31  # deterministic but valid scalar
-        pk = secp.PrivateKey(privkey_bytes)
+        pk = cc.PrivateKey(privkey_bytes)
         # x-only pubkey (drop the leading 02/03 byte from compressed form)
-        pubkey_hex = pk.pubkey.serialize()[1:33].hex()
+        pubkey_hex = pk.public_key.format(compressed=True)[1:33].hex()
         return privkey_bytes, pubkey_hex
 
     def test_verify_nostr_event_signature_valid_event_returns_true(self):
         # Sign-then-verify baseline. Establishes that genuine events pass.
-        pytest.importorskip("secp256k1")
+        pytest.importorskip("coincurve")
         from lightning_enable_mcp.nwc_wallet import _verify_nostr_event_signature
 
         privkey, pubkey_hex = self._new_keypair()
@@ -829,7 +826,7 @@ class TestNWCEncryptionDefault:
         # encryption tag (but otherwise looking like the wallet's INFO event)
         # must fail verification. Tamper after signing — the recomputed event
         # id won't match the claimed id.
-        pytest.importorskip("secp256k1")
+        pytest.importorskip("coincurve")
         from lightning_enable_mcp.nwc_wallet import _verify_nostr_event_signature
 
         privkey, pubkey_hex = self._new_keypair()
@@ -846,7 +843,7 @@ class TestNWCEncryptionDefault:
     def test_verify_nostr_event_signature_wrong_signature_returns_false(self):
         # Substitute a signature from a different keypair — pubkey unchanged
         # but sig signed by attacker's key. Must fail.
-        secp = pytest.importorskip("secp256k1")
+        cc = pytest.importorskip("coincurve")
         from lightning_enable_mcp.nwc_wallet import (
             _sign_event,
             _verify_nostr_event_signature,
@@ -855,7 +852,7 @@ class TestNWCEncryptionDefault:
         alice_priv, alice_pubkey_hex = self._new_keypair()
         # Different keypair for Bob
         bob_priv = b"\x02" + b"\x37" * 31
-        secp.PrivateKey(bob_priv)  # validate
+        cc.PrivateKey(bob_priv)  # validate
 
         event = self._build_signed_info_event(
             alice_priv, alice_pubkey_hex, "nip04 nip44_v2"
@@ -891,9 +888,9 @@ class TestNWCEncryptionDefault:
         # used to return None when pycryptodome (``Crypto``) was importable, because
         # the only ``return`` lived inside the ``except ImportError`` fallback.
         # The post-fix invariant: the function always returns a NIP-04-shaped
-        # string. Skipped when ``secp256k1`` (a C lib) isn't installed locally;
+        # string. Skipped when ``coincurve`` isn't installed locally;
         # CI has it.
-        pytest.importorskip("secp256k1")
+        pytest.importorskip("coincurve")
         from lightning_enable_mcp.nwc_wallet import _encrypt_content
 
         secret = bytes.fromhex(

--- a/python/lightning-enable-mcp/tests/test_nwc_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_wallet.py
@@ -801,7 +801,7 @@ class TestNWCEncryptionDefault:
 
     @staticmethod
     def _new_keypair():
-        cc = pytest.importorskip("coincurve")
+        import coincurve as cc
         privkey_bytes = b"\x01" + b"\x42" * 31  # deterministic but valid scalar
         pk = cc.PrivateKey(privkey_bytes)
         # x-only pubkey (drop the leading 02/03 byte from compressed form)
@@ -810,7 +810,7 @@ class TestNWCEncryptionDefault:
 
     def test_verify_nostr_event_signature_valid_event_returns_true(self):
         # Sign-then-verify baseline. Establishes that genuine events pass.
-        pytest.importorskip("coincurve")
+        import coincurve  # noqa: F401  (required dep — fail loudly if missing)
         from lightning_enable_mcp.nwc_wallet import _verify_nostr_event_signature
 
         privkey, pubkey_hex = self._new_keypair()
@@ -826,7 +826,7 @@ class TestNWCEncryptionDefault:
         # encryption tag (but otherwise looking like the wallet's INFO event)
         # must fail verification. Tamper after signing — the recomputed event
         # id won't match the claimed id.
-        pytest.importorskip("coincurve")
+        import coincurve  # noqa: F401  (required dep — fail loudly if missing)
         from lightning_enable_mcp.nwc_wallet import _verify_nostr_event_signature
 
         privkey, pubkey_hex = self._new_keypair()
@@ -843,7 +843,7 @@ class TestNWCEncryptionDefault:
     def test_verify_nostr_event_signature_wrong_signature_returns_false(self):
         # Substitute a signature from a different keypair — pubkey unchanged
         # but sig signed by attacker's key. Must fail.
-        cc = pytest.importorskip("coincurve")
+        import coincurve as cc
         from lightning_enable_mcp.nwc_wallet import (
             _sign_event,
             _verify_nostr_event_signature,
@@ -890,7 +890,7 @@ class TestNWCEncryptionDefault:
         # The post-fix invariant: the function always returns a NIP-04-shaped
         # string. Skipped when ``coincurve`` isn't installed locally;
         # CI has it.
-        pytest.importorskip("coincurve")
+        import coincurve  # noqa: F401  (required dep — fail loudly if missing)
         from lightning_enable_mcp.nwc_wallet import _encrypt_content
 
         secret = bytes.fromhex(

--- a/python/lightning-enable-mcp/tests/test_nwc_wallet.py
+++ b/python/lightning-enable-mcp/tests/test_nwc_wallet.py
@@ -888,9 +888,9 @@ class TestNWCEncryptionDefault:
         # used to return None when pycryptodome (``Crypto``) was importable, because
         # the only ``return`` lived inside the ``except ImportError`` fallback.
         # The post-fix invariant: the function always returns a NIP-04-shaped
-        # string. Skipped when ``coincurve`` isn't installed locally;
-        # CI has it.
-        import coincurve  # noqa: F401  (required dep — fail loudly if missing)
+        # string. ``coincurve`` is a required base dependency, so this imports it
+        # directly — the test fails loudly (not skips) if it's ever missing.
+        import coincurve  # noqa: F401
         from lightning_enable_mcp.nwc_wallet import _encrypt_content
 
         secret = bytes.fromhex(

--- a/python/lightning-enable-mcp/tests/test_security_f11_f12.py
+++ b/python/lightning-enable-mcp/tests/test_security_f11_f12.py
@@ -108,17 +108,11 @@ class TestF11ProcessMessageRejectsForgedEvents:
     necessary but not sufficient — Copilot review on PR #21 noted there's
     no proof the *gate inside _process_message* actually invokes the helper.
 
-    Constructing an NWCWallet calls _get_pubkey which requires the coincurve
-    elliptic-curve library. coincurve is now a base dependency (ships wheels for
-    every platform), so it should always be importable — this guard only fires if
-    the install is broken, in which case skipping (rather than erroring the whole
-    suite) keeps the signal localized.
+    Constructing an NWCWallet calls _get_pubkey, which uses coincurve — a base
+    dependency that ships wheels for every platform. We deliberately do NOT skip on
+    its absence: if coincurve is somehow missing, these security tests should FAIL
+    loudly (a broken-install signal), not silently skip and let CI pass.
     """
-
-    pytestmark = pytest.mark.skipif(
-        __import__("importlib").util.find_spec("coincurve") is None,
-        reason="coincurve not installed in this env",
-    )
 
     @staticmethod
     def _make_nwc_uri(wallet_pubkey_hex: str) -> str:

--- a/python/lightning-enable-mcp/tests/test_security_f11_f12.py
+++ b/python/lightning-enable-mcp/tests/test_security_f11_f12.py
@@ -108,14 +108,16 @@ class TestF11ProcessMessageRejectsForgedEvents:
     necessary but not sufficient — Copilot review on PR #21 noted there's
     no proof the *gate inside _process_message* actually invokes the helper.
 
-    Constructing an NWCWallet calls _get_pubkey which requires the secp256k1
-    native extension; skip the whole class if it's not installed in the test
-    env (CI installs it via dev deps).
+    Constructing an NWCWallet calls _get_pubkey which requires the coincurve
+    elliptic-curve library. coincurve is now a base dependency (ships wheels for
+    every platform), so it should always be importable — this guard only fires if
+    the install is broken, in which case skipping (rather than erroring the whole
+    suite) keeps the signal localized.
     """
 
     pytestmark = pytest.mark.skipif(
-        __import__("importlib").util.find_spec("secp256k1") is None,
-        reason="secp256k1 native extension not installed in this env",
+        __import__("importlib").util.find_spec("coincurve") is None,
+        reason="coincurve not installed in this env",
     )
 
     @staticmethod


### PR DESCRIPTION
## Why
`secp256k1` is a C-extension with **no prebuilt Windows wheel** — 1.12.11 worked around that by making it an optional `[nwc]` extra (NWC users on Windows still had to build it). `coincurve` wraps the **same libsecp256k1 C library** but ships prebuilt wheels for **Linux, macOS, and Windows**, so it removes the root cause. coincurve is now a base dependency; NWC works with a plain `pip install lightning-enable-mcp` everywhere. The `[nwc]` extra stays as an empty back-compat no-op.

## What changed
All four curve ops in `nwc_wallet.py`:
| Operation | coincurve call |
|---|---|
| pubkey derivation | `PrivateKey.public_key.format(compressed=True)[1:33]` |
| BIP340 schnorr sign | `PrivateKey.sign_schnorr(id)` (raw 32-byte event id, not hashed) |
| schnorr verify | `PublicKeyXOnly(x).verify(sig, id)` |
| NIP-04/44 ECDH raw shared-X | `PublicKey(p).multiply(sk).format(compressed=False)[1:33]` |

The ECDH uses `multiply`, **not** coincurve's `.ecdh()` (which hashes the shared point) — NIP-04/CoinOS needs the **raw X coordinate**.

## Verification (test-first, golden vectors)
`test_nwc_coincurve_vectors.py` pins correctness against **independent ground truth**, not just round-trips (a round-trip would pass even if the shared-X silently diverged and broke CoinOS):
- pubkey derivation **== canonical BIP340 vector** (seckey 3 → `f9308a…036f9`)
- raw shared-X **== `cryptography`'s SECP256K1 ECDH** (a second, unrelated implementation) + symmetry
- sign→verify round-trips through the production verify gate; a **1-bit-flipped sig is rejected** (the F-11 INFO-event forgery gate stays sound)
- NIP-04 encrypt/decrypt round-trips

The existing NWC asymmetric tests were `importorskip`'d on `secp256k1` and **never actually ran locally**; they now run under coincurve. **Full suite: 385 passed, 6 skipped.** NWC pubkey derivation now works on Windows (this box) where it previously raised ImportError.

## Notes
- Independent of the out-of-band confirmation PR #38 (different files) — can merge in either order.
- No version bump. Ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)