### PR TITLE
fix(ci): unblock 1.12.12 publish — version-grep matched a csproj comment

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -60,7 +60,8 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/mcp-v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/mcp-v}"
           else
-            VERSION=$(grep -oP '(?<=<Version>)[^<]+' dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj)
+            # First <Version> match only — defends against the tag appearing in comments.
+            VERSION=$(grep -oP '(?<=<Version>)[^<]+' dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj | head -n1)
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"

--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -13,8 +13,10 @@
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
     <Version>1.12.12</Version>
-    <!-- Track Version so the assembly/file version (read by the MCP serverInfo handshake
-         and the startup banner) never drifts from the package version. Bump <Version> only. -->
+    <!-- Track the package version so the assembly/file version (read by the MCP serverInfo
+         handshake and the startup banner) never drifts. Bump the package version only.
+         NOTE: keep the literal version-tag text out of this comment — the publish workflow
+         greps this file for it. -->
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Authors>Lightning Enable</Authors>


### PR DESCRIPTION
The 1.12.12 publish run failed at the version-extraction step: a comment I added to the csproj contained the literal version-tag text, so the workflow's `grep -oP '(?<=<Version>)[^<]+'` returned two lines and broke `$GITHUB_OUTPUT`. **Nothing was published** (failure preceded every build/publish step; NuGet/PyPI/Docker/Registry untouched).

Fix: reword the comment to drop the literal tag **and** add `| head -n1` to the grep (defense in depth). Merging re-triggers `publish-mcp.yml` (csproj is in its `paths` filter); version stays 1.12.12 for a clean retry.