### PR TITLE
fix(security): bind confirmation codes to destination — anti-redirect (#21)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/Models/PendingConfirmation.cs
+++ b/dotnet/src/LightningEnable.Mcp/Models/PendingConfirmation.cs
@@ -27,9 +27,18 @@ public record PendingConfirmation
     public string ToolName { get; init; } = string.Empty;
 
     /// <summary>
-    /// Human-readable description of the payment (URL, invoice prefix, etc.).
+    /// Human-readable description of the payment (URL, invoice prefix, etc.). May be
+    /// redacted/truncated for display — do NOT use it for binding; use <see cref="Destination"/>.
     /// </summary>
     public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The exact payment target this confirmation authorizes — the BOLT11 invoice
+    /// (pay_invoice / pay_l402_challenge), the resource URL (access_l402_resource), or the
+    /// on-chain address (send_onchain). Bound and checked on consume so a code can never be
+    /// redirected to a different destination (#21). Distinct from <see cref="Description"/>.
+    /// </summary>
+    public string Destination { get; init; } = string.Empty;
 
     /// <summary>
     /// When this confirmation was created.

--- a/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/BudgetService.cs
@@ -354,7 +354,7 @@ public class BudgetService : IBudgetService
         }
     }
 
-    public PendingConfirmation CreatePendingConfirmation(long amountSats, decimal amountUsd, string toolName, string description)
+    public PendingConfirmation CreatePendingConfirmation(long amountSats, decimal amountUsd, string toolName, string description, string destination)
     {
         lock (_lock)
         {
@@ -369,6 +369,7 @@ public class BudgetService : IBudgetService
                 AmountUsd = amountUsd,
                 ToolName = toolName,
                 Description = description,
+                Destination = (destination ?? string.Empty).Trim(),
                 CreatedAt = DateTime.UtcNow,
                 ExpiresAt = DateTime.UtcNow.AddMinutes(2)
             };
@@ -398,7 +399,7 @@ public class BudgetService : IBudgetService
         }
     }
 
-    public PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats, string expectedToolName)
+    public PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats, string expectedToolName, string expectedDestination)
     {
         if (string.IsNullOrWhiteSpace(nonce))
             return null;
@@ -423,8 +424,13 @@ public class BudgetService : IBudgetService
                 return null;
             if (!string.Equals(confirmation.ToolName, expectedToolName, StringComparison.Ordinal))
                 return null;
+            // #21 anti-redirect: bind to the EXACT destination too. A code approved to pay
+            // invoice/URL/address X must never authorize paying a different one (compared
+            // after trimming, mirroring how the destination was stored).
+            if (!string.Equals(confirmation.Destination, (expectedDestination ?? string.Empty).Trim(), StringComparison.Ordinal))
+                return null;
 
-            // Amount + tool match — consume (one-time use).
+            // Amount + tool + destination match — consume (one-time use).
             _pendingConfirmations.Remove(nonce);
             return confirmation;
         }

--- a/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/IBudgetService.cs
@@ -77,9 +77,10 @@ public interface IBudgetService
     /// <param name="amountSats">Payment amount in satoshis.</param>
     /// <param name="amountUsd">Payment amount in USD (for display).</param>
     /// <param name="toolName">Which tool requested confirmation.</param>
-    /// <param name="description">Human-readable description (URL, invoice prefix).</param>
+    /// <param name="description">Human-readable description (URL, invoice prefix) — for display only.</param>
+    /// <param name="destination">The exact payment target (invoice / URL / on-chain address); bound and checked on consume so the code cannot be redirected (#21).</param>
     /// <returns>The pending confirmation with its nonce code.</returns>
-    PendingConfirmation CreatePendingConfirmation(long amountSats, decimal amountUsd, string toolName, string description);
+    PendingConfirmation CreatePendingConfirmation(long amountSats, decimal amountUsd, string toolName, string description, string destination);
 
     /// <summary>
     /// Validates a nonce and checks expiry WITHOUT consuming it.
@@ -101,8 +102,9 @@ public interface IBudgetService
     /// <param name="nonce">The confirmation code.</param>
     /// <param name="expectedAmountSats">The amount about to be paid; must equal the approved amount.</param>
     /// <param name="expectedToolName">The tool consuming the code; must equal the tool the confirmation was created for (prevents cross-tool replay).</param>
-    /// <returns>The confirmed pending confirmation, or null if invalid / amount- or tool-mismatched.</returns>
-    PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats, string expectedToolName);
+    /// <param name="expectedDestination">The payment target about to be paid; must equal the approved destination (#21 anti-redirect). Compared after trimming.</param>
+    /// <returns>The confirmed pending confirmation, or null if invalid / amount-, tool-, or destination-mismatched.</returns>
+    PendingConfirmation? ValidateAndConsumeConfirmation(string nonce, long expectedAmountSats, string expectedToolName, string expectedDestination);
 
     /// <summary>
     /// Purges expired pending confirmations from memory.

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -122,16 +122,17 @@ public static class AccessL402ResourceTool
                 // Check if a confirmed nonce was provided
                 if (!string.IsNullOrWhiteSpace(confirmationNonce))
                 {
-                    var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "access_l402_resource");
+                    var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "access_l402_resource", url);
                     if (confirmation == null)
                     {
                         return JsonSerializer.Serialize(new
                         {
                             success = false,
                             error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
-                                    "request's amount and tool. Codes are bound to the exact amount + tool approved.",
+                                    "request's amount, tool, and URL. Codes are bound to the exact amount, tool, and " +
+                                    "destination approved — a code cannot be redirected to a different URL.",
                             message = "The code may have expired (2-minute limit), been used already, or been issued for a " +
-                                      "different amount/tool. Request a new confirmation by calling access_l402_resource without a confirmationNonce."
+                                      "different amount/tool/URL. Request a new confirmation by calling access_l402_resource without a confirmationNonce."
                         });
                     }
 
@@ -156,7 +157,8 @@ public static class AccessL402ResourceTool
                             maxSats,
                             approvalResult.AmountUsd,
                             "access_l402_resource",
-                            urlDisplay);
+                            urlDisplay,
+                            url);
 
                         // OUT-OF-BAND CONFIRMATION: code to STDERR only (human sees the server
                         // console/logs; the model only sees tool results). An injected agent

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayInvoiceTool.cs
@@ -124,16 +124,17 @@ public static class PayInvoiceTool
                     // Check if a confirmed nonce was provided
                     if (!string.IsNullOrWhiteSpace(confirmationNonce))
                     {
-                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "pay_invoice");
+                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "pay_invoice", normalizedInvoice);
                         if (confirmation == null)
                         {
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
                                 error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
-                                        "payment's amount and tool. Codes are bound to the exact amount + tool approved.",
+                                        "payment's amount, tool, and invoice. Codes are bound to the exact amount, tool, and " +
+                                        "destination approved — a code cannot be redirected to a different invoice.",
                                 message = "The code may have expired (2-minute limit), been used already, or been issued for a " +
-                                          "different amount/tool. Request a new confirmation by calling pay_invoice without a confirmationNonce."
+                                          "different amount/tool/invoice. Request a new confirmation by calling pay_invoice without a confirmationNonce."
                             });
                         }
 
@@ -159,7 +160,8 @@ public static class PayInvoiceTool
                                 amountSats.Value,
                                 approvalResult.AmountUsd,
                                 "pay_invoice",
-                                invoicePrefix);
+                                invoicePrefix,
+                                normalizedInvoice);
 
                             // OUT-OF-BAND CONFIRMATION: the code is written to STDERR only —
                             // the human sees the server console/logs; the model does NOT (it

--- a/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/PayL402ChallengeTool.cs
@@ -92,16 +92,17 @@ public static class PayL402ChallengeTool
                     // Check if a confirmed nonce was provided
                     if (!string.IsNullOrWhiteSpace(confirmationNonce))
                     {
-                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "pay_l402_challenge");
+                        var confirmation = budgetService.ValidateAndConsumeConfirmation(confirmationNonce.Trim().ToUpperInvariant(), approvalResult.AmountSats, "pay_l402_challenge", normalizedInvoice);
                         if (confirmation == null)
                         {
                             return JsonSerializer.Serialize(new
                             {
                                 success = false,
                                 error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
-                                        "payment's amount and tool. Codes are bound to the exact amount + tool approved.",
+                                        "payment's amount, tool, and invoice. Codes are bound to the exact amount, tool, and " +
+                                        "destination approved — a code cannot be redirected to a different invoice.",
                                 message = "The code may have expired (2-minute limit), been used already, or been issued for a " +
-                                          "different amount/tool. Request a new confirmation by calling pay_l402_challenge without a confirmationNonce."
+                                          "different amount/tool/invoice. Request a new confirmation by calling pay_l402_challenge without a confirmationNonce."
                             });
                         }
 
@@ -126,7 +127,8 @@ public static class PayL402ChallengeTool
                                 budgetCheckAmount,
                                 approvalResult.AmountUsd,
                                 "pay_l402_challenge",
-                                invoicePrefix);
+                                invoicePrefix,
+                                normalizedInvoice);
 
                             // OUT-OF-BAND CONFIRMATION: code to STDERR only (human sees the server
                             // console/logs; the model only sees tool results). An injected agent

--- a/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/SendOnChainTool.cs
@@ -117,14 +117,15 @@ public static class SendOnChainTool
             if (!string.IsNullOrWhiteSpace(confirmationNonce))
             {
                 var confirmation = budgetService.ValidateAndConsumeConfirmation(
-                    confirmationNonce.Trim().ToUpperInvariant(), amountSats, "send_onchain");
+                    confirmationNonce.Trim().ToUpperInvariant(), amountSats, "send_onchain", address);
                 if (confirmation == null)
                 {
                     return JsonSerializer.Serialize(new
                     {
                         success = false,
                         error = "Confirmation code is invalid, expired, already used, or does not match THIS " +
-                                "send's amount and tool. Codes are bound to the exact amount + tool they were approved for.",
+                                "send's amount, tool, and address. Codes are bound to the exact amount, tool, and " +
+                                "destination they were approved for — a code cannot be redirected to a different address.",
                         message = "Request a fresh confirmation by calling send_onchain again without a confirmationNonce, then supply the new code."
                     });
                 }
@@ -133,7 +134,7 @@ public static class SendOnChainTool
             else
             {
                 var pending = budgetService.CreatePendingConfirmation(
-                    amountSats, approval.AmountUsd, "send_onchain", address);
+                    amountSats, approval.AmountUsd, "send_onchain", address, address);
 
                 // Code to STDERR only — the human sees it; the model never does.
                 Console.Error.WriteLine(

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/BudgetServiceTests.cs
@@ -672,22 +672,44 @@ public class BudgetServiceTests
     {
         SetupConfigurationWithLimits(500m, 100m);
         var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
-        var pending = service.CreatePendingConfirmation(1000, 0.01m, "pay_invoice", "inv...");
+        var pending = service.CreatePendingConfirmation(1000, 0.01m, "pay_invoice", "inv...", "lnbc-dest");
 
-        // Wrong AMOUNT (right tool) → rejected; a 1,000-sat approval can't authorize 1,000,000.
-        service.ValidateAndConsumeConfirmation(pending.Nonce, 1_000_000, "pay_invoice").Should().BeNull();
+        // Wrong AMOUNT (right tool + dest) → rejected; a 1,000-sat approval can't authorize 1,000,000.
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1_000_000, "pay_invoice", "lnbc-dest").Should().BeNull();
 
-        // Wrong TOOL (right amount) → rejected; a pay_invoice code can't authorize send_onchain
+        // Wrong TOOL (right amount + dest) → rejected; a pay_invoice code can't authorize send_onchain
         // (no cross-tool replay).
-        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "send_onchain").Should().BeNull();
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "send_onchain", "lnbc-dest").Should().BeNull();
 
-        // Neither mismatch consumed the nonce — the correct (amount, tool) still works.
-        var ok = service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice");
+        // Neither mismatch consumed the nonce — the correct (amount, tool, dest) still works.
+        var ok = service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice", "lnbc-dest");
         ok.Should().NotBeNull();
         ok!.AmountSats.Should().Be(1000);
 
         // One-time use: a second consume fails.
-        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice").Should().BeNull();
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice", "lnbc-dest").Should().BeNull();
+    }
+
+    [Fact]
+    public void Confirmation_BoundToDestination_RejectsRedirect_AndNonceNotConsumed()
+    {
+        // #21 anti-redirect: a code approved to pay destination X (invoice / URL / on-chain
+        // address) must never authorize a payment to a DIFFERENT destination, even when the
+        // amount and tool match. A mismatch must NOT consume the code.
+        SetupConfigurationWithLimits(500m, 100m);
+        var service = new BudgetService(_configServiceMock.Object, _priceServiceMock.Object);
+        var pending = service.CreatePendingConfirmation(1000, 0.01m, "pay_invoice", "lnbc1...AAA", "lnbc1aaa");
+        pending.Destination.Should().Be("lnbc1aaa");
+
+        // Same amount + tool, DIFFERENT destination → rejected (the redirect attack).
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice", "lnbc1bbb").Should().BeNull();
+
+        // Whitespace-only difference is tolerated (trim).
+        var ok = service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice", "  lnbc1aaa  ");
+        ok.Should().NotBeNull();
+
+        // Consumed once → gone.
+        service.ValidateAndConsumeConfirmation(pending.Nonce, 1000, "pay_invoice", "lnbc1aaa").Should().BeNull();
     }
 
     #endregion

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/L402ToolsTests.cs
@@ -191,7 +191,7 @@ public class L402ToolsTests
                 RemainingSessionBudgetUsd = 95.00m
             });
         budgetServiceMock.Setup(b => b.CreatePendingConfirmation(
-                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new PendingConfirmation
             {
                 Nonce = "L4C123",
@@ -241,7 +241,7 @@ public class L402ToolsTests
                 RemainingSessionBudgetUsd = 97.50m
             });
         budgetServiceMock.Setup(b => b.CreatePendingConfirmation(
-                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new PendingConfirmation
             {
                 Nonce = "PLC456",

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/PayInvoiceToolTests.cs
@@ -544,7 +544,7 @@ public class PayInvoiceToolTests
                 RemainingSessionBudgetUsd = 95.00m
             });
         _budgetServiceMock.Setup(b => b.CreatePendingConfirmation(
-                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new PendingConfirmation
             {
                 Nonce = "ABC123",

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/SendOnChainToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/SendOnChainToolTests.cs
@@ -28,7 +28,7 @@ public class SendOnChainToolTests
         budget.Setup(b => b.CheckApprovalLevelAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ApprovalCheckResult { Level = ApprovalLevel.AutoApprove, AmountSats = 5000, AmountUsd = 0.05m });
         budget.Setup(b => b.CreatePendingConfirmation(
-                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>()))
+                It.IsAny<long>(), It.IsAny<decimal>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns(new PendingConfirmation
             {
                 Nonce = "ONCH99",

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/budget_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/budget_service.py
@@ -75,6 +75,12 @@ class PendingConfirmation:
     amount_usd: Decimal
     tool_name: str
     description: str
+    # The exact payment target the code authorizes — the BOLT11 invoice (pay_invoice /
+    # pay_l402_challenge), the resource URL (access_l402_resource / settle_agent_service),
+    # or the on-chain address (send_onchain). Bound and checked on consume so a code can
+    # never be redirected to a different destination (#21). Distinct from `description`,
+    # which is a display string and may be redacted/truncated.
+    destination: str
     created_at: datetime
     expires_at: datetime
 
@@ -453,8 +459,13 @@ class BudgetService:
         amount_usd: Decimal,
         tool_name: str,
         description: str,
+        destination: str,
     ) -> PendingConfirmation:
-        """Create a pending confirmation with a crypto-random code, bound to amount + tool.
+        """Create a pending confirmation with a crypto-random code, bound to amount + tool
+        + destination.
+
+        ``destination`` is the exact payment target (invoice / URL / on-chain address); it is
+        checked on consume so an approved code can never be redirected elsewhere (#21).
 
         The caller (a pay tool) MUST print the returned ``nonce`` to STDERR ONLY and MUST
         NOT include it in the tool result — that is what stops a prompt-injected agent from
@@ -475,6 +486,7 @@ class BudgetService:
                 amount_usd=amount_usd,
                 tool_name=tool_name,
                 description=description,
+                destination=(destination or "").strip(),
                 created_at=now,
                 expires_at=now + timedelta(minutes=2),
             )
@@ -502,13 +514,14 @@ class BudgetService:
         nonce: str,
         expected_amount_sats: int,
         expected_tool_name: str,
+        expected_destination: str,
     ) -> Optional[PendingConfirmation]:
-        """Validate a code, check expiry, verify it matches the amount AND tool about to be
-        paid, then consume it (one-time use).
+        """Validate a code, check expiry, verify it matches the amount AND tool AND
+        destination about to be paid, then consume it (one-time use).
 
-        Returns None if invalid, expired, already used, or the amount/tool does not match.
-        On an amount/tool MISMATCH the code is NOT consumed (a correct retry still works),
-        so a code approved for one (amount, tool) can never authorize a different one.
+        Returns None if invalid, expired, already used, or the amount/tool/destination does
+        not match. On a MISMATCH the code is NOT consumed (a correct retry still works), so a
+        code approved for one (amount, tool, destination) can never authorize a different one.
         """
         if not nonce:
             return None
@@ -524,7 +537,11 @@ class BudgetService:
                 return None
             if pc.tool_name != expected_tool_name:
                 return None
-            # Amount + tool match -> consume (one-time use).
+            # #21 anti-redirect: bind to the EXACT destination too. A code approved to pay
+            # invoice/URL/address X must never authorize paying a different one.
+            if pc.destination != (expected_destination or "").strip():
+                return None
+            # Amount + tool + destination match -> consume (one-time use).
             self._pending_confirmations.pop(nonce, None)
             return pc
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/access_resource.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/access_resource.py
@@ -125,24 +125,26 @@ async def access_l402_resource(
                 url_display = _redact_url_for_display(url)
                 if confirmation_nonce:
                     confirmation = budget_service.validate_and_consume_confirmation(
-                        confirmation_nonce.strip().upper(), max_sats, "access_l402_resource"
+                        confirmation_nonce.strip().upper(), max_sats, "access_l402_resource", url
                     )
                     if confirmation is None:
                         return json.dumps({
                             "success": False,
                             "error": (
                                 "Confirmation code is invalid, expired, already used, or does not match THIS "
-                                "request's amount and tool. Codes are bound to the exact amount + tool approved."
+                                "request's amount, tool, and URL. Codes are bound to the exact amount, tool, and "
+                                "destination approved — a code cannot be redirected to a different URL."
                             ),
                             "message": (
                                 "Ask the human operator for the code shown in the server console, then call "
                                 "access_l402_resource again with confirmation_nonce set to it."
                             ),
                         })
-                    # Human-relayed code validated (amount + tool bound) — fall through.
+                    # Human-relayed code validated (amount + tool + URL bound) — fall through.
                 else:
                     pending = budget_service.create_pending_confirmation(
-                        max_sats, result.amount_usd, "access_l402_resource", url_display
+                        max_sats, result.amount_usd, "access_l402_resource", url_display,
+                        destination=url,
                     )
                     print(
                         "[Lightning Enable] *** L402 PAYMENT CONFIRMATION REQUIRED ***\n"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_challenge.py
@@ -116,24 +116,26 @@ async def pay_l402_challenge(
                 inv_prefix = invoice[:30] + "..."
                 if confirmation_nonce:
                     confirmation = budget_service.validate_and_consume_confirmation(
-                        confirmation_nonce.strip().upper(), amount_sats, "pay_l402_challenge"
+                        confirmation_nonce.strip().upper(), amount_sats, "pay_l402_challenge", invoice
                     )
                     if confirmation is None:
                         return json.dumps({
                             "success": False,
                             "error": (
                                 "Confirmation code is invalid, expired, already used, or does not match THIS "
-                                "payment's amount and tool. Codes are bound to the exact amount + tool approved."
+                                "payment's amount, tool, and invoice. Codes are bound to the exact amount, tool, "
+                                "and destination approved — a code cannot be redirected to a different invoice."
                             ),
                             "message": (
                                 "Ask the human operator for the code shown in the server console, then call "
                                 "pay_l402_challenge again with confirmation_nonce set to it."
                             ),
                         })
-                    # Human-relayed code validated — fall through and pay.
+                    # Human-relayed code validated (amount + tool + invoice bound) — fall through and pay.
                 else:
                     pending = budget_service.create_pending_confirmation(
-                        amount_sats, approval.amount_usd, "pay_l402_challenge", inv_prefix
+                        amount_sats, approval.amount_usd, "pay_l402_challenge", inv_prefix,
+                        destination=invoice,
                     )
                     print(
                         "[Lightning Enable] *** L402 CHALLENGE PAYMENT CONFIRMATION REQUIRED ***\n"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_invoice.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/pay_invoice.py
@@ -138,24 +138,26 @@ async def pay_invoice(
             if result.requires_confirmation:
                 if confirmation_nonce:
                     confirmation = budget_service.validate_and_consume_confirmation(
-                        confirmation_nonce.strip().upper(), amount_sats, "pay_invoice"
+                        confirmation_nonce.strip().upper(), amount_sats, "pay_invoice", normalized_invoice
                     )
                     if confirmation is None:
                         return json.dumps({
                             "success": False,
                             "error": (
                                 "Confirmation code is invalid, expired, already used, or does not match THIS "
-                                "payment's amount and tool. Codes are bound to the exact amount + tool approved."
+                                "payment's amount, tool, and invoice. Codes are bound to the exact amount, tool, "
+                                "and destination approved — a code cannot be redirected to a different invoice."
                             ),
                             "message": (
                                 "Ask the human operator for the code shown in the server console, then call "
                                 "pay_invoice again with confirmation_nonce set to it."
                             ),
                         })
-                    # Human-relayed code validated (amount + tool bound) — fall through and pay.
+                    # Human-relayed code validated (amount + tool + invoice bound) — fall through and pay.
                 else:
                     pending = budget_service.create_pending_confirmation(
-                        amount_sats, result.amount_usd, "pay_invoice", normalized_invoice[:30] + "..."
+                        amount_sats, result.amount_usd, "pay_invoice", normalized_invoice[:30] + "...",
+                        destination=normalized_invoice,
                     )
                     print(
                         "[Lightning Enable] *** PAYMENT CONFIRMATION REQUIRED ***\n"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/send_onchain.py
@@ -123,20 +123,21 @@ async def send_onchain(
     address = address.strip()
     if confirmation_nonce:
         confirmation = budget_service.validate_and_consume_confirmation(
-            confirmation_nonce.strip().upper(), amount_sats, "send_onchain"
+            confirmation_nonce.strip().upper(), amount_sats, "send_onchain", address
         )
         if confirmation is None:
             return json.dumps({
                 "success": False,
                 "error": "Confirmation code is invalid, expired, already used, or does not match THIS "
-                         "send's amount and tool. Codes are bound to the exact amount + tool approved.",
+                         "send's amount, tool, and address. Codes are bound to the exact amount, tool, and "
+                         "destination approved — a code cannot be redirected to a different address.",
                 "message": "Ask the human operator for the code shown in the server console, then call "
                            "send_onchain again with confirmation_nonce set to it.",
             })
-        # Human-relayed code validated (amount + tool bound) — fall through and send.
+        # Human-relayed code validated (amount + tool + address bound) — fall through and send.
     else:
         pending = budget_service.create_pending_confirmation(
-            amount_sats, budget_result.amount_usd, "send_onchain", address
+            amount_sats, budget_result.amount_usd, "send_onchain", address, destination=address
         )
         print(
             "[Lightning Enable] *** ON-CHAIN SEND CONFIRMATION REQUIRED (irreversible) ***\n"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/settle_agent_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/settle_agent_service.py
@@ -125,24 +125,26 @@ async def settle_agent_service(
                 )
                 if confirmation_nonce:
                     confirmation = budget_service.validate_and_consume_confirmation(
-                        confirmation_nonce.strip().upper(), max_sats, "settle_agent_service"
+                        confirmation_nonce.strip().upper(), max_sats, "settle_agent_service", l402_endpoint
                     )
                     if confirmation is None:
                         return json.dumps({
                             "success": False,
                             "error": (
                                 "Confirmation code is invalid, expired, already used, or does not match THIS "
-                                "settlement's amount and tool. Codes are bound to the exact amount + tool approved."
+                                "settlement's amount, tool, and endpoint. Codes are bound to the exact amount, tool, "
+                                "and destination approved — a code cannot be redirected to a different endpoint."
                             ),
                             "message": (
                                 "Ask the human operator for the code shown in the server console, then call "
                                 "settle_agent_service again with confirmation_nonce set to it."
                             ),
                         })
-                    # Human-relayed code validated (amount + tool bound) — fall through and settle.
+                    # Human-relayed code validated (amount + tool + endpoint bound) — fall through and settle.
                 else:
                     pending = budget_service.create_pending_confirmation(
-                        max_sats, result.amount_usd, "settle_agent_service", endpoint_display
+                        max_sats, result.amount_usd, "settle_agent_service", endpoint_display,
+                        destination=l402_endpoint,
                     )
                     print(
                         "[Lightning Enable] *** L402 SETTLEMENT CONFIRMATION REQUIRED ***\n"

--- a/python/lightning-enable-mcp/tests/test_budget_service_confirmation.py
+++ b/python/lightning-enable-mcp/tests/test_budget_service_confirmation.py
@@ -20,7 +20,7 @@ def _service() -> BudgetService:
 
 def test_create_pending_confirmation_generates_code_and_peek_does_not_consume():
     svc = _service()
-    pc = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "inv...")
+    pc = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "inv...", destination="d")
 
     assert pc.nonce and len(pc.nonce) == 6
     assert pc.amount_sats == 1000
@@ -32,40 +32,59 @@ def test_create_pending_confirmation_generates_code_and_peek_does_not_consume():
 
 def test_confirmation_bound_to_amount_and_tool_and_not_consumed_on_mismatch():
     svc = _service()
-    pc = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "inv...")
+    pc = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "inv...", destination="lnbc-dest")
 
-    # Wrong AMOUNT (right tool) -> rejected; a 1,000-sat approval can't authorize 1,000,000.
-    assert svc.validate_and_consume_confirmation(pc.nonce, 1_000_000, "pay_invoice") is None
-    # Wrong TOOL (right amount) -> rejected; a pay_invoice code can't move send_onchain funds.
-    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "send_onchain") is None
+    # Wrong AMOUNT (right tool + dest) -> rejected; a 1,000-sat approval can't authorize 1,000,000.
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1_000_000, "pay_invoice", "lnbc-dest") is None
+    # Wrong TOOL (right amount + dest) -> rejected; a pay_invoice code can't move send_onchain funds.
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "send_onchain", "lnbc-dest") is None
 
     # Neither mismatch consumed it — the correct (amount, tool) still works.
-    ok = svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice")
+    ok = svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice", "lnbc-dest")
     assert ok is pc
     # One-time use: a second consume fails.
-    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice") is None
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice", "lnbc-dest") is None
+
+
+def test_confirmation_bound_to_destination_and_not_consumed_on_mismatch():
+    """#21 anti-redirect: a code approved for one destination (invoice / URL / on-chain
+    address) must not authorize a payment to a DIFFERENT destination, even when the amount
+    and tool match. A mismatch must NOT consume the code, so the legitimate retry still works.
+    """
+    svc = _service()
+    pc = svc.create_pending_confirmation(
+        1000, Decimal("0.01"), "pay_invoice", "lnbc1...AAA", destination="lnbc1aaa"
+    )
+    assert pc.destination == "lnbc1aaa"
+
+    # Same amount + tool, but a DIFFERENT destination -> rejected (the redirect attack).
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice", "lnbc1bbb") is None
+    # Whitespace-only difference is tolerated (trim), not a bypass either way.
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice", "  lnbc1aaa  ") is pc
+    # Consumed once -> gone.
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice", "lnbc1aaa") is None
 
 
 def test_expired_confirmation_is_rejected():
     svc = _service()
-    pc = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "inv...")
+    pc = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "inv...", destination="d")
     pc.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)  # force expiry
 
     assert svc.validate_confirmation(pc.nonce) is None
-    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice") is None
+    assert svc.validate_and_consume_confirmation(pc.nonce, 1000, "pay_invoice", "d") is None
 
 
 def test_create_pending_confirmation_regenerates_on_collision(monkeypatch):
     import lightning_enable_mcp.budget_service as bs
 
     svc = _service()
-    existing = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "a")
+    existing = svc.create_pending_confirmation(1000, Decimal("0.01"), "pay_invoice", "a", destination="da")
 
     # Force the next code to first collide with the live one, then resolve to ZZZZZZ.
     seq = iter(list(existing.nonce) + list("ZZZZZZ"))
     monkeypatch.setattr(bs.secrets, "choice", lambda _chars: next(seq))
 
-    new = svc.create_pending_confirmation(2000, Decimal("0.02"), "send_onchain", "b")
+    new = svc.create_pending_confirmation(2000, Decimal("0.02"), "send_onchain", "b", destination="db")
     assert new.nonce == "ZZZZZZ"
     assert new.nonce != existing.nonce
     # The original human-approved confirmation must survive — never overwritten.
@@ -76,5 +95,5 @@ def test_blank_or_unknown_code_returns_none():
     svc = _service()
     assert svc.validate_confirmation("") is None
     assert svc.validate_confirmation("UNKNOWN") is None
-    assert svc.validate_and_consume_confirmation("", 1000, "pay_invoice") is None
-    assert svc.validate_and_consume_confirmation("NOPE12", 1000, "pay_invoice") is None
+    assert svc.validate_and_consume_confirmation("", 1000, "pay_invoice", "d") is None
+    assert svc.validate_and_consume_confirmation("NOPE12", 1000, "pay_invoice", "d") is None

--- a/python/lightning-enable-mcp/tests/test_confirm_payment.py
+++ b/python/lightning-enable-mcp/tests/test_confirm_payment.py
@@ -50,6 +50,7 @@ class TestConfirmPayment:
             amount_usd=Decimal("5.00"),
             tool_name="pay_invoice",
             description="Invoice payment",
+            destination="lnbc-test-invoice",
             created_at=now,
             expires_at=now + timedelta(minutes=2),
         )

--- a/python/lightning-enable-mcp/tests/test_pay_challenge.py
+++ b/python/lightning-enable-mcp/tests/test_pay_challenge.py
@@ -23,7 +23,7 @@ def _confirming_budget(code: str = "ABC123", sats: int = 10):
     now = datetime.now(timezone.utc)
     pc = PendingConfirmation(
         nonce=code, amount_sats=sats, amount_usd=Decimal("0.01"),
-        tool_name="pay_l402_challenge", description="lnbc...",
+        tool_name="pay_l402_challenge", description="lnbc...", destination="lnbc10n1pjtest",
         created_at=now, expires_at=now + timedelta(minutes=2),
     )
     budget.create_pending_confirmation = MagicMock(return_value=pc)
@@ -83,7 +83,7 @@ class TestPayL402ChallengeOutOfBandConfirmation:
 
         assert data["success"] is True
         assert data["preimage"] == "preimage123"
-        budget.validate_and_consume_confirmation.assert_called_once_with("ABC123", 10, "pay_l402_challenge")
+        budget.validate_and_consume_confirmation.assert_called_once_with("ABC123", 10, "pay_l402_challenge", "lnbc10n1pjtest")
         mock_wallet.pay_invoice.assert_called_once()
 
     @pytest.mark.asyncio
@@ -108,7 +108,7 @@ class TestPayL402ChallengeOutOfBandConfirmation:
         data = json.loads(result)
 
         assert data["success"] is False
-        assert "amount and tool" in data["error"]
+        assert "amount, tool, and invoice" in data["error"]
         mock_wallet.pay_invoice.assert_not_called()
 
 class TestPayL402ChallengeNoAmountRejection:

--- a/python/lightning-enable-mcp/tests/test_pay_invoice.py
+++ b/python/lightning-enable-mcp/tests/test_pay_invoice.py
@@ -300,7 +300,7 @@ def _confirming_budget(code: str = "ABC123", sats: int = 50000):
     now = datetime.now(timezone.utc)
     pc = PendingConfirmation(
         nonce=code, amount_sats=sats, amount_usd=Decimal("50.00"),
-        tool_name="pay_invoice", description="lnbc...",
+        tool_name="pay_invoice", description="lnbc...", destination="lnbc500u1pj9npjpp5...",
         created_at=now, expires_at=now + timedelta(minutes=2),
     )
     budget.create_pending_confirmation = MagicMock(return_value=pc)
@@ -356,7 +356,7 @@ class TestPayInvoiceOutOfBandConfirmation:
 
         assert data["success"] is True
         assert data["preimage"] == "preimage123"
-        budget.validate_and_consume_confirmation.assert_called_once_with("ABC123", 50000, "pay_invoice")
+        budget.validate_and_consume_confirmation.assert_called_once_with("ABC123", 50000, "pay_invoice", "lnbc500u1pj9npjpp5...")
         wallet.pay_invoice.assert_called_once()
 
     @pytest.mark.asyncio
@@ -377,7 +377,7 @@ class TestPayInvoiceOutOfBandConfirmation:
         data = json.loads(result)
 
         assert data["success"] is False
-        assert "amount and tool" in data["error"]
+        assert "amount, tool, and invoice" in data["error"]
         wallet.pay_invoice.assert_not_called()
 
 

--- a/python/lightning-enable-mcp/tests/test_send_onchain.py
+++ b/python/lightning-enable-mcp/tests/test_send_onchain.py
@@ -44,7 +44,7 @@ def _approving_budget(code: str = "ABC123"):
     now = datetime.now(timezone.utc)
     pc = PendingConfirmation(
         nonce=code, amount_sats=0, amount_usd=Decimal("5.00"),
-        tool_name="send_onchain", description=VALID_ADDR,
+        tool_name="send_onchain", description=VALID_ADDR, destination=VALID_ADDR,
         created_at=now, expires_at=now + timedelta(minutes=2),
     )
     budget.create_pending_confirmation = MagicMock(return_value=pc)

--- a/python/lightning-enable-mcp/tests/test_settle_agent_service.py
+++ b/python/lightning-enable-mcp/tests/test_settle_agent_service.py
@@ -172,7 +172,7 @@ class TestSettleAgentServiceBudget:
         )
         parsed = json.loads(result)
 
-        budget.validate_and_consume_confirmation.assert_called_once_with("ABC123", 500, "settle_agent_service")
+        budget.validate_and_consume_confirmation.assert_called_once_with("ABC123", 500, "settle_agent_service", "https://example.com/l402")
         assert parsed["success"] is True
         assert parsed["settlement"]["paid"] is True
         assert parsed["settlement"]["amountSats"] == 500


### PR DESCRIPTION
Closes the last funds-safety item: out-of-band confirmation codes were bound to **(amount, tool)** but not the payment target, so a prompt-injected agent could get a code approved for a cheap/benign call and then re-call the same tool + amount with a **different destination** to redirect the money. Now codes are bound to **(amount, tool, destination)**.

### Destination per tool
| Tool | Destination bound |
|------|-------------------|
| `pay_invoice` / `pay_l402_challenge` | the BOLT11 invoice |
| `access_l402_resource` | the resource URL |
| `settle_agent_service` (Python) | the settlement endpoint |
| `send_onchain` | the on-chain address |

### How
`PendingConfirmation` gains a `Destination` field, **distinct from the display `Description`** (which may be redacted/truncated). `validate_and_consume` compares the destination (trimmed, ordinal) and — like the existing amount/tool checks — **does not consume on mismatch**, so the legitimate retry still works. Mirrored in **.NET and Python**.

### Test-first
New service-level redirect test in each package (RED before the comparison, GREEN after). Existing confirmation tests + tool-call assertions updated to the new arity, and the tools' error text now names the destination binding.

- Python: **453 passed** / 4 skipped
- .NET: **273 passed**

**No version bump in this PR** — merging it does not trigger a publish (csproj/pyproject untouched). The 1.12.13 release stays a separate, gated step.