### PR TITLE
release: 1.12.13 — destination-bound confirmation codes (#21)

### DIFF
--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.12</Version>
+    <Version>1.12.13</Version>
     <!-- Track the package version so the assembly/file version (read by the MCP serverInfo
          handshake and the startup banner) never drifts. Bump the package version only.
          NOTE: keep the literal version-tag text out of this comment — the publish workflow

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.12"
+version = "1.12.13"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only — ships the **#21** anti-redirect hardening that already merged + passed Copilot review in #46.

**Pre-publish lightweight check (per the calibrated call that a full smoke wasn't warranted for a pure-internal change):**
- Full unit suites: Python **453** / .NET **273** green
- Fresh 1.12.13 artifacts build → install → boot → `tools/list`=**23** → `serverInfo`=**1.12.13** → stdout clean (both flavors)

Merging triggers `publish-mcp.yml` → NuGet / PyPI / Docker / MCP Registry.