### PR TITLE
release: v1.13.0 — test_l402_payment self-test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of [Lightning Enable](https://lightningenable.com) — infrastructure for a
 [![Discord](https://img.shields.io/discord/1405389254892195951?label=community&logo=discord&color=5865F2)](https://discord.gg/rX7NxHY8vx)
 
 
-An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 23 tools total: 15 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, requesting, settling, and attesting services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
+An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 24 tools total: 16 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, requesting, settling, and attesting services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
 
 Available in **.NET** and **Python**.
 
@@ -104,7 +104,7 @@ Buy me a Lightning Enable t-shirt from store.lightningenable.com
 
 - [.NET README](dotnet/src/LightningEnable.Mcp/README.md) — Full .NET documentation
 - [Python README](python/lightning-enable-mcp/README.md) — Full Python documentation
-- [Full Docs](https://docs.lightningenable.com/products/l402-microtransactions/mcp-complete-guide) — Complete guide with all 23 tools
+- [Full Docs](https://docs.lightningenable.com/products/l402-microtransactions/mcp-complete-guide) — Complete guide with all 24 tools
 - [AI Spending Security](https://docs.lightningenable.com/products/l402-microtransactions/ai-spending-security) — Budget controls and safety
 
 ## Repository Structure

--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.12.13</Version>
+    <Version>1.13.0</Version>
     <!-- Track the package version so the assembly/file version (read by the MCP serverInfo
          handshake and the startup banner) never drifts. Bump the package version only.
          NOTE: keep the literal version-tag text out of this comment — the publish workflow

--- a/dotnet/src/LightningEnable.Mcp/README.md
+++ b/dotnet/src/LightningEnable.Mcp/README.md
@@ -2,7 +2,7 @@
 
 # Lightning Enable MCP Server
 
-A Model Context Protocol (MCP) server that enables AI agents to make Lightning Network payments. 15 tools work out of the box (free, no subscription). 8 tools require an [Agentic Commerce subscription](https://lightningenable.com) (from $99/mo) and `LIGHTNING_ENABLE_API_KEY`: 2 producer tools (`create_l402_challenge`, `verify_l402_payment`) and 6 Agent Service Agreement tools for agent-to-agent commerce over Nostr.
+A Model Context Protocol (MCP) server that enables AI agents to make Lightning Network payments. 16 tools work out of the box (free, no subscription). 8 tools require an [Agentic Commerce subscription](https://lightningenable.com) (from $99/mo) and `LIGHTNING_ENABLE_API_KEY`: 2 producer tools (`create_l402_challenge`, `verify_l402_payment`) and 6 Agent Service Agreement tools for agent-to-agent commerce over Nostr.
 
 ## Overview
 
@@ -246,6 +246,13 @@ Fetches a URL, automatically paying any L402 challenge. Requires a wallet that r
 - `headers`: Optional headers as JSON object
 - `body`: Optional request body
 - `maxSats`: Maximum sats to pay. Default: 1000
+
+### test_l402_payment
+
+Self-tests the wallet by paying the public 1-sat L402 test endpoint (`/l402/test/ping`) end to end. Proves the wallet is connected, returns a preimage, and can complete an L402 payment — the one-line answer to "is my wallet actually working?". Costs about 1 satoshi. Returns a plain verdict (`passed` / `needs_confirmation` / `inconclusive` / `failed` with a reason code). If your budget config requires confirmation for this amount, re-run with `confirmationNonce` set to the code the server prints to its console.
+
+**Parameters:**
+- `confirmationNonce`: Confirmation code from the server console, if a prior call returned `test="needs_confirmation"`. Omit on the first call.
 
 ### pay_l402_challenge
 

--- a/dotnet/src/LightningEnable.Mcp/Tools/TestL402PaymentTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/TestL402PaymentTool.cs
@@ -180,6 +180,25 @@ public static class TestL402PaymentTool
             });
         }
 
+        // (3.5) Idempotency: the same 1-sat invoice was already paid moments ago
+        // (L402 reuses it for ~60s to prevent double-charges). NOT a wallet failure —
+        // it's evidence a prior payment succeeded; the wallet is fine.
+        var errPeek = (root.TryGetProperty("error", out var epk) ? epk.GetString() : "") ?? "";
+        var errLow = errPeek.ToLowerInvariant();
+        if (errLow.Contains("already") && errLow.Contains("paid"))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                test = "inconclusive",
+                message = "The 1-sat test invoice was already paid moments ago — L402 reuses the same "
+                    + "invoice for ~60 seconds to prevent double-charges. Your wallet is fine; wait a "
+                    + "minute and run the test again for a fresh payment.",
+                endpoint,
+                walletWorking = (bool?)null
+            });
+        }
+
         // (4) Otherwise diagnose from the error string.
         var error = root.TryGetProperty("error", out var e) ? (e.GetString() ?? "") : "";
         var (reason, fix) = Diagnose(error);
@@ -218,6 +237,13 @@ public static class TestL402PaymentTool
     internal static (string reason, string fix) Diagnose(string error)
     {
         var e = (error ?? string.Empty).ToLowerInvariant();
+
+        // A blank error usually means a client-side timeout / dropped connection
+        // (e.g. an HTTP ReadTimeout stringifies to empty) — surface that, not "unknown".
+        if (string.IsNullOrWhiteSpace(e))
+            return ("network",
+                "The request failed without a specific error — usually a timeout or a dropped connection. "
+                + "Check your network / the NWC relay is reachable, then retry.");
 
         if (e.Contains("not configured") || e.Contains("no wallet") || e.Contains("not initialized"))
             return ("no_wallet",

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Tools/TestL402PaymentToolTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Tools/TestL402PaymentToolTests.cs
@@ -184,8 +184,30 @@ public class TestL402PaymentToolTests
         verdict.GetProperty("reason").GetString().Should().Be("unexpected");
     }
 
+    [Fact]
+    public void Interpret_AlreadyPaid_IsInconclusive_NotBrokenWallet()
+    {
+        // L402 idempotency: re-testing within ~60s reuses the same invoice, which
+        // the wallet refuses to double-pay. The wallet is fine — not a failure.
+        var raw = JsonSerializer.Serialize(new
+        {
+            success = false,
+            error = "Payment failed: Invoice has already been paid"
+        });
+
+        var verdict = JsonDocument.Parse(TestL402PaymentTool.Interpret(raw, "e")).RootElement;
+
+        verdict.GetProperty("test").GetString().Should().Be("inconclusive");
+        verdict.GetProperty("message").GetString().Should().Contain("60 second");
+        // must NOT claim the wallet is broken
+        verdict.TryGetProperty("walletWorking", out var ww).Should().BeTrue();
+        (ww.ValueKind == JsonValueKind.Null).Should().BeTrue();
+    }
+
     [Theory]
     [InlineData("Wallet not configured. Set STRIKE_API_KEY...", "no_wallet")]
+    [InlineData("", "network")]                                                  // blank (e.g. ReadTimeout) -> network, not unknown
+    [InlineData("   ", "network")]
     [InlineData("Rate limit exceeded", "rate_limited")]                          // must NOT be budget_block
     [InlineData("timed out waiting for preimage from relay", "network")]         // network before preimage
     [InlineData("Payment succeeded but no preimage was returned", "no_preimage")]

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.12.13"
+version = "1.13.0"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/test_l402_payment.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/test_l402_payment.py
@@ -54,6 +54,15 @@ def _diagnose(error: str) -> tuple[str, str]:
     """
     e = (error or "").lower()
 
+    # A blank error usually means a client-side timeout / dropped connection (e.g. an
+    # httpx.ReadTimeout stringifies to empty) — surface that, not "unknown".
+    if not e.strip():
+        return (
+            "network",
+            "The request failed without a specific error — usually a timeout or a dropped connection. "
+            "Check your network / the NWC relay is reachable, then retry.",
+        )
+
     if "not configured" in e or "no wallet" in e or "not initialized" in e:
         return (
             "no_wallet",
@@ -195,6 +204,23 @@ def interpret(raw: str, endpoint: str) -> str:
             ),
             "endpoint": endpoint,
             "walletWorking": False,
+        }, indent=2)
+
+    # (2.5) Idempotency: the same 1-sat invoice was already paid moments ago (L402
+    # reuses it for ~60s to prevent double-charges). NOT a wallet failure — it's
+    # evidence a prior payment succeeded; the wallet is fine.
+    err_peek = (data.get("error") or "").lower()
+    if "already" in err_peek and "paid" in err_peek:
+        return json.dumps({
+            "success": False,
+            "test": "inconclusive",
+            "message": (
+                "The 1-sat test invoice was already paid moments ago — L402 reuses the same invoice "
+                "for ~60 seconds to prevent double-charges. Your wallet is fine; wait a minute and run "
+                "the test again for a fresh payment."
+            ),
+            "endpoint": endpoint,
+            "walletWorking": None,
         }, indent=2)
 
     # (3) Otherwise diagnose from the error string.

--- a/python/lightning-enable-mcp/tests/test_l402_self_test.py
+++ b/python/lightning-enable-mcp/tests/test_l402_self_test.py
@@ -99,8 +99,19 @@ class TestL402SelfTest:
         assert data["reason"] == "no_wallet"
         assert "NWC_CONNECTION_STRING" in data["howToFix"]
 
+    def test_interpret_already_paid_is_inconclusive(self):
+        # L402 idempotency: re-testing within ~60s reuses the same invoice, which the
+        # wallet refuses to double-pay. The wallet is fine — not a failure.
+        raw = json.dumps({"success": False, "error": "Payment failed: Invoice has already been paid"})
+        data = json.loads(interpret(raw, "endpoint"))
+        assert data["test"] == "inconclusive"
+        assert data["walletWorking"] is None  # not a broken wallet
+        assert "60 second" in data["message"]
+
     @pytest.mark.parametrize("error,reason", [
         ("Wallet not configured. Set STRIKE_API_KEY", "no_wallet"),
+        ("", "network"),                                                # blank (e.g. ReadTimeout) -> network, not unknown
+        ("   ", "network"),
         ("Rate limit exceeded", "rate_limited"),                        # must NOT be budget_block
         ("timed out waiting for preimage from relay", "network"),       # network before preimage
         ("Payment succeeded but no preimage was returned", "no_preimage"),


### PR DESCRIPTION
Publishes the new **test_l402_payment** self-test tool to NuGet / PyPI / Docker / MCP Registry.

**Verified end to end** against a live NWC wallet: real 1-sat L402 payment → `test: "passed"`, `walletWorking: true`.

## Included
- The `test_l402_payment` tool (both packages), with all code-review findings from #52 already fixed.
- Two error-message fixes surfaced by the live run:
  - "Invoice has already been paid" (L402 idempotency, ~60s reuse) → `test="inconclusive"` / `walletWorking=null` with a clear retry message (not a failure).
  - A blank error (e.g. an HTTP ReadTimeout that stringifies to empty) → `reason="network"` with a useful message (not an empty `"failed: "`).
- Version `1.12.13 → 1.13.0`; README tool counts `15→16` out-of-box, `23→24` total; `test_l402_payment` documented.

## Tests
.NET **295** pass, Python **476** pass.

Merging touches `csproj` + `pyproject`, which triggers `publish-mcp.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeVJ1dSozozhHDmNHiPj5f