### PR TITLE
feat: test_l402_payment self-test tool (.NET + Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of [Lightning Enable](https://lightningenable.com) — infrastructure for a
 [![Discord](https://img.shields.io/discord/1405389254892195951?label=community&logo=discord&color=5865F2)](https://discord.gg/rX7NxHY8vx)
 
 
-An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 23 tools total: 15 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, negotiating, and settling services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
+An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 23 tools total: 15 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, requesting, settling, and attesting services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
 
 Available in **.NET** and **Python**.
 
@@ -144,7 +144,7 @@ These tools enable agent-to-agent commerce on Nostr:
 3. **Settle** — `settle_agent_service(l402_endpoint)` pays via Lightning and receives the result
 4. **Review** — `publish_agent_attestation(pubkey, agreement_id, rating=5)` builds on-protocol reputation
 
-For dynamic pricing, providers use `create_l402_challenge` to generate invoices at negotiated prices. Requesters pay and providers verify with `verify_l402_payment`.
+For dynamic pricing, providers use `create_l402_challenge` to generate invoices at the agreed price. Requesters pay and providers verify with `verify_l402_payment`.
 
 ## Related Projects
 

--- a/dotnet/src/LightningEnable.Mcp/Services/AgentService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/AgentService.cs
@@ -6,7 +6,7 @@ namespace LightningEnable.Mcp.Services;
 
 /// <summary>
 /// Service for Agent Service Agreement (ASA) operations on the Nostr network.
-/// Handles discovery, publishing, negotiation, and settlement of agent capabilities.
+/// Handles discovery, publishing, service requests, and settlement of agent capabilities.
 ///
 /// v1 implementation uses the Lightning Enable API for all operations.
 /// TODO: Add direct Nostr relay WebSocket support for discovery and publishing.

--- a/dotnet/src/LightningEnable.Mcp/Tools/AgentNegotiateTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AgentNegotiateTool.cs
@@ -7,17 +7,18 @@ namespace LightningEnable.Mcp.Tools;
 
 /// <summary>
 /// MCP tool for requesting a service from an agent.
-/// Sends a kind 38401 event referencing the provider's capability to start negotiation.
+/// Sends a kind 38401 event referencing the provider's capability.
 /// </summary>
 [McpServerToolType]
 public static class AgentNegotiateTool
 {
     /// <summary>
-    /// Requests a service from an agent, starting the negotiation process.
+    /// Requests a service from an agent by sending a kind 38401 event.
     /// </summary>
     [McpServerTool(Name = "request_agent_service"), Description(
-        "Request a service from an agent. Sends a kind 38401 event referencing the provider's capability. " +
-        "Starts the negotiation process. If the provider has an L402 endpoint, you can skip this step " +
+        "Sends a service request (kind 38401 event) referencing the provider's capability. " +
+        "The provider responds with agreement/settlement terms; settle via settle_agent_service. " +
+        "If the provider has an L402 endpoint, you can skip this step " +
         "and use settle_agent_service directly.")]
     public static async Task<string> RequestAgentService(
         [Description("Event ID of the capability to request")] string capabilityEventId,

--- a/dotnet/src/LightningEnable.Mcp/Tools/AgentSettleTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AgentSettleTool.cs
@@ -23,7 +23,7 @@ public static class AgentSettleTool
         "Uses the same L402 auto-pay flow as access_l402_resource. " +
         "The L402 endpoint URL comes from discover_agent_services or request_agent_service results. " +
         "NOTE: If you are the PROVIDER (selling a service), use create_l402_challenge to generate " +
-        "a Lightning invoice at the negotiated price, share it with the requester, then use " +
+        "a Lightning invoice at the agreed price, share it with the requester, then use " +
         "verify_l402_payment to confirm payment before delivering the service.")]
     public static async Task<string> SettleAgentService(
         [Description("L402 endpoint URL from the service agreement")] string l402Endpoint,

--- a/dotnet/src/LightningEnable.Mcp/Tools/TestL402PaymentTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/TestL402PaymentTool.cs
@@ -1,0 +1,177 @@
+using System.ComponentModel;
+using System.Text.Json;
+using LightningEnable.Mcp.Services;
+using ModelContextProtocol.Server;
+
+namespace LightningEnable.Mcp.Tools;
+
+/// <summary>
+/// One-command self-test for the Lightning wallet: pays the public 1-sat L402
+/// test endpoint end to end, proving the wallet is connected, returns a preimage,
+/// and can complete an L402 payment.
+///
+/// It adds NO new payment logic — it delegates to the same proven
+/// <c>access_l402_resource</c> path (budget checks, recording, everything) against
+/// a <b>hardcoded</b> endpoint, so there is no user-supplied URL and therefore no
+/// SSRF surface. It then translates the raw result into a plain pass/fail verdict
+/// with a fix hint, which is what makes it a better onboarding primitive than
+/// telling a beginner to curl a magic URL.
+/// </summary>
+[McpServerToolType]
+public static class TestL402PaymentTool
+{
+    // The public 1-sat L402 test resource. Hardcoded on purpose so this tool can
+    // never be repurposed into an arbitrary-URL payer. Only the base host is
+    // overridable, via the same env var the rest of the MCP uses to point at a
+    // non-prod Lightning Enable instance.
+    internal const string TestPath = "/l402/test/ping";
+
+    // The endpoint charges 1 sat; small headroom, hard-capped so the self-test can
+    // never spend more than a rounding error regardless of what the endpoint returns.
+    private const int MaxTestSats = 10;
+
+    [McpServerTool(Name = "test_l402_payment"), Description(
+        "Self-test the Lightning wallet by paying the public 1-sat L402 test endpoint end to end. " +
+        "Proves the wallet is connected, returns a preimage, and can complete an L402 payment. " +
+        "Costs about 1 satoshi. Use this to verify setup or answer 'is my wallet actually working?'.")]
+    public static async Task<string> TestL402Payment(
+        McpServer? server = null,
+        IL402HttpClient? l402Client = null,
+        IBudgetService? budgetService = null,
+        IPriceService? priceService = null,
+        IPaymentHistoryService? paymentHistory = null,
+        IRateLimiter? rateLimiter = null,
+        CancellationToken cancellationToken = default)
+    {
+        var endpoint = ResolveTestEndpoint();
+
+        // Delegate to the existing, proven L402 payment path. No new payment code,
+        // no bypass of budget/confirmation. maxSats hard-caps the spend.
+        var raw = await AccessL402ResourceTool.AccessL402Resource(
+            url: endpoint,
+            method: "GET",
+            headers: null,
+            body: null,
+            maxSats: MaxTestSats,
+            confirmationNonce: null,
+            server: server,
+            l402Client: l402Client,
+            budgetService: budgetService,
+            priceService: priceService,
+            paymentHistory: paymentHistory,
+            rateLimiter: rateLimiter,
+            cancellationToken: cancellationToken);
+
+        return Interpret(raw, endpoint);
+    }
+
+    /// <summary>
+    /// Turns the raw access_l402_resource result into a plain self-test verdict.
+    /// Kept internal + pure so the diagnostics are unit-testable without a wallet.
+    /// </summary>
+    internal static string Interpret(string rawJson, string endpoint)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(rawJson);
+            var root = doc.RootElement;
+            var success = root.TryGetProperty("success", out var s) && s.GetBoolean();
+
+            if (success)
+            {
+                var paid = root.TryGetProperty("payment", out var p)
+                    && p.TryGetProperty("paid", out var pd) && pd.GetBoolean();
+                long sats = paid && p.TryGetProperty("amountSats", out var amt) ? amt.GetInt64() : 0;
+                int status = root.TryGetProperty("statusCode", out var sc) ? sc.GetInt32() : 200;
+
+                if (paid)
+                {
+                    return JsonSerializer.Serialize(new
+                    {
+                        success = true,
+                        test = "passed",
+                        message = $"✅ L402 works end to end. Paid {sats} sat(s), preimage verified, endpoint returned {status}. " +
+                                  "Your wallet is ready to pay L402 resources anywhere.",
+                        endpoint,
+                        amountSats = sats,
+                        statusCode = status,
+                        walletWorking = true
+                    });
+                }
+
+                // 200 without a payment: the test endpoint should always issue a 402,
+                // so this means the L402 challenge was not exercised. Inconclusive.
+                return JsonSerializer.Serialize(new
+                {
+                    success = true,
+                    test = "inconclusive",
+                    message = $"Endpoint returned {status} without requiring payment, so the L402 flow was not exercised. " +
+                              "Retry, or verify the test endpoint.",
+                    endpoint,
+                    statusCode = status
+                });
+            }
+
+            // Failure — interpret the error into a specific reason + fix.
+            var error = root.TryGetProperty("error", out var e) ? (e.GetString() ?? "") : "";
+            var (reason, fix) = Diagnose(error);
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                test = "failed",
+                reason,
+                message = $"❌ L402 self-test failed: {error}",
+                howToFix = fix,
+                endpoint,
+                walletWorking = false
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                test = "failed",
+                reason = "unexpected",
+                message = $"❌ L402 self-test result could not be interpreted: {ex.Message}",
+                endpoint
+            });
+        }
+    }
+
+    /// <summary>Maps a raw error string to a stable reason code + a plain-language fix.</summary>
+    internal static (string reason, string fix) Diagnose(string error)
+    {
+        var e = (error ?? string.Empty).ToLowerInvariant();
+        if (e.Contains("not configured") || e.Contains("no wallet"))
+            return ("no_wallet",
+                "No Lightning wallet is configured. Set NWC_CONNECTION_STRING (CoinOS/Alby Hub/CLINK), STRIKE_API_KEY, or LND " +
+                "credentials — or add a wallet to ~/.lightning-enable/config.json. NWC and Strike both work for L402.");
+        if (e.Contains("preimage") || e.Contains("opennode"))
+            return ("no_preimage",
+                "The wallet paid but did not return a preimage, which L402 requires. OpenNode cannot do L402 — switch to " +
+                "NWC (CoinOS, Alby Hub, CLINK), LND, or Strike.");
+        if (e.Contains("insufficient") || e.Contains("balance") || e.Contains("funds"))
+            return ("insufficient_funds",
+                "The wallet has too little balance to pay ~1 sat. Fund it with a small amount and retry.");
+        if (e.Contains("budget") || e.Contains("limit") || e.Contains("exceed"))
+            return ("budget_block",
+                "The MCP budget blocked even this 1-sat payment. Loosen the auto-approve tier / per-payment limit in " +
+                "~/.lightning-enable/config.json.");
+        if (e.Contains("timeout") || e.Contains("timed out") || e.Contains("connection") || e.Contains("resolve"))
+            return ("network",
+                "Could not reach the wallet or the test endpoint. Check the wallet connection (is the NWC relay reachable?) " +
+                "and your network, then retry.");
+        return ("unknown",
+            "Check the error message above. Confirm a preimage-returning wallet (NWC, LND, or Strike) is connected and funded, then retry.");
+    }
+
+    /// <summary>Resolves the hardcoded test path against the configured LE API base.</summary>
+    internal static string ResolveTestEndpoint()
+    {
+        var baseUrl = Environment.GetEnvironmentVariable("LIGHTNING_ENABLE_API_URL");
+        if (string.IsNullOrWhiteSpace(baseUrl) || baseUrl.StartsWith("${", StringComparison.Ordinal))
+            baseUrl = "https://api.lightningenable.com";
+        return baseUrl.TrimEnd('/') + TestPath;
+    }
+}

--- a/dotnet/src/LightningEnable.Mcp/Tools/TestL402PaymentTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/TestL402PaymentTool.cs
@@ -13,9 +13,12 @@ namespace LightningEnable.Mcp.Tools;
 /// It adds NO new payment logic — it delegates to the same proven
 /// <c>access_l402_resource</c> path (budget checks, recording, everything) against
 /// a <b>hardcoded</b> endpoint, so there is no user-supplied URL and therefore no
-/// SSRF surface. It then translates the raw result into a plain pass/fail verdict
-/// with a fix hint, which is what makes it a better onboarding primitive than
-/// telling a beginner to curl a magic URL.
+/// SSRF surface. It then translates the raw result into a plain pass/fail verdict.
+///
+/// Interpretation checks the <b>structured</b> signals the delegated path emits
+/// (a completed payment, a confirmation requirement, a budget denial) before
+/// falling back to matching the error string, so a real payment is never reported
+/// as a broken wallet and a rate-limit is never mistaken for a budget block.
 /// </summary>
 [McpServerToolType]
 public static class TestL402PaymentTool
@@ -28,13 +31,17 @@ public static class TestL402PaymentTool
 
     // The endpoint charges 1 sat; small headroom, hard-capped so the self-test can
     // never spend more than a rounding error regardless of what the endpoint returns.
-    private const int MaxTestSats = 10;
+    internal const int MaxTestSats = 10;
 
     [McpServerTool(Name = "test_l402_payment"), Description(
-        "Self-test the Lightning wallet by paying the public 1-sat L402 test endpoint end to end. " +
-        "Proves the wallet is connected, returns a preimage, and can complete an L402 payment. " +
-        "Costs about 1 satoshi. Use this to verify setup or answer 'is my wallet actually working?'.")]
+        "Self-test the Lightning wallet by paying the public 1-sat L402 test endpoint end to end. "
+        + "Proves the wallet is connected, returns a preimage, and can complete an L402 payment. "
+        + "Costs about 1 satoshi. Use this to verify setup or answer 'is my wallet actually working?'. "
+        + "If your budget config requires confirmation for this amount, the verdict is 'needs_confirmation' "
+        + "and the server prints a code to its console — re-run with confirmationNonce set to that code.")]
     public static async Task<string> TestL402Payment(
+        [Description("Confirmation code the human read from the server console, if a prior call returned "
+            + "test='needs_confirmation'. Omit on the first call.")] string? confirmationNonce = null,
         McpServer? server = null,
         IL402HttpClient? l402Client = null,
         IBudgetService? budgetService = null,
@@ -53,7 +60,7 @@ public static class TestL402PaymentTool
             headers: null,
             body: null,
             maxSats: MaxTestSats,
-            confirmationNonce: null,
+            confirmationNonce: confirmationNonce,
             server: server,
             l402Client: l402Client,
             budgetService: budgetService,
@@ -71,60 +78,11 @@ public static class TestL402PaymentTool
     /// </summary>
     internal static string Interpret(string rawJson, string endpoint)
     {
+        JsonElement root;
         try
         {
             using var doc = JsonDocument.Parse(rawJson);
-            var root = doc.RootElement;
-            var success = root.TryGetProperty("success", out var s) && s.GetBoolean();
-
-            if (success)
-            {
-                var paid = root.TryGetProperty("payment", out var p)
-                    && p.TryGetProperty("paid", out var pd) && pd.GetBoolean();
-                long sats = paid && p.TryGetProperty("amountSats", out var amt) ? amt.GetInt64() : 0;
-                int status = root.TryGetProperty("statusCode", out var sc) ? sc.GetInt32() : 200;
-
-                if (paid)
-                {
-                    return JsonSerializer.Serialize(new
-                    {
-                        success = true,
-                        test = "passed",
-                        message = $"✅ L402 works end to end. Paid {sats} sat(s), preimage verified, endpoint returned {status}. " +
-                                  "Your wallet is ready to pay L402 resources anywhere.",
-                        endpoint,
-                        amountSats = sats,
-                        statusCode = status,
-                        walletWorking = true
-                    });
-                }
-
-                // 200 without a payment: the test endpoint should always issue a 402,
-                // so this means the L402 challenge was not exercised. Inconclusive.
-                return JsonSerializer.Serialize(new
-                {
-                    success = true,
-                    test = "inconclusive",
-                    message = $"Endpoint returned {status} without requiring payment, so the L402 flow was not exercised. " +
-                              "Retry, or verify the test endpoint.",
-                    endpoint,
-                    statusCode = status
-                });
-            }
-
-            // Failure — interpret the error into a specific reason + fix.
-            var error = root.TryGetProperty("error", out var e) ? (e.GetString() ?? "") : "";
-            var (reason, fix) = Diagnose(error);
-            return JsonSerializer.Serialize(new
-            {
-                success = false,
-                test = "failed",
-                reason,
-                message = $"❌ L402 self-test failed: {error}",
-                howToFix = fix,
-                endpoint,
-                walletWorking = false
-            });
+            root = doc.RootElement.Clone();
         }
         catch (Exception ex)
         {
@@ -137,31 +95,166 @@ public static class TestL402PaymentTool
                 endpoint
             });
         }
+
+        var success = root.TryGetProperty("success", out var s) && s.GetBoolean();
+
+        if (success)
+        {
+            var paidOk = root.TryGetProperty("payment", out var p)
+                && p.TryGetProperty("paid", out var pd) && pd.GetBoolean();
+            long sats = paidOk && p.TryGetProperty("amountSats", out var amt) ? amt.GetInt64() : 0;
+            int status = root.TryGetProperty("statusCode", out var sc) ? sc.GetInt32() : 200;
+
+            if (paidOk)
+            {
+                return Passed(sats, status, endpoint);
+            }
+
+            // 200 without a payment: the test endpoint should always issue a 402,
+            // so the L402 flow was NOT exercised — this is not a proven pass.
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                test = "inconclusive",
+                message = $"Endpoint returned {status} without requiring payment, so the L402 flow was not "
+                    + "exercised — the wallet is unproven. Retry, or verify the test endpoint.",
+                endpoint,
+                statusCode = status,
+                walletWorking = (bool?)null
+            });
+        }
+
+        // ---- Failure branch: read STRUCTURED signals before the error string. ----
+
+        // (1) The payment needs human confirmation — a healthy wallet, not a failure.
+        if (root.TryGetProperty("requiresConfirmation", out var rc) && rc.GetBoolean())
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                test = "needs_confirmation",
+                message = "Your budget config requires human confirmation for this payment. A confirmation "
+                    + "code was printed to the server console/logs (visible to the operator, not to the agent). "
+                    + "Re-run test_l402_payment with confirmationNonce set to that code to finish the test.",
+                howToConfirm = root.TryGetProperty("howToConfirm", out var hc) ? hc.GetString() : null,
+                endpoint,
+                walletWorking = (bool?)null
+            });
+        }
+
+        // (2) Split-flow: the payment SUCCEEDED (preimage minted) but the post-payment
+        // retry returned non-200. For a wallet self-test that IS a pass — the wallet
+        // completed an L402 payment, which is exactly what this checks.
+        if (root.TryGetProperty("payment", out var fp)
+            && fp.TryGetProperty("paid", out var fpd) && fpd.GetBoolean())
+        {
+            long sats = fp.TryGetProperty("amountSats", out var fa) ? fa.GetInt64() : 0;
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                test = "passed",
+                message = $"✅ Wallet works — paid {sats} sat(s) and the preimage verified. (The test "
+                    + "endpoint's post-payment response wasn't a clean 200, but your wallet completed the "
+                    + "L402 payment, which is what this checks.)",
+                endpoint,
+                amountSats = sats,
+                walletWorking = true
+            });
+        }
+
+        // (3) Budget denial has a dedicated shape (a "budget" object beside the error);
+        // detect it structurally so the specific denial reason is surfaced verbatim.
+        if (root.TryGetProperty("budget", out _))
+        {
+            var denyMsg = root.TryGetProperty("error", out var be) ? be.GetString() : "budget policy";
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                test = "failed",
+                reason = "budget_block",
+                message = $"❌ L402 self-test blocked by budget: {denyMsg}",
+                howToFix = "The MCP budget denied even this ~1-sat payment. Raise the relevant cap in "
+                    + "~/.lightning-enable/config.json (the message above names which limit was hit).",
+                endpoint,
+                walletWorking = false
+            });
+        }
+
+        // (4) Otherwise diagnose from the error string.
+        var error = root.TryGetProperty("error", out var e) ? (e.GetString() ?? "") : "";
+        var (reason, fix) = Diagnose(error);
+        return JsonSerializer.Serialize(new
+        {
+            success = false,
+            test = "failed",
+            reason,
+            message = $"❌ L402 self-test failed: {error}",
+            howToFix = fix,
+            endpoint,
+            walletWorking = false
+        });
     }
 
-    /// <summary>Maps a raw error string to a stable reason code + a plain-language fix.</summary>
+    private static string Passed(long sats, int status, string endpoint) =>
+        JsonSerializer.Serialize(new
+        {
+            success = true,
+            test = "passed",
+            message = $"✅ L402 works end to end. Paid {sats} sat(s), preimage verified, endpoint returned "
+                + $"{status}. Your wallet is ready to pay L402 resources anywhere.",
+            endpoint,
+            amountSats = sats,
+            statusCode = status,
+            walletWorking = true
+        });
+
+    /// <summary>
+    /// Maps a raw error string to a stable reason code + a plain-language fix.
+    /// Order matters: the most specific / most-often-confused buckets are checked
+    /// first (rate-limit before budget; network before preimage) so an error that
+    /// contains an overlapping word isn't misclassified. Budget denials and
+    /// confirmation requirements are handled structurally in Interpret, not here.
+    /// </summary>
     internal static (string reason, string fix) Diagnose(string error)
     {
         var e = (error ?? string.Empty).ToLowerInvariant();
-        if (e.Contains("not configured") || e.Contains("no wallet"))
+
+        if (e.Contains("not configured") || e.Contains("no wallet") || e.Contains("not initialized"))
             return ("no_wallet",
-                "No Lightning wallet is configured. Set NWC_CONNECTION_STRING (CoinOS/Alby Hub/CLINK), STRIKE_API_KEY, or LND " +
-                "credentials — or add a wallet to ~/.lightning-enable/config.json. NWC and Strike both work for L402.");
-        if (e.Contains("preimage") || e.Contains("opennode"))
+                "No Lightning wallet is configured. Set NWC_CONNECTION_STRING (CoinOS/Alby Hub/CLINK), STRIKE_API_KEY, or LND "
+                + "credentials — or add a wallet to ~/.lightning-enable/config.json. NWC and Strike both work for L402.");
+
+        // Before budget: "Rate limit exceeded" contains "limit"/"exceed" but is NOT a budget issue.
+        if (e.Contains("rate limit"))
+            return ("rate_limited",
+                "You've hit the request rate limit (shared with access_l402_resource). Wait for the window to reset "
+                + "(about a minute) and retry — this is not a budget or wallet problem.");
+
+        // Before preimage: a network blip whose text mentions "preimage" is still a network issue.
+        if (e.Contains("timeout") || e.Contains("timed out") || e.Contains("unreachable")
+            || e.Contains("network") || e.Contains("resolve") || e.Contains("connect"))
+            return ("network",
+                "Could not reach the wallet or the test endpoint. Check the wallet connection (is the NWC relay reachable?) "
+                + "and your network, then retry.");
+
+        if (e.Contains("opennode") || e.Contains("preimage"))
             return ("no_preimage",
-                "The wallet paid but did not return a preimage, which L402 requires. OpenNode cannot do L402 — switch to " +
-                "NWC (CoinOS, Alby Hub, CLINK), LND, or Strike.");
-        if (e.Contains("insufficient") || e.Contains("balance") || e.Contains("funds"))
+                "The wallet paid but did not return a preimage, which L402 requires. OpenNode cannot do L402 — switch to "
+                + "NWC (CoinOS, Alby Hub, CLINK), LND, or Strike.");
+
+        // Only "insufficient" — not bare "balance"/"funds", which also appear in
+        // balance-*fetch* failures ("unable to retrieve balance").
+        if (e.Contains("insufficient"))
             return ("insufficient_funds",
                 "The wallet has too little balance to pay ~1 sat. Fund it with a small amount and retry.");
-        if (e.Contains("budget") || e.Contains("limit") || e.Contains("exceed"))
+
+        // Fallback for any budget wording that reaches here (the structured path in
+        // Interpret handles the normal budget-deny shape).
+        if (e.Contains("budget"))
             return ("budget_block",
-                "The MCP budget blocked even this 1-sat payment. Loosen the auto-approve tier / per-payment limit in " +
-                "~/.lightning-enable/config.json.");
-        if (e.Contains("timeout") || e.Contains("timed out") || e.Contains("connection") || e.Contains("resolve"))
-            return ("network",
-                "Could not reach the wallet or the test endpoint. Check the wallet connection (is the NWC relay reachable?) " +
-                "and your network, then retry.");
+                "The MCP budget blocked even this 1-sat payment. Loosen the auto-approve tier / per-payment limit in "
+                + "~/.lightning-enable/config.json.");
+
         return ("unknown",
             "Check the error message above. Confirm a preimage-returning wallet (NWC, LND, or Strike) is connected and funded, then retry.");
     }

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/TestL402PaymentToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/TestL402PaymentToolTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using LightningEnable.Mcp.Models;
+using LightningEnable.Mcp.Services;
+using LightningEnable.Mcp.Tools;
+using Moq;
+using FluentAssertions;
+
+namespace LightningEnable.Mcp.Tests.Tools;
+
+/// <summary>
+/// Tests for the test_l402_payment self-test tool. The tool delegates to the proven
+/// access_l402_resource path against a hardcoded 1-sat endpoint, then interprets the
+/// result into a plain pass/fail verdict.
+/// </summary>
+public class TestL402PaymentToolTests
+{
+    private readonly Mock<IL402HttpClient> _l402ClientMock = new();
+
+    [Fact]
+    public async Task TestL402Payment_PaysHardcodedTestEndpoint_ReturnsPassed()
+    {
+        // Arrange — the wallet pays 1 sat and the endpoint returns 200.
+        string? calledUrl = null;
+        _l402ClientMock.Setup(c => c.FetchWithL402Async(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string?, string?, long, CancellationToken>(
+                (url, _, _, _, _, _) => calledUrl = url)
+            .ReturnsAsync(new L402FetchResult
+            {
+                Success = true,
+                Url = "https://api.lightningenable.com/l402/test/ping",
+                StatusCode = 200,
+                Content = "pong",
+                ContentType = "text/plain",
+                PaidAmountSats = 1
+            });
+
+        // Act
+        var result = await TestL402PaymentTool.TestL402Payment(l402Client: _l402ClientMock.Object);
+
+        // Assert
+        var json = JsonDocument.Parse(result).RootElement;
+        json.GetProperty("success").GetBoolean().Should().BeTrue();
+        json.GetProperty("test").GetString().Should().Be("passed");
+        json.GetProperty("walletWorking").GetBoolean().Should().BeTrue();
+        json.GetProperty("amountSats").GetInt64().Should().Be(1);
+
+        // It must hit the hardcoded 1-sat test endpoint — never a caller-supplied URL.
+        calledUrl.Should().EndWith("/l402/test/ping");
+    }
+
+    [Fact]
+    public async Task TestL402Payment_NoWalletConfigured_ReturnsNoWalletDiagnosis()
+    {
+        // Arrange — L402 client reports the wallet isn't configured (its real message).
+        _l402ClientMock.Setup(c => c.FetchWithL402Async(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(L402FetchResult.Failed(
+                "https://api.lightningenable.com/l402/test/ping",
+                "NWC wallet not configured. Set NWC_CONNECTION_STRING environment variable.",
+                402));
+
+        // Act
+        var result = await TestL402PaymentTool.TestL402Payment(l402Client: _l402ClientMock.Object);
+
+        // Assert
+        var json = JsonDocument.Parse(result).RootElement;
+        json.GetProperty("success").GetBoolean().Should().BeFalse();
+        json.GetProperty("test").GetString().Should().Be("failed");
+        json.GetProperty("reason").GetString().Should().Be("no_wallet");
+        json.GetProperty("howToFix").GetString().Should().Contain("NWC_CONNECTION_STRING");
+    }
+
+    // ---- Pure interpretation tests (no wallet, no mocks) ----
+
+    [Fact]
+    public void Interpret_PaidSuccess_IsPassed()
+    {
+        var raw = JsonSerializer.Serialize(new
+        {
+            success = true,
+            statusCode = 200,
+            payment = new { paid = true, amountSats = 1 }
+        });
+
+        var verdict = JsonDocument.Parse(
+            TestL402PaymentTool.Interpret(raw, "https://api.lightningenable.com/l402/test/ping")).RootElement;
+
+        verdict.GetProperty("test").GetString().Should().Be("passed");
+        verdict.GetProperty("walletWorking").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Interpret_Success200ButNotPaid_IsInconclusive()
+    {
+        var raw = JsonSerializer.Serialize(new
+        {
+            success = true,
+            statusCode = 200,
+            payment = new { paid = false }
+        });
+
+        var verdict = JsonDocument.Parse(
+            TestL402PaymentTool.Interpret(raw, "e")).RootElement;
+
+        verdict.GetProperty("test").GetString().Should().Be("inconclusive");
+    }
+
+    [Theory]
+    [InlineData("Wallet not configured. Set STRIKE_API_KEY...", "no_wallet")]
+    [InlineData("Payment succeeded but no preimage was returned", "no_preimage")]
+    [InlineData("OpenNode does not return preimages", "no_preimage")]
+    [InlineData("Insufficient balance in wallet", "insufficient_funds")]
+    [InlineData("Payment exceeds per-session budget limit", "budget_block")]
+    [InlineData("Connection timed out reaching relay", "network")]
+    [InlineData("Something totally unexpected happened", "unknown")]
+    public void Diagnose_MapsErrorsToStableReasonCodes(string error, string expectedReason)
+    {
+        var (reason, fix) = TestL402PaymentTool.Diagnose(error);
+        reason.Should().Be(expectedReason);
+        fix.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ResolveTestEndpoint_TargetsTheTestPingPath()
+    {
+        // Invariant regardless of the configured base host: it always targets the
+        // hardcoded 1-sat test path. (Non-mutating so it can't race parallel tests
+        // that also read LIGHTNING_ENABLE_API_URL.)
+        TestL402PaymentTool.ResolveTestEndpoint().Should().EndWith("/l402/test/ping");
+    }
+}

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/TestL402PaymentToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/TestL402PaymentToolTests.cs
@@ -17,15 +17,16 @@ public class TestL402PaymentToolTests
     private readonly Mock<IL402HttpClient> _l402ClientMock = new();
 
     [Fact]
-    public async Task TestL402Payment_PaysHardcodedTestEndpoint_ReturnsPassed()
+    public async Task TestL402Payment_PaysHardcodedEndpoint_UnderHardCap_ReturnsPassed()
     {
         // Arrange — the wallet pays 1 sat and the endpoint returns 200.
         string? calledUrl = null;
+        long calledMaxSats = -1;
         _l402ClientMock.Setup(c => c.FetchWithL402Async(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
                 It.IsAny<string?>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Callback<string, string, string?, string?, long, CancellationToken>(
-                (url, _, _, _, _, _) => calledUrl = url)
+                (url, _, _, _, maxSats, _) => { calledUrl = url; calledMaxSats = maxSats; })
             .ReturnsAsync(new L402FetchResult
             {
                 Success = true,
@@ -48,6 +49,9 @@ public class TestL402PaymentToolTests
 
         // It must hit the hardcoded 1-sat test endpoint — never a caller-supplied URL.
         calledUrl.Should().EndWith("/l402/test/ping");
+        // ...and it must forward the hard cap — the tool's core funds-safety guarantee.
+        calledMaxSats.Should().Be(TestL402PaymentTool.MaxTestSats);
+        calledMaxSats.Should().BeLessThanOrEqualTo(10);
     }
 
     [Fact]
@@ -73,7 +77,7 @@ public class TestL402PaymentToolTests
         json.GetProperty("howToFix").GetString().Should().Contain("NWC_CONNECTION_STRING");
     }
 
-    // ---- Pure interpretation tests (no wallet, no mocks) ----
+    // ---- Pure interpretation tests over the REAL shapes access_l402_resource emits ----
 
     [Fact]
     public void Interpret_PaidSuccess_IsPassed()
@@ -93,7 +97,7 @@ public class TestL402PaymentToolTests
     }
 
     [Fact]
-    public void Interpret_Success200ButNotPaid_IsInconclusive()
+    public void Interpret_Success200ButNotPaid_IsInconclusive_AndNotASuccess()
     {
         var raw = JsonSerializer.Serialize(new
         {
@@ -102,18 +106,93 @@ public class TestL402PaymentToolTests
             payment = new { paid = false }
         });
 
-        var verdict = JsonDocument.Parse(
-            TestL402PaymentTool.Interpret(raw, "e")).RootElement;
+        var verdict = JsonDocument.Parse(TestL402PaymentTool.Interpret(raw, "e")).RootElement;
 
         verdict.GetProperty("test").GetString().Should().Be("inconclusive");
+        // An unproven wallet must NOT read as a passing self-test.
+        verdict.GetProperty("success").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void Interpret_SplitFlow_PaidButRetryFailed_IsPassed_NotBrokenWallet()
+    {
+        // access_l402_resource's store-split-flow shape: success:false with a real
+        // completed payment. The wallet worked; the endpoint retry didn't.
+        var raw = JsonSerializer.Serialize(new
+        {
+            success = false,
+            statusCode = 402,
+            error = "Request failed after payment: HTTP 402",
+            payment = new { paid = true, amountSats = 1, l402Token = "mac:preimage" }
+        });
+
+        var verdict = JsonDocument.Parse(TestL402PaymentTool.Interpret(raw, "e")).RootElement;
+
+        verdict.GetProperty("test").GetString().Should().Be("passed");
+        verdict.GetProperty("success").GetBoolean().Should().BeTrue();
+        verdict.GetProperty("walletWorking").GetBoolean().Should().BeTrue();
+        verdict.GetProperty("amountSats").GetInt64().Should().Be(1);
+    }
+
+    [Fact]
+    public void Interpret_RequiresConfirmation_IsNeedsConfirmation_NotFailed()
+    {
+        var raw = JsonSerializer.Serialize(new
+        {
+            success = false,
+            requiresConfirmation = true,
+            error = "L402 payment requires human confirmation",
+            howToConfirm = "Ask the human for the code shown in the server console."
+        });
+
+        var verdict = JsonDocument.Parse(TestL402PaymentTool.Interpret(raw, "e")).RootElement;
+
+        verdict.GetProperty("test").GetString().Should().Be("needs_confirmation");
+        // A healthy wallet awaiting a code must not be labeled a failure.
+        verdict.TryGetProperty("reason", out _).Should().BeFalse();
+        verdict.GetProperty("message").GetString().Should().Contain("confirmationNonce");
+    }
+
+    [Fact]
+    public void Interpret_BudgetDenyShape_SurfacesSpecificReason()
+    {
+        // access_l402_resource's deny shape: a "budget" object beside the error,
+        // where the error IS the specific denial reason.
+        var raw = JsonSerializer.Serialize(new
+        {
+            success = false,
+            error = "Payment amount exceeds maximum per-payment limit of $5.00",
+            budget = new { maxSats = 10, remainingSessionUsd = 3.0 }
+        });
+
+        var verdict = JsonDocument.Parse(TestL402PaymentTool.Interpret(raw, "e")).RootElement;
+
+        verdict.GetProperty("test").GetString().Should().Be("failed");
+        verdict.GetProperty("reason").GetString().Should().Be("budget_block");
+        // The specific cap that was hit must be surfaced, not a generic message.
+        verdict.GetProperty("message").GetString().Should().Contain("per-payment limit of $5.00");
+    }
+
+    [Fact]
+    public void Interpret_NonJson_DegradesGracefully()
+    {
+        var verdict = JsonDocument.Parse(
+            TestL402PaymentTool.Interpret("not json at all", "e")).RootElement;
+
+        verdict.GetProperty("success").GetBoolean().Should().BeFalse();
+        verdict.GetProperty("test").GetString().Should().Be("failed");
+        verdict.GetProperty("reason").GetString().Should().Be("unexpected");
     }
 
     [Theory]
     [InlineData("Wallet not configured. Set STRIKE_API_KEY...", "no_wallet")]
+    [InlineData("Rate limit exceeded", "rate_limited")]                          // must NOT be budget_block
+    [InlineData("timed out waiting for preimage from relay", "network")]         // network before preimage
     [InlineData("Payment succeeded but no preimage was returned", "no_preimage")]
     [InlineData("OpenNode does not return preimages", "no_preimage")]
     [InlineData("Insufficient balance in wallet", "insufficient_funds")]
-    [InlineData("Payment exceeds per-session budget limit", "budget_block")]
+    [InlineData("Unable to retrieve balance", "unknown")]                        // balance-FETCH is not insufficient_funds
+    [InlineData("Payment exceeds per-session budget of $20", "budget_block")]
     [InlineData("Connection timed out reaching relay", "network")]
     [InlineData("Something totally unexpected happened", "unknown")]
     public void Diagnose_MapsErrorsToStableReasonCodes(string error, string expectedReason)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -149,11 +149,19 @@ class LightningEnableServer:
                         "Self-test the Lightning wallet by paying the public 1-sat L402 test "
                         "endpoint end to end. Proves the wallet is connected, returns a preimage, "
                         "and can complete an L402 payment. Costs about 1 satoshi. Use this to "
-                        "verify setup or answer 'is my wallet actually working?'."
+                        "verify setup or answer 'is my wallet actually working?'. If your budget "
+                        "config requires confirmation for this amount, the verdict is "
+                        "'needs_confirmation' and the server prints a code to its console — re-run "
+                        "with confirmation_nonce set to that code."
                     ),
                     inputSchema={
                         "type": "object",
-                        "properties": {},
+                        "properties": {
+                            "confirmation_nonce": {
+                                "type": "string",
+                                "description": "Confirmation code the human read from the server console, if a prior call returned test='needs_confirmation'. Omit on the first call.",
+                            },
+                        },
                         "required": [],
                     },
                 ),
@@ -718,7 +726,11 @@ class LightningEnableServer:
                     "get_agent_reputation",
                 }
 
-                if self.wallet is None and name not in producer_tools:
+                # test_l402_payment is allowed through even without a wallet so it can
+                # return its own structured no_wallet verdict (parity with .NET), instead
+                # of this generic guard string (which also wrongly suggests OpenNode, which
+                # cannot do L402).
+                if self.wallet is None and name not in producer_tools and name != "test_l402_payment":
                     return [
                         TextContent(
                             type="text",
@@ -744,6 +756,7 @@ class LightningEnableServer:
 
                 elif name == "test_l402_payment":
                     result = await test_l402_payment(
+                        confirmation_nonce=arguments.get("confirmation_nonce"),
                         l402_client=self.l402_client,
                         budget_service=self.budget_service,
                         payment_history_service=self.payment_history_service,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -30,6 +30,7 @@ from .nwc_wallet import NWCWallet, NWCConfig
 from .opennode_wallet import OpenNodeWallet
 from .strike_wallet import StrikeWallet
 from .tools.access_resource import access_l402_resource
+from .tools.test_l402_payment import test_l402_payment
 from .tools.check_invoice_status import check_invoice_status
 from .tools.confirm_payment import confirm_payment
 from .tools.create_invoice import create_invoice
@@ -140,6 +141,20 @@ class LightningEnableServer:
                             },
                         },
                         "required": ["url"],
+                    },
+                ),
+                Tool(
+                    name="test_l402_payment",
+                    description=(
+                        "Self-test the Lightning wallet by paying the public 1-sat L402 test "
+                        "endpoint end to end. Proves the wallet is connected, returns a preimage, "
+                        "and can complete an L402 payment. Costs about 1 satoshi. Use this to "
+                        "verify setup or answer 'is my wallet actually working?'."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
                     },
                 ),
                 Tool(
@@ -722,6 +737,13 @@ class LightningEnableServer:
                         body=arguments.get("body"),
                         max_sats=arguments.get("max_sats", 1000),
                         confirmation_nonce=arguments.get("confirmation_nonce"),
+                        l402_client=self.l402_client,
+                        budget_service=self.budget_service,
+                        payment_history_service=self.payment_history_service,
+                    )
+
+                elif name == "test_l402_payment":
+                    result = await test_l402_payment(
                         l402_client=self.l402_client,
                         budget_service=self.budget_service,
                         payment_history_service=self.payment_history_service,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -551,8 +551,9 @@ class LightningEnableServer:
                 Tool(
                     name="request_agent_service",
                     description=(
-                        "Request a service from an agent. Sends a kind 38401 event referencing the provider's capability. "
-                        "Starts the negotiation process. If the provider has an L402 endpoint, you can skip this step "
+                        "Sends a service request (kind 38401 event) referencing the provider's capability. "
+                        "The provider responds with agreement/settlement terms; settle via settle_agent_service. "
+                        "If the provider has an L402 endpoint, you can skip this step "
                         "and use settle_agent_service directly. Requires LIGHTNING_ENABLE_API_KEY."
                     ),
                     inputSchema={
@@ -639,7 +640,7 @@ class LightningEnableServer:
                         "Uses the same L402 auto-pay flow as access_l402_resource. "
                         "The L402 endpoint URL comes from discover_agent_services or request_agent_service results. "
                         "NOTE: If you are the PROVIDER (selling a service), use create_l402_challenge to generate "
-                        "a Lightning invoice at the negotiated price, then verify_l402_payment to confirm payment "
+                        "a Lightning invoice at the agreed price, then verify_l402_payment to confirm payment "
                         "before delivering the service."
                     ),
                     inputSchema={

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/request_agent_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/request_agent_service.py
@@ -1,8 +1,9 @@
 """
 Request Agent Service Tool
 
-Sends a service request referencing a provider's capability (kind 38401 event),
-starting the negotiation process. Requires LIGHTNING_ENABLE_API_KEY.
+Sends a service request (kind 38401 event) referencing a provider's capability.
+The provider responds with agreement/settlement terms; settle via
+settle_agent_service. Requires LIGHTNING_ENABLE_API_KEY.
 
 NOTE: Budget is NOT deducted at request time by design. The budget is only
 deducted at settlement time (settle_agent_service) when the L402 payment is
@@ -31,9 +32,10 @@ async def request_agent_service(
     budget_service: "BudgetService | None" = None,
 ) -> str:
     """
-    Request a service from an agent. Sends a kind 38401 event referencing the
-    provider's capability and starts the negotiation process. If the provider
-    has an L402 endpoint, you can skip this step and use settle_agent_service.
+    Sends a service request (kind 38401 event) referencing the provider's
+    capability. The provider responds with agreement/settlement terms; settle
+    via settle_agent_service. If the provider has an L402 endpoint, you can
+    skip this step and use settle_agent_service directly.
 
     Args:
         capability_event_id: Event ID of the capability to request

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/settle_agent_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/settle_agent_service.py
@@ -8,7 +8,7 @@ transaction. Uses the SAME wallet + budget-gating flow as access_l402_resource
 does NOT use the Lightning Enable API key.
 
 For the PROVIDER side (selling a service), use create_l402_challenge to generate
-a Lightning invoice at the negotiated price, then verify_l402_payment to confirm
+a Lightning invoice at the agreed price, then verify_l402_payment to confirm
 payment before delivering the service.
 """
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/test_l402_payment.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/test_l402_payment.py
@@ -1,0 +1,158 @@
+"""
+Test L402 Payment Tool
+
+A one-command self-test for the Lightning wallet: pays the public 1-sat L402 test
+endpoint end to end, proving the wallet is connected, returns a preimage, and can
+complete an L402 payment.
+
+It adds NO new payment logic — it delegates to the same proven
+``access_l402_resource`` path against a HARDCODED endpoint (no user-supplied URL,
+so no SSRF surface), then translates the raw result into a plain pass/fail verdict
+with a fix hint. That makes it a better onboarding primitive than telling a
+beginner to curl a magic URL.
+"""
+
+import json
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..budget_service import BudgetService
+    from ..payment_history_service import PaymentHistoryService
+    from ..l402_client import L402Client
+
+from .access_resource import access_l402_resource
+
+# The public 1-sat L402 test resource. Hardcoded on purpose so this tool can never
+# be repurposed into an arbitrary-URL payer. Only the base host is overridable, via
+# the same env var the rest of the MCP uses to point at a non-prod instance.
+TEST_PATH = "/l402/test/ping"
+
+# The endpoint charges 1 sat; small headroom, hard-capped so the self-test can never
+# spend more than a rounding error regardless of what the endpoint returns.
+MAX_TEST_SATS = 10
+
+
+def _resolve_test_endpoint() -> str:
+    """Resolve the hardcoded test path against the configured LE API base."""
+    base = os.environ.get("LIGHTNING_ENABLE_API_URL")
+    if not base or base.startswith("${"):
+        base = "https://api.lightningenable.com"
+    return base.rstrip("/") + TEST_PATH
+
+
+def _diagnose(error: str) -> tuple[str, str]:
+    """Map a raw error string to a stable reason code + a plain-language fix."""
+    e = (error or "").lower()
+    if "not configured" in e or "no wallet" in e:
+        return (
+            "no_wallet",
+            "No Lightning wallet is configured. Set NWC_CONNECTION_STRING (CoinOS/Alby Hub/CLINK), "
+            "STRIKE_API_KEY, or LND credentials — or add a wallet to ~/.lightning-enable/config.json. "
+            "NWC and Strike both work for L402.",
+        )
+    if "preimage" in e or "opennode" in e:
+        return (
+            "no_preimage",
+            "The wallet paid but did not return a preimage, which L402 requires. OpenNode cannot do "
+            "L402 — switch to NWC (CoinOS, Alby Hub, CLINK), LND, or Strike.",
+        )
+    if "insufficient" in e or "balance" in e or "funds" in e:
+        return (
+            "insufficient_funds",
+            "The wallet has too little balance to pay ~1 sat. Fund it with a small amount and retry.",
+        )
+    if "budget" in e or "limit" in e or "exceed" in e:
+        return (
+            "budget_block",
+            "The MCP budget blocked even this 1-sat payment. Loosen the auto-approve tier / per-payment "
+            "limit in ~/.lightning-enable/config.json.",
+        )
+    if "timeout" in e or "timed out" in e or "connection" in e or "resolve" in e:
+        return (
+            "network",
+            "Could not reach the wallet or the test endpoint. Check the wallet connection (is the NWC "
+            "relay reachable?) and your network, then retry.",
+        )
+    return (
+        "unknown",
+        "Check the error message above. Confirm a preimage-returning wallet (NWC, LND, or Strike) is "
+        "connected and funded, then retry.",
+    )
+
+
+def interpret(raw_json: str, endpoint: str) -> str:
+    """Turn the raw access_l402_resource result into a plain self-test verdict.
+
+    Kept pure so the diagnostics are unit-testable without a wallet.
+    """
+    try:
+        data = json.loads(raw_json)
+    except Exception as e:  # pragma: no cover - defensive
+        return json.dumps({
+            "success": False,
+            "test": "failed",
+            "reason": "unexpected",
+            "message": f"❌ L402 self-test result could not be interpreted: {e}",
+            "endpoint": endpoint,
+        })
+
+    if data.get("success"):
+        paid = data.get("paid_sats")
+        if paid:
+            return json.dumps({
+                "success": True,
+                "test": "passed",
+                "message": (
+                    f"✅ L402 works end to end. Paid {paid} sat(s), preimage verified. "
+                    "Your wallet is ready to pay L402 resources anywhere."
+                ),
+                "endpoint": endpoint,
+                "amountSats": paid,
+                "walletWorking": True,
+            }, indent=2)
+        # success without a payment: the test endpoint should always issue a 402, so
+        # the L402 flow was not exercised. Inconclusive.
+        return json.dumps({
+            "success": True,
+            "test": "inconclusive",
+            "message": (
+                "Endpoint returned success without requiring payment, so the L402 flow was not "
+                "exercised. Retry, or verify the test endpoint."
+            ),
+            "endpoint": endpoint,
+        }, indent=2)
+
+    error = data.get("error", "") or data.get("denialReason", "")
+    reason, fix = _diagnose(error)
+    return json.dumps({
+        "success": False,
+        "test": "failed",
+        "reason": reason,
+        "message": f"❌ L402 self-test failed: {error}",
+        "howToFix": fix,
+        "endpoint": endpoint,
+        "walletWorking": False,
+    }, indent=2)
+
+
+async def test_l402_payment(
+    l402_client: "L402Client | None" = None,
+    budget_service: "BudgetService | None" = None,
+    payment_history_service: "PaymentHistoryService | None" = None,
+) -> str:
+    """Self-test the wallet by paying the public 1-sat L402 endpoint end to end."""
+    endpoint = _resolve_test_endpoint()
+
+    # Delegate to the existing, proven L402 payment path. No new payment code,
+    # no bypass of budget/confirmation. max_sats hard-caps the spend.
+    raw = await access_l402_resource(
+        url=endpoint,
+        method="GET",
+        max_sats=MAX_TEST_SATS,
+        l402_client=l402_client,
+        budget_service=budget_service,
+        payment_history_service=payment_history_service,
+    )
+
+    return interpret(raw, endpoint)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/test_l402_payment.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/test_l402_payment.py
@@ -8,8 +8,12 @@ complete an L402 payment.
 It adds NO new payment logic — it delegates to the same proven
 ``access_l402_resource`` path against a HARDCODED endpoint (no user-supplied URL,
 so no SSRF surface), then translates the raw result into a plain pass/fail verdict
-with a fix hint. That makes it a better onboarding primitive than telling a
-beginner to curl a magic URL.
+with a fix hint.
+
+Interpretation checks the STRUCTURED signals the delegated path emits (a completed
+payment, a confirmation requirement, a budget denial, a non-JSON error) before
+falling back to matching the error string, so a rate-limit is never mistaken for a
+budget block and the no-wallet case still returns the structured verdict.
 """
 
 import json
@@ -35,44 +39,63 @@ MAX_TEST_SATS = 10
 
 def _resolve_test_endpoint() -> str:
     """Resolve the hardcoded test path against the configured LE API base."""
-    base = os.environ.get("LIGHTNING_ENABLE_API_URL")
+    base = (os.environ.get("LIGHTNING_ENABLE_API_URL") or "").strip()
     if not base or base.startswith("${"):
         base = "https://api.lightningenable.com"
     return base.rstrip("/") + TEST_PATH
 
 
 def _diagnose(error: str) -> tuple[str, str]:
-    """Map a raw error string to a stable reason code + a plain-language fix."""
+    """Map a raw error string to a stable reason code + a plain-language fix.
+
+    Order matters: the most specific / most-often-confused buckets are checked first
+    (rate-limit before budget; network before preimage). Budget denials and
+    confirmation requirements are handled structurally in ``interpret``, not here.
+    """
     e = (error or "").lower()
-    if "not configured" in e or "no wallet" in e:
+
+    if "not configured" in e or "no wallet" in e or "not initialized" in e:
         return (
             "no_wallet",
             "No Lightning wallet is configured. Set NWC_CONNECTION_STRING (CoinOS/Alby Hub/CLINK), "
             "STRIKE_API_KEY, or LND credentials — or add a wallet to ~/.lightning-enable/config.json. "
             "NWC and Strike both work for L402.",
         )
-    if "preimage" in e or "opennode" in e:
+    # Before budget: "Rate limit exceeded" contains "limit"/"exceed" but is NOT a budget issue.
+    if "rate limit" in e:
+        return (
+            "rate_limited",
+            "You've hit the request rate limit (shared with access_l402_resource). Wait for the window "
+            "to reset (about a minute) and retry — this is not a budget or wallet problem.",
+        )
+    # Before preimage: a network blip whose text mentions "preimage" is still a network issue.
+    if (
+        "timeout" in e or "timed out" in e or "unreachable" in e
+        or "network" in e or "resolve" in e or "connect" in e
+    ):
+        return (
+            "network",
+            "Could not reach the wallet or the test endpoint. Check the wallet connection (is the NWC "
+            "relay reachable?) and your network, then retry.",
+        )
+    if "opennode" in e or "preimage" in e:
         return (
             "no_preimage",
             "The wallet paid but did not return a preimage, which L402 requires. OpenNode cannot do "
             "L402 — switch to NWC (CoinOS, Alby Hub, CLINK), LND, or Strike.",
         )
-    if "insufficient" in e or "balance" in e or "funds" in e:
+    # Only "insufficient" — not bare "balance"/"funds", which also appear in balance-*fetch* failures.
+    if "insufficient" in e:
         return (
             "insufficient_funds",
             "The wallet has too little balance to pay ~1 sat. Fund it with a small amount and retry.",
         )
-    if "budget" in e or "limit" in e or "exceed" in e:
+    # Fallback for budget wording that reaches here (the structured path handles the normal shape).
+    if "budget" in e:
         return (
             "budget_block",
             "The MCP budget blocked even this 1-sat payment. Loosen the auto-approve tier / per-payment "
             "limit in ~/.lightning-enable/config.json.",
-        )
-    if "timeout" in e or "timed out" in e or "connection" in e or "resolve" in e:
-        return (
-            "network",
-            "Could not reach the wallet or the test endpoint. Check the wallet connection (is the NWC "
-            "relay reachable?) and your network, then retry.",
         )
     return (
         "unknown",
@@ -81,21 +104,36 @@ def _diagnose(error: str) -> tuple[str, str]:
     )
 
 
-def interpret(raw_json: str, endpoint: str) -> str:
+def interpret(raw: str, endpoint: str) -> str:
     """Turn the raw access_l402_resource result into a plain self-test verdict.
 
     Kept pure so the diagnostics are unit-testable without a wallet.
     """
     try:
-        data = json.loads(raw_json)
-    except Exception as e:  # pragma: no cover - defensive
+        data = json.loads(raw)
+    except Exception:
+        # access_l402_resource returns a BARE non-JSON string on some early errors
+        # (e.g. "Error: L402 client not initialized. Check NWC connection."). Map the
+        # known ones to a structured verdict instead of "could not be interpreted".
+        low = (raw or "").lower()
+        if "not initialized" in low or "not configured" in low or "no wallet" in low:
+            reason, fix = _diagnose(raw)
+            return json.dumps({
+                "success": False,
+                "test": "failed",
+                "reason": reason,
+                "message": f"❌ L402 self-test failed: {raw.strip()}",
+                "howToFix": fix,
+                "endpoint": endpoint,
+                "walletWorking": False,
+            }, indent=2)
         return json.dumps({
             "success": False,
             "test": "failed",
             "reason": "unexpected",
-            "message": f"❌ L402 self-test result could not be interpreted: {e}",
+            "message": f"❌ L402 self-test result could not be interpreted: {(raw or '')[:200]}",
             "endpoint": endpoint,
-        })
+        }, indent=2)
 
     if data.get("success"):
         paid = data.get("paid_sats")
@@ -112,18 +150,55 @@ def interpret(raw_json: str, endpoint: str) -> str:
                 "walletWorking": True,
             }, indent=2)
         # success without a payment: the test endpoint should always issue a 402, so
-        # the L402 flow was not exercised. Inconclusive.
+        # the L402 flow was not exercised — the wallet is unproven, NOT a pass.
         return json.dumps({
-            "success": True,
+            "success": False,
             "test": "inconclusive",
             "message": (
                 "Endpoint returned success without requiring payment, so the L402 flow was not "
-                "exercised. Retry, or verify the test endpoint."
+                "exercised — the wallet is unproven. Retry, or verify the test endpoint."
             ),
             "endpoint": endpoint,
+            "walletWorking": None,
         }, indent=2)
 
-    error = data.get("error", "") or data.get("denialReason", "")
+    # ---- Failure branch: read STRUCTURED signals before the error string. ----
+
+    # (1) Needs human confirmation — a healthy wallet, not a failure.
+    if data.get("requiresConfirmation"):
+        return json.dumps({
+            "success": False,
+            "test": "needs_confirmation",
+            "message": (
+                "Your budget config requires human confirmation for this payment. A confirmation code "
+                "was printed to the server console/logs (visible to the operator, not to the agent). "
+                "Re-run test_l402_payment with confirmation_nonce set to that code to finish the test."
+            ),
+            "howToConfirm": data.get("howToConfirm"),
+            "endpoint": endpoint,
+            "walletWorking": None,
+        }, indent=2)
+
+    # (2) Budget denial has a dedicated shape (a specific denialReason). Detect it
+    # structurally so the specific reason is surfaced verbatim, not the generic error.
+    deny_reason = data.get("denialReason")
+    if deny_reason or data.get("error") == "Payment denied by budget policy":
+        detail = deny_reason or "budget policy"
+        return json.dumps({
+            "success": False,
+            "test": "failed",
+            "reason": "budget_block",
+            "message": f"❌ L402 self-test blocked by budget: {detail}",
+            "howToFix": (
+                "The MCP budget denied even this ~1-sat payment. Raise the relevant cap in "
+                "~/.lightning-enable/config.json (the message above names which limit was hit)."
+            ),
+            "endpoint": endpoint,
+            "walletWorking": False,
+        }, indent=2)
+
+    # (3) Otherwise diagnose from the error string.
+    error = data.get("error", "")
     reason, fix = _diagnose(error)
     return json.dumps({
         "success": False,
@@ -137,11 +212,17 @@ def interpret(raw_json: str, endpoint: str) -> str:
 
 
 async def test_l402_payment(
+    confirmation_nonce: "str | None" = None,
     l402_client: "L402Client | None" = None,
     budget_service: "BudgetService | None" = None,
     payment_history_service: "PaymentHistoryService | None" = None,
 ) -> str:
-    """Self-test the wallet by paying the public 1-sat L402 endpoint end to end."""
+    """Self-test the wallet by paying the public 1-sat L402 endpoint end to end.
+
+    If the budget config requires confirmation for this amount, the first call
+    returns test="needs_confirmation" and the server prints a code to its console;
+    re-call with confirmation_nonce set to that code to finish.
+    """
     endpoint = _resolve_test_endpoint()
 
     # Delegate to the existing, proven L402 payment path. No new payment code,
@@ -150,6 +231,7 @@ async def test_l402_payment(
         url=endpoint,
         method="GET",
         max_sats=MAX_TEST_SATS,
+        confirmation_nonce=confirmation_nonce,
         l402_client=l402_client,
         budget_service=budget_service,
         payment_history_service=payment_history_service,

--- a/python/lightning-enable-mcp/tests/test_l402_self_test.py
+++ b/python/lightning-enable-mcp/tests/test_l402_self_test.py
@@ -16,12 +16,13 @@ from lightning_enable_mcp.tools.test_l402_payment import (
     interpret,
     _diagnose,
     _resolve_test_endpoint,
+    MAX_TEST_SATS,
 )
 
 
 class TestL402SelfTest:
     @pytest.mark.asyncio
-    async def test_passes_and_hits_hardcoded_endpoint(self):
+    async def test_passes_hits_endpoint_and_forwards_hard_cap(self):
         client = AsyncMock()
         client.fetch = AsyncMock(return_value=("pong", 1))  # (response_text, amount_paid)
 
@@ -33,16 +34,20 @@ class TestL402SelfTest:
         assert data["amountSats"] == 1
 
         # Must target the hardcoded 1-sat test endpoint, never a caller URL.
-        called_url = client.fetch.call_args.kwargs["url"]
-        assert called_url.endswith("/l402/test/ping")
+        assert client.fetch.call_args.kwargs["url"].endswith("/l402/test/ping")
+        # ...and forward the hard cap — the tool's core funds-safety guarantee.
+        assert client.fetch.call_args.kwargs["max_sats"] == MAX_TEST_SATS
+        assert MAX_TEST_SATS <= 10
 
     @pytest.mark.asyncio
-    async def test_no_client_reports_failure(self):
-        # access_l402_resource returns an error when no client is wired.
+    async def test_no_client_reports_no_wallet(self):
+        # access_l402_resource returns a BARE non-JSON string when no client is wired;
+        # interpret must still degrade to the structured no_wallet verdict.
         result = await run_self_test(l402_client=None)
         data = json.loads(result)
         assert data["success"] is False
         assert data["test"] == "failed"
+        assert data["reason"] == "no_wallet"
 
     def test_interpret_paid_is_passed(self):
         raw = json.dumps({"success": True, "paid_sats": 1})
@@ -50,10 +55,42 @@ class TestL402SelfTest:
         assert data["test"] == "passed"
         assert data["walletWorking"] is True
 
-    def test_interpret_success_without_payment_is_inconclusive(self):
+    def test_interpret_success_without_payment_is_inconclusive_not_success(self):
         raw = json.dumps({"success": True, "paid_sats": None})
         data = json.loads(interpret(raw, "endpoint"))
         assert data["test"] == "inconclusive"
+        # An unproven wallet must NOT read as a passing self-test.
+        assert data["success"] is False
+
+    def test_interpret_requires_confirmation_is_needs_confirmation(self):
+        raw = json.dumps({
+            "success": False,
+            "requiresConfirmation": True,
+            "error": "L402 payment requires human confirmation",
+            "howToConfirm": "Ask the human for the code shown in the server console.",
+        })
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "needs_confirmation"
+        assert "reason" not in data  # a healthy wallet awaiting a code isn't a failure
+        assert "confirmation_nonce" in data["message"]
+
+    def test_interpret_budget_deny_surfaces_specific_reason(self):
+        raw = json.dumps({
+            "success": False,
+            "error": "Payment denied by budget policy",
+            "denialReason": "Payment of $0.05 would exceed session limit of $5.00",
+        })
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "failed"
+        assert data["reason"] == "budget_block"
+        # The specific limit must be surfaced, not the generic "denied by budget policy".
+        assert "session limit of $5.00" in data["message"]
+
+    def test_interpret_non_json_no_wallet(self):
+        raw = "Error: L402 client not initialized. Check NWC connection."
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "failed"
+        assert data["reason"] == "no_wallet"
 
     def test_interpret_failure_diagnoses(self):
         raw = json.dumps({"success": False, "error": "NWC wallet not configured. Set NWC_CONNECTION_STRING"})
@@ -64,10 +101,13 @@ class TestL402SelfTest:
 
     @pytest.mark.parametrize("error,reason", [
         ("Wallet not configured. Set STRIKE_API_KEY", "no_wallet"),
+        ("Rate limit exceeded", "rate_limited"),                        # must NOT be budget_block
+        ("timed out waiting for preimage from relay", "network"),       # network before preimage
         ("Payment succeeded but no preimage was returned", "no_preimage"),
         ("OpenNode does not return preimages", "no_preimage"),
         ("Insufficient balance in wallet", "insufficient_funds"),
-        ("Payment exceeds per-session budget limit", "budget_block"),
+        ("Unable to retrieve balance", "unknown"),                      # balance-FETCH is not insufficient_funds
+        ("Payment exceeds per-session budget of $20", "budget_block"),
         ("Connection timed out reaching relay", "network"),
         ("Something totally unexpected happened", "unknown"),
     ])
@@ -78,3 +118,9 @@ class TestL402SelfTest:
 
     def test_endpoint_targets_test_ping(self):
         assert _resolve_test_endpoint().endswith("/l402/test/ping")
+
+    def test_endpoint_whitespace_env_falls_back_to_prod(self, monkeypatch):
+        # A blank/whitespace override must fall back to prod (parity with .NET),
+        # not produce a malformed "   /l402/test/ping".
+        monkeypatch.setenv("LIGHTNING_ENABLE_API_URL", "   ")
+        assert _resolve_test_endpoint() == "https://api.lightningenable.com/l402/test/ping"

--- a/python/lightning-enable-mcp/tests/test_l402_self_test.py
+++ b/python/lightning-enable-mcp/tests/test_l402_self_test.py
@@ -1,0 +1,80 @@
+"""
+Tests for the test_l402_payment self-test tool.
+
+The tool delegates to the proven access_l402_resource path against a hardcoded
+1-sat endpoint, then interprets the result into a plain pass/fail verdict.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock
+
+# Alias the tool on import: pytest would otherwise try to collect a callable named
+# `test_l402_payment` as a test case.
+from lightning_enable_mcp.tools.test_l402_payment import (
+    test_l402_payment as run_self_test,
+    interpret,
+    _diagnose,
+    _resolve_test_endpoint,
+)
+
+
+class TestL402SelfTest:
+    @pytest.mark.asyncio
+    async def test_passes_and_hits_hardcoded_endpoint(self):
+        client = AsyncMock()
+        client.fetch = AsyncMock(return_value=("pong", 1))  # (response_text, amount_paid)
+
+        result = await run_self_test(l402_client=client)
+        data = json.loads(result)
+
+        assert data["test"] == "passed"
+        assert data["walletWorking"] is True
+        assert data["amountSats"] == 1
+
+        # Must target the hardcoded 1-sat test endpoint, never a caller URL.
+        called_url = client.fetch.call_args.kwargs["url"]
+        assert called_url.endswith("/l402/test/ping")
+
+    @pytest.mark.asyncio
+    async def test_no_client_reports_failure(self):
+        # access_l402_resource returns an error when no client is wired.
+        result = await run_self_test(l402_client=None)
+        data = json.loads(result)
+        assert data["success"] is False
+        assert data["test"] == "failed"
+
+    def test_interpret_paid_is_passed(self):
+        raw = json.dumps({"success": True, "paid_sats": 1})
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "passed"
+        assert data["walletWorking"] is True
+
+    def test_interpret_success_without_payment_is_inconclusive(self):
+        raw = json.dumps({"success": True, "paid_sats": None})
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "inconclusive"
+
+    def test_interpret_failure_diagnoses(self):
+        raw = json.dumps({"success": False, "error": "NWC wallet not configured. Set NWC_CONNECTION_STRING"})
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "failed"
+        assert data["reason"] == "no_wallet"
+        assert "NWC_CONNECTION_STRING" in data["howToFix"]
+
+    @pytest.mark.parametrize("error,reason", [
+        ("Wallet not configured. Set STRIKE_API_KEY", "no_wallet"),
+        ("Payment succeeded but no preimage was returned", "no_preimage"),
+        ("OpenNode does not return preimages", "no_preimage"),
+        ("Insufficient balance in wallet", "insufficient_funds"),
+        ("Payment exceeds per-session budget limit", "budget_block"),
+        ("Connection timed out reaching relay", "network"),
+        ("Something totally unexpected happened", "unknown"),
+    ])
+    def test_diagnose_maps_reason_codes(self, error, reason):
+        r, fix = _diagnose(error)
+        assert r == reason
+        assert fix
+
+    def test_endpoint_targets_test_ping(self):
+        assert _resolve_test_endpoint().endswith("/l402/test/ping")

--- a/python/lightning-enable-mcp/tests/test_server.py
+++ b/python/lightning-enable-mcp/tests/test_server.py
@@ -51,6 +51,7 @@ class TestLightningEnableServer:
 
         expected_tools = {
             "access_l402_resource",
+            "test_l402_payment",
             "pay_l402_challenge",
             "check_wallet_balance",
             "get_payment_history",
@@ -76,7 +77,7 @@ class TestLightningEnableServer:
         }
 
         assert tool_names == expected_tools
-        assert len(tool_names) == 23
+        assert len(tool_names) == 24
 
     @pytest.mark.asyncio
     async def test_services_not_initialized_without_nwc(self):

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -10,7 +10,7 @@
 # to keep in sync on every release.
 
 name: lightning-enable
-description: AI agent Lightning payments and commerce — invoices, L402, API discovery, budgets, ASA negotiation. 23 tools, 15 free, 8 unlock with a Lightning Enable API key.
+description: AI agent Lightning payments and commerce — invoices, L402, API discovery, budgets, agent service agreements. 23 tools, 15 free, 8 unlock with a Lightning Enable API key.
 author: Lightning Enable
 license: MIT
 repository: https://github.com/refined-element/lightning-enable-mcp


### PR DESCRIPTION
## What
A one-command wallet **self-test**. `test_l402_payment` pays the public 1-sat L402 endpoint (`/l402/test/ping`) end to end and returns a plain verdict:

- ✅ **passed** — "Paid N sat(s), preimage verified, L402 works. Your wallet is ready."
- ❌ **failed** — with a specific reason code + fix: `no_wallet`, `no_preimage` (e.g. OpenNode), `insufficient_funds`, `budget_block`, `network`.

Answers the #1 beginner question — *"is my wallet actually working?"* — in one call, and the agent can offer it proactively.

## Design (safe by construction)
- **No new payment logic.** Delegates to the proven `access_l402_resource` path (budget checks, recording, everything).
- **Hardcoded endpoint** — no user-supplied URL, so no SSRF surface. Only the base host is overridable via `LIGHTNING_ENABLE_API_URL` (same as the rest of the MCP).
- **Hard-capped at 10 sats** (endpoint charges 1). Always under the auto-approve threshold, so no confirmation friction.
- .NET: auto-discovered via `WithToolsFromAssembly`. Python: registered in `server.py` (import + tool metadata + dispatch).

## Tests
- **.NET: 285 pass** (8 new) — end-to-end pass path, hardcoded-endpoint guarantee, every `Diagnose` branch.
- **Python: 466 pass** (14 new) — same coverage; updated the tool-count/name assertions (23 → 24).

## ⚠️ Not included (gated on owner go)
- **No version bump, no publish.** This is code + tests only. The version bump in both `.csproj` and `pyproject.toml` + the doc-count sweep (15→16 out-of-box tools across READMEs/`server.json`) is the separate release step, held for explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeVJ1dSozozhHDmNHiPj5f