### PR TITLE
release: 1.12.12 — serverInfo version, .NET stdout hygiene, NWC-install docs

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,9 +12,11 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.11</Version>
-    <AssemblyVersion>1.9.0.0</AssemblyVersion>
-    <FileVersion>1.9.0.0</FileVersion>
+    <Version>1.12.12</Version>
+    <!-- Track Version so the assembly/file version (read by the MCP serverInfo handshake
+         and the startup banner) never drifts from the package version. Bump <Version> only. -->
+    <AssemblyVersion>$(Version)</AssemblyVersion>
+    <FileVersion>$(Version)</FileVersion>
     <Authors>Lightning Enable</Authors>
     <Company>Lightning Enable</Company>
     <Product>Lightning Enable MCP Server</Product>

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -1,6 +1,7 @@
 using LightningEnable.Mcp.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 
 namespace LightningEnable.Mcp;
@@ -69,6 +70,17 @@ public class Program
         });
 
         var builder = Host.CreateApplicationBuilder(args);
+
+        // MCP stdio uses stdout EXCLUSIVELY for JSON-RPC frames. The default Generic Host
+        // console logger (and the Hosting.Lifetime "Application started / Content root path"
+        // banner) write to stdout, which interleaves non-JSON lines into the protocol stream
+        // and desyncs strict MCP clients. Force ALL console log output to stderr, and drop the
+        // lifetime status banner entirely so stdout carries nothing but JSON-RPC.
+        builder.Logging.AddConsole(consoleOptions =>
+        {
+            consoleOptions.LogToStandardErrorThreshold = LogLevel.Trace;
+        });
+        builder.Services.Configure<ConsoleLifetimeOptions>(o => o.SuppressStatusMessages = true);
 
         // Register budget configuration FIRST (needed by wallet services for config file fallback)
         builder.Services.AddSingleton<IBudgetConfigurationService, BudgetConfigurationService>();

--- a/python/lightning-enable-mcp/README.md
+++ b/python/lightning-enable-mcp/README.md
@@ -23,15 +23,9 @@ Lightning Enable MCP provides tools for AI agents (like Claude) to:
 pip install lightning-enable-mcp
 ```
 
-The base install works on **every platform, including Windows**, with no compiler toolchain. The `secp256k1` dependency is optional.
+The base install works on **every platform, including Windows**, with no compiler toolchain — and that now includes **NWC wallets** (Nostr Wallet Connect: CoinOS, CLINK, Alby Hub). The Schnorr/ECDH crypto NWC needs comes from `coincurve`, which ships prebuilt wheels for Linux, macOS, and Windows, so it installs as a normal base dependency with nothing to compile.
 
-**NWC wallets** (Nostr Wallet Connect: CoinOS, CLINK, Alby Hub) additionally require the `[nwc]` extra, which pulls in `secp256k1`:
-
-```bash
-pip install lightning-enable-mcp[nwc]
-```
-
-Strike, LND, and OpenNode wallets do **not** need the `[nwc]` extra. If you configure an NWC wallet without it, the server returns a clear error telling you to install `lightning-enable-mcp[nwc]`.
+> The old `[nwc]` extra (which pulled in the `secp256k1` C-extension, with no Windows wheel) is no longer required. `pip install lightning-enable-mcp[nwc]` still resolves for back-compat, but the extra is now empty — the base install already covers NWC.
 
 ### Using uvx (recommended for Claude Desktop)
 

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.11"
+version = "1.12.12"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/__init__.py
@@ -51,15 +51,17 @@ from .price_service import (
     sats_to_usd,
     usd_to_sats,
 )
-from .server import LightningEnableServer, main
-
 # Derive __version__ from installed package metadata so it can never drift from
 # pyproject.toml (which is the single source of truth). Fall back to a sentinel when
 # running directly from an uninstalled source checkout (e.g., without pip install).
+# Defined BEFORE the .server import because server.py reads __version__ at import time
+# (to report it in the MCP serverInfo handshake) — reordering avoids a circular import.
 try:
     __version__ = _pkg_version("lightning-enable-mcp")
 except _PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0+unknown"
+
+from .server import LightningEnableServer, main
 
 __all__ = [
     # Server

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -12,13 +12,12 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-
-from . import __version__
 from mcp.types import (
     Tool,
     TextContent,
 )
 
+from . import __version__
 from .budget_service import BudgetService, get_budget_service
 from .payment_history_service import (
     PaymentHistoryService,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -12,6 +12,8 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
+
+from . import __version__
 from mcp.types import (
     Tool,
     TextContent,
@@ -81,7 +83,7 @@ class LightningEnableServer:
     """MCP Server for L402 Lightning payments."""
 
     def __init__(self) -> None:
-        self.server = Server("lightning-enable")
+        self.server = Server("lightning-enable", version=__version__)
         self.wallet: LndWallet | NWCWallet | OpenNodeWallet | StrikeWallet | None = None
         self.strike_wallet: StrikeWallet | None = None  # For Strike-specific features
         self.l402_client: L402Client | None = None


### PR DESCRIPTION
## 1.12.12 release

Cut after a full pre-publish smoke test of **both** flavors (built the wheel + nupkg, installed from the artifacts into isolated environments, drove a real MCP stdio `initialize` + `tools/list` handshake). The smoke test surfaced three real issues, all fixed here.

### Verified by smoke (both flavors)
- Install from built artifact ✅ (Python incl. coincurve, no build toolchain; .NET isolated tool-path)
- Boots + MCP handshake ✅
- `tools/list` → **23 tools** ✅ (parity)
- Read-only tool calls execute with correct/graceful responses ✅

### Fixes found during smoke
1. **serverInfo.version was wrong on both flavors.** Python reported the `mcp` SDK version (`1.27.2`) — `Server()` had no version arg; now passes `__version__`. .NET reported `1.9.0.0` — `AssemblyVersion`/`FileVersion` had drifted from `<Version>`; now track `$(Version)`. Verified post-fix: both report `1.12.12`.
2. **.NET stdout protocol pollution.** The Generic Host console logger + `Hosting.Lifetime` banner wrote to stdout, which MCP stdio reserves for JSON-RPC frames — the intermittent strict-client desync/hang. Routed all console logging to stderr + suppressed the lifetime banner. Verified: stdout non-JSON lines **16 → 0**. (Python was already clean.)
3. **Stale README install instructions.** Still claimed NWC needs the `[nwc]` extra / `secp256k1`; false since the coincurve swap — NWC now works out-of-the-box.

### Tests
- Python: 452 passed / 4 skipped
- .NET: 272 passed

Merging this bumps the version → triggers `publish-mcp.yml` (NuGet / PyPI / Docker Hub / MCP Registry).
