### PR TITLE
docs: remove negotiation framing from ASA tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of [Lightning Enable](https://lightningenable.com) — infrastructure for a
 [![Discord](https://img.shields.io/discord/1405389254892195951?label=community&logo=discord&color=5865F2)](https://discord.gg/rX7NxHY8vx)
 
 
-An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 23 tools total: 15 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, negotiating, and settling services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
+An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 23 tools total: 15 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, requesting, settling, and attesting services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
 
 Available in **.NET** and **Python**.
 
@@ -144,7 +144,7 @@ These tools enable agent-to-agent commerce on Nostr:
 3. **Settle** — `settle_agent_service(l402_endpoint)` pays via Lightning and receives the result
 4. **Review** — `publish_agent_attestation(pubkey, agreement_id, rating=5)` builds on-protocol reputation
 
-For dynamic pricing, providers use `create_l402_challenge` to generate invoices at negotiated prices. Requesters pay and providers verify with `verify_l402_payment`.
+For dynamic pricing, providers use `create_l402_challenge` to generate invoices at the agreed price. Requesters pay and providers verify with `verify_l402_payment`.
 
 ## Related Projects
 

--- a/dotnet/src/LightningEnable.Mcp/Services/AgentService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/AgentService.cs
@@ -6,7 +6,7 @@ namespace LightningEnable.Mcp.Services;
 
 /// <summary>
 /// Service for Agent Service Agreement (ASA) operations on the Nostr network.
-/// Handles discovery, publishing, negotiation, and settlement of agent capabilities.
+/// Handles discovery, publishing, service requests, and settlement of agent capabilities.
 ///
 /// v1 implementation uses the Lightning Enable API for all operations.
 /// TODO: Add direct Nostr relay WebSocket support for discovery and publishing.

--- a/dotnet/src/LightningEnable.Mcp/Tools/AgentNegotiateTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AgentNegotiateTool.cs
@@ -7,17 +7,18 @@ namespace LightningEnable.Mcp.Tools;
 
 /// <summary>
 /// MCP tool for requesting a service from an agent.
-/// Sends a kind 38401 event referencing the provider's capability to start negotiation.
+/// Sends a kind 38401 event referencing the provider's capability.
 /// </summary>
 [McpServerToolType]
 public static class AgentNegotiateTool
 {
     /// <summary>
-    /// Requests a service from an agent, starting the negotiation process.
+    /// Requests a service from an agent by sending a kind 38401 event.
     /// </summary>
     [McpServerTool(Name = "request_agent_service"), Description(
-        "Request a service from an agent. Sends a kind 38401 event referencing the provider's capability. " +
-        "Starts the negotiation process. If the provider has an L402 endpoint, you can skip this step " +
+        "Sends a service request (kind 38401 event) referencing the provider's capability. " +
+        "The provider responds with agreement/settlement terms; settle via settle_agent_service. " +
+        "If the provider has an L402 endpoint, you can skip this step " +
         "and use settle_agent_service directly.")]
     public static async Task<string> RequestAgentService(
         [Description("Event ID of the capability to request")] string capabilityEventId,

--- a/dotnet/src/LightningEnable.Mcp/Tools/AgentSettleTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AgentSettleTool.cs
@@ -23,7 +23,7 @@ public static class AgentSettleTool
         "Uses the same L402 auto-pay flow as access_l402_resource. " +
         "The L402 endpoint URL comes from discover_agent_services or request_agent_service results. " +
         "NOTE: If you are the PROVIDER (selling a service), use create_l402_challenge to generate " +
-        "a Lightning invoice at the negotiated price, share it with the requester, then use " +
+        "a Lightning invoice at the agreed price, share it with the requester, then use " +
         "verify_l402_payment to confirm payment before delivering the service.")]
     public static async Task<string> SettleAgentService(
         [Description("L402 endpoint URL from the service agreement")] string l402Endpoint,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -551,8 +551,9 @@ class LightningEnableServer:
                 Tool(
                     name="request_agent_service",
                     description=(
-                        "Request a service from an agent. Sends a kind 38401 event referencing the provider's capability. "
-                        "Starts the negotiation process. If the provider has an L402 endpoint, you can skip this step "
+                        "Sends a service request (kind 38401 event) referencing the provider's capability. "
+                        "The provider responds with agreement/settlement terms; settle via settle_agent_service. "
+                        "If the provider has an L402 endpoint, you can skip this step "
                         "and use settle_agent_service directly. Requires LIGHTNING_ENABLE_API_KEY."
                     ),
                     inputSchema={
@@ -639,7 +640,7 @@ class LightningEnableServer:
                         "Uses the same L402 auto-pay flow as access_l402_resource. "
                         "The L402 endpoint URL comes from discover_agent_services or request_agent_service results. "
                         "NOTE: If you are the PROVIDER (selling a service), use create_l402_challenge to generate "
-                        "a Lightning invoice at the negotiated price, then verify_l402_payment to confirm payment "
+                        "a Lightning invoice at the agreed price, then verify_l402_payment to confirm payment "
                         "before delivering the service."
                     ),
                     inputSchema={

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/request_agent_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/request_agent_service.py
@@ -1,8 +1,9 @@
 """
 Request Agent Service Tool
 
-Sends a service request referencing a provider's capability (kind 38401 event),
-starting the negotiation process. Requires LIGHTNING_ENABLE_API_KEY.
+Sends a service request (kind 38401 event) referencing a provider's capability.
+The provider responds with agreement/settlement terms; settle via
+settle_agent_service. Requires LIGHTNING_ENABLE_API_KEY.
 
 NOTE: Budget is NOT deducted at request time by design. The budget is only
 deducted at settlement time (settle_agent_service) when the L402 payment is
@@ -31,9 +32,10 @@ async def request_agent_service(
     budget_service: "BudgetService | None" = None,
 ) -> str:
     """
-    Request a service from an agent. Sends a kind 38401 event referencing the
-    provider's capability and starts the negotiation process. If the provider
-    has an L402 endpoint, you can skip this step and use settle_agent_service.
+    Sends a service request (kind 38401 event) referencing the provider's
+    capability. The provider responds with agreement/settlement terms; settle
+    via settle_agent_service. If the provider has an L402 endpoint, you can
+    skip this step and use settle_agent_service directly.
 
     Args:
         capability_event_id: Event ID of the capability to request

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/settle_agent_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/settle_agent_service.py
@@ -8,7 +8,7 @@ transaction. Uses the SAME wallet + budget-gating flow as access_l402_resource
 does NOT use the Lightning Enable API key.
 
 For the PROVIDER side (selling a service), use create_l402_challenge to generate
-a Lightning invoice at the negotiated price, then verify_l402_payment to confirm
+a Lightning invoice at the agreed price, then verify_l402_payment to confirm
 payment before delivering the service.
 """
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -10,7 +10,7 @@
 # to keep in sync on every release.
 
 name: lightning-enable
-description: AI agent Lightning payments and commerce — invoices, L402, API discovery, budgets, ASA negotiation. 23 tools, 15 free, 8 unlock with a Lightning Enable API key.
+description: AI agent Lightning payments and commerce — invoices, L402, API discovery, budgets, agent service agreements. 23 tools, 15 free, 8 unlock with a Lightning Enable API key.
 author: Lightning Enable
 license: MIT
 repository: https://github.com/refined-element/lightning-enable-mcp


### PR DESCRIPTION
Fixes #50 (2026-07-03 docs audit, findings mcp-12 / agent-sdks-2).

The shipped ASA flow is **discover (38400) -> request (38401) -> settle (L402) -> attest (38403)** — there is no offer/counter/accept negotiation loop. But `request_agent_service`'s tool description said "Starts the negotiation process" in both servers, and every connected agent reads that description (it also leaked into external docs).

## Changes

- **`request_agent_service` description** (.NET `AgentNegotiateTool.cs` + Python `server.py`/tool docstring): now "Sends a service request (kind 38401 event) referencing the provider's capability. The provider responds with agreement/settlement terms; settle via settle_agent_service." (L402-endpoint shortcut note retained.)
- **`settle_agent_service` description** (both servers): "negotiated price" -> "agreed price"
- **README**: ASA tools "discovering, negotiating, and settling" -> "discovering, requesting, settling, and attesting"; "invoices at negotiated prices" -> "at the agreed price"
- **smithery.yaml**: "ASA negotiation" -> "agent service agreements"
- Matching doc comments/docstrings (`AgentService.cs`, Python tool docstrings)

No tool renames, no behavior changes, no version bump (descriptions ship with the next release).

## Tests

- .NET: `dotnet test` — 273 passed, 0 failed
- Python: `python -m pytest` — 453 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeVJ1dSozozhHDmNHiPj5f