### PR TITLE
feat: durable payment receipts + get_receipts tool (v1.14.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Part of [Lightning Enable](https://lightningenable.com) — infrastructure for a
 [![Discord](https://img.shields.io/discord/1405389254892195951?label=community&logo=discord&color=5865F2)](https://discord.gg/rX7NxHY8vx)
 
 
-An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 24 tools total: 16 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, requesting, settling, and attesting services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
+An open-source MCP (Model Context Protocol) server that enables AI agents to make Lightning Network payments and participate in agent-to-agent commerce. 25 tools total: 17 free wallet tools, 2 producer tools, and 6 Agent Service Agreement (ASA) tools for discovering, requesting, settling, and attesting services between agents on Nostr. Producer and ASA tools require an [Agentic Commerce subscription](https://lightningenable.com).
 
 Available in **.NET** and **Python**.
 
@@ -104,7 +104,7 @@ Buy me a Lightning Enable t-shirt from store.lightningenable.com
 
 - [.NET README](dotnet/src/LightningEnable.Mcp/README.md) — Full .NET documentation
 - [Python README](python/lightning-enable-mcp/README.md) — Full Python documentation
-- [Full Docs](https://docs.lightningenable.com/products/l402-microtransactions/mcp-complete-guide) — Complete guide with all 24 tools
+- [Full Docs](https://docs.lightningenable.com/products/l402-microtransactions/mcp-complete-guide) — Complete guide with all 25 tools
 - [AI Spending Security](https://docs.lightningenable.com/products/l402-microtransactions/ai-spending-security) — Budget controls and safety
 
 ## Repository Structure

--- a/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
+++ b/dotnet/src/LightningEnable.Mcp/LightningEnable.Mcp.csproj
@@ -12,7 +12,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>LightningEnable.Mcp</PackageId>
-    <Version>1.13.0</Version>
+    <Version>1.14.0</Version>
     <!-- Track the package version so the assembly/file version (read by the MCP serverInfo
          handshake and the startup banner) never drifts. Bump the package version only.
          NOTE: keep the literal version-tag text out of this comment — the publish workflow

--- a/dotnet/src/LightningEnable.Mcp/Program.cs
+++ b/dotnet/src/LightningEnable.Mcp/Program.cs
@@ -212,6 +212,8 @@ public class Program
         builder.Services.AddSingleton<IBudgetService, BudgetService>();
         builder.Services.AddSingleton<IPaymentHistoryService, PaymentHistoryService>();
         builder.Services.AddSingleton<IRateLimiter, RateLimiter>();
+        // Durable, append-only spend receipts (~/.lightning-enable/receipts.jsonl).
+        builder.Services.AddSingleton<IReceiptService, ReceiptService>();
 
         // Configure MCP server with stdio transport
         builder.Services

--- a/dotnet/src/LightningEnable.Mcp/README.md
+++ b/dotnet/src/LightningEnable.Mcp/README.md
@@ -189,14 +189,16 @@ Checks the connected wallet balance and session spending.
 
 **Parameters:** None
 
+**Returns:** Wallet balance in satoshis, session spending summary, budget remaining
+
 ### get_receipts
 
-Reads the durable, append-only payment receipt log at `~/.lightning-enable/receipts.jsonl`. Every L402 payment appends one receipt (endpoint, amount, wallet, spend policy, session totals, and how to revoke the wallet). Unlike `get_payment_history` (in-memory, this session only), receipts persist across sessions — the audit + "pull the plug" record. Receipts never contain secrets (no preimage, macaroon, or connection string).
+Reads the durable, append-only payment receipt log at `~/.lightning-enable/receipts.jsonl`. Every L402 payment appends one receipt (endpoint, amount, wallet, spend policy, session spend, and how to revoke the wallet). Unlike `get_payment_history` (in-memory, this session only), receipts persist across sessions — the audit + "pull the plug" record. Receipts never contain secrets (no preimage, macaroon, or connection string).
 
 **Parameters:**
 - `limit`: Maximum number of recent receipts to return (1-200). Default: 20
 
-**Returns:** Wallet balance in satoshis, session spending summary, budget remaining
+**Returns:** `{ success, count, totalSatsInView, logFile, receipts, note }` — the recent receipts plus a spend total and the log-file path.
 
 ### get_payment_history
 

--- a/dotnet/src/LightningEnable.Mcp/README.md
+++ b/dotnet/src/LightningEnable.Mcp/README.md
@@ -2,7 +2,7 @@
 
 # Lightning Enable MCP Server
 
-A Model Context Protocol (MCP) server that enables AI agents to make Lightning Network payments. 16 tools work out of the box (free, no subscription). 8 tools require an [Agentic Commerce subscription](https://lightningenable.com) (from $99/mo) and `LIGHTNING_ENABLE_API_KEY`: 2 producer tools (`create_l402_challenge`, `verify_l402_payment`) and 6 Agent Service Agreement tools for agent-to-agent commerce over Nostr.
+A Model Context Protocol (MCP) server that enables AI agents to make Lightning Network payments. 17 tools work out of the box (free, no subscription). 8 tools require an [Agentic Commerce subscription](https://lightningenable.com) (from $99/mo) and `LIGHTNING_ENABLE_API_KEY`: 2 producer tools (`create_l402_challenge`, `verify_l402_payment`) and 6 Agent Service Agreement tools for agent-to-agent commerce over Nostr.
 
 ## Overview
 
@@ -188,6 +188,13 @@ Pay a Lightning invoice directly and get the preimage as proof of payment.
 Checks the connected wallet balance and session spending.
 
 **Parameters:** None
+
+### get_receipts
+
+Reads the durable, append-only payment receipt log at `~/.lightning-enable/receipts.jsonl`. Every L402 payment appends one receipt (endpoint, amount, wallet, spend policy, session totals, and how to revoke the wallet). Unlike `get_payment_history` (in-memory, this session only), receipts persist across sessions — the audit + "pull the plug" record. Receipts never contain secrets (no preimage, macaroon, or connection string).
+
+**Parameters:**
+- `limit`: Maximum number of recent receipts to return (1-200). Default: 20
 
 **Returns:** Wallet balance in satoshis, session spending summary, budget remaining
 

--- a/dotnet/src/LightningEnable.Mcp/Services/ReceiptService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/ReceiptService.cs
@@ -1,0 +1,161 @@
+using System.Text.Json.Nodes;
+
+namespace LightningEnable.Mcp.Services;
+
+/// <summary>
+/// Writes and reads durable, append-only spend receipts at
+/// <c>~/.lightning-enable/receipts.jsonl</c> — one JSON object per line.
+///
+/// This is the audit + revocation record the in-memory
+/// <see cref="IPaymentHistoryService"/> is not: it survives the session and lives
+/// off the agent's context path, so rapid machine-to-machine / agent-to-agent flows
+/// don't pay a per-payment token cost for it. Never contains secrets (no preimage,
+/// macaroon, or wallet connection string). <c>revokePath</c> is instructions only.
+/// </summary>
+public interface IReceiptService
+{
+    void LogPayment(string walletLabel, string endpoint, long amountSats, string policy,
+        long? sessionSpentSats, decimal? sessionRemainingUsd);
+
+    List<JsonNode> ReadRecent(int limit);
+
+    string Path { get; }
+}
+
+public sealed class ReceiptService : IReceiptService
+{
+    // Rotate to a single ".1" backup once the live file passes this size, so the
+    // log is self-limiting (~2x this cap) without per-write trims.
+    private const long MaxBytes = 5 * 1024 * 1024; // 5 MB
+
+    private static readonly object _lock = new();
+
+    private static readonly Dictionary<string, string> RevokePaths = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["NWC"] = "Your NWC wallet app (CoinOS / Alby Hub / CLINK) → Connections / Nostr Wallet Connect → delete this connection.",
+        ["Strike"] = "Strike dashboard (dashboard.strike.me) → API keys → revoke the key this agent uses.",
+        ["LND"] = "Your LND node → bake a new macaroon and revoke/rotate the one this client uses.",
+        ["OpenNode"] = "OpenNode dashboard → Integrations / API keys → revoke the key this agent uses.",
+    };
+    private const string RevokeDefault = "Revoke this wallet's connection or API key in its own app/dashboard.";
+
+    private readonly string _path;
+
+    public ReceiptService(IBudgetConfigurationService? configService = null)
+    {
+        var dir = TryGetConfigDir(configService)
+            ?? System.IO.Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".lightning-enable");
+        _path = System.IO.Path.Combine(dir, "receipts.jsonl");
+    }
+
+    // Test-only: write to an explicit path.
+    internal ReceiptService(string receiptsPath) => _path = receiptsPath;
+
+    public string Path => _path;
+
+    private static string? TryGetConfigDir(IBudgetConfigurationService? cs)
+    {
+        try
+        {
+            var p = cs?.ConfigFilePath;
+            return string.IsNullOrWhiteSpace(p) ? null : System.IO.Path.GetDirectoryName(p);
+        }
+        catch { return null; }
+    }
+
+    public void LogPayment(string walletLabel, string endpoint, long amountSats, string policy,
+        long? sessionSpentSats, decimal? sessionRemainingUsd)
+    {
+        try
+        {
+            var label = string.IsNullOrWhiteSpace(walletLabel) ? "unknown" : walletLabel;
+            var receipt = new JsonObject
+            {
+                ["type"] = "l402_payment_receipt",
+                ["timestamp"] = DateTime.UtcNow.ToString("o"),
+                ["endpoint"] = endpoint,               // already redacted by the caller
+                ["amountSats"] = amountSats,
+                ["wallet"] = label,
+                ["policy"] = policy,
+                ["sessionSpentSats"] = sessionSpentSats.HasValue ? JsonValue.Create(sessionSpentSats.Value) : null,
+                ["sessionRemainingUsd"] = sessionRemainingUsd.HasValue ? JsonValue.Create(sessionRemainingUsd.Value) : null,
+                ["revokePath"] = RevokePaths.TryGetValue(label, out var rp) ? rp : RevokeDefault,
+            };
+            Append(receipt.ToJsonString());
+        }
+        catch (Exception ex)
+        {
+            // A receipt is an audit convenience — it must NEVER break a payment.
+            Console.Error.WriteLine($"[Lightning Enable] Failed to write payment receipt: {ex.Message}");
+        }
+    }
+
+    private void Append(string line)
+    {
+        lock (_lock)
+        {
+            var dir = System.IO.Path.GetDirectoryName(_path);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            RotateIfNeeded();
+            var isNew = !File.Exists(_path);
+            File.AppendAllText(_path, line + "\n");
+            if (isNew) RestrictPerms();
+        }
+    }
+
+    private void RotateIfNeeded()
+    {
+        try
+        {
+            var fi = new FileInfo(_path);
+            if (fi.Exists && fi.Length > MaxBytes)
+            {
+                var backup = _path + ".1";
+                if (File.Exists(backup)) File.Delete(backup);
+                File.Move(_path, backup);
+            }
+        }
+        catch { /* rotation is best-effort */ }
+    }
+
+    private void RestrictPerms()
+    {
+        try
+        {
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(_path, UnixFileMode.UserRead | UnixFileMode.UserWrite); // 0600
+            // Windows: the config directory is already ACL-restricted on first-run
+            // config write; the receipts file inherits that. Best-effort skip here.
+        }
+        catch { /* best effort, mirrors config.json */ }
+    }
+
+    public List<JsonNode> ReadRecent(int limit)
+    {
+        var outp = new List<JsonNode>();
+        try
+        {
+            if (!File.Exists(_path)) return outp;
+            string[] lines;
+            lock (_lock) { lines = File.ReadAllLines(_path); }
+            var start = Math.Max(0, lines.Length - Math.Max(0, limit));
+            for (var i = start; i < lines.Length; i++)
+            {
+                var l = lines[i].Trim();
+                if (l.Length == 0) continue;
+                try
+                {
+                    var node = JsonNode.Parse(l);
+                    if (node != null) outp.Add(node);
+                }
+                catch { /* skip a torn/partial line rather than fail the whole read */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Lightning Enable] Failed to read receipts: {ex.Message}");
+        }
+        return outp;
+    }
+}

--- a/dotnet/src/LightningEnable.Mcp/Services/ReceiptService.cs
+++ b/dotnet/src/LightningEnable.Mcp/Services/ReceiptService.cs
@@ -15,7 +15,7 @@ namespace LightningEnable.Mcp.Services;
 public interface IReceiptService
 {
     void LogPayment(string walletLabel, string endpoint, long amountSats, string policy,
-        long? sessionSpentSats, decimal? sessionRemainingUsd);
+        long? sessionSpentSats);
 
     List<JsonNode> ReadRecent(int limit);
 
@@ -26,7 +26,7 @@ public sealed class ReceiptService : IReceiptService
 {
     // Rotate to a single ".1" backup once the live file passes this size, so the
     // log is self-limiting (~2x this cap) without per-write trims.
-    private const long MaxBytes = 5 * 1024 * 1024; // 5 MB
+    private const long DefaultMaxBytes = 5 * 1024 * 1024; // 5 MB
 
     private static readonly object _lock = new();
 
@@ -40,6 +40,7 @@ public sealed class ReceiptService : IReceiptService
     private const string RevokeDefault = "Revoke this wallet's connection or API key in its own app/dashboard.";
 
     private readonly string _path;
+    private readonly long _maxBytes;
 
     public ReceiptService(IBudgetConfigurationService? configService = null)
     {
@@ -47,10 +48,22 @@ public sealed class ReceiptService : IReceiptService
             ?? System.IO.Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".lightning-enable");
         _path = System.IO.Path.Combine(dir, "receipts.jsonl");
+        _maxBytes = DefaultMaxBytes;
     }
 
     // Test-only: write to an explicit path.
-    internal ReceiptService(string receiptsPath) => _path = receiptsPath;
+    internal ReceiptService(string receiptsPath)
+    {
+        _path = receiptsPath;
+        _maxBytes = DefaultMaxBytes;
+    }
+
+    // Test-only: explicit path + a shrunk rotation threshold to exercise rotation cheaply.
+    internal ReceiptService(string receiptsPath, long maxBytes)
+    {
+        _path = receiptsPath;
+        _maxBytes = maxBytes;
+    }
 
     public string Path => _path;
 
@@ -65,7 +78,7 @@ public sealed class ReceiptService : IReceiptService
     }
 
     public void LogPayment(string walletLabel, string endpoint, long amountSats, string policy,
-        long? sessionSpentSats, decimal? sessionRemainingUsd)
+        long? sessionSpentSats)
     {
         try
         {
@@ -73,13 +86,16 @@ public sealed class ReceiptService : IReceiptService
             var receipt = new JsonObject
             {
                 ["type"] = "l402_payment_receipt",
-                ["timestamp"] = DateTime.UtcNow.ToString("o"),
+                // Canonical millisecond-precision UTC "Z" form (parity with the Python side).
+                ["timestamp"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
                 ["endpoint"] = endpoint,               // already redacted by the caller
                 ["amountSats"] = amountSats,
                 ["wallet"] = label,
                 ["policy"] = policy,
+                // Post-payment session total (session-remaining is intentionally omitted:
+                // deriving it consistently across runtimes was error-prone — spentSats is
+                // the accurate, unambiguous figure).
                 ["sessionSpentSats"] = sessionSpentSats.HasValue ? JsonValue.Create(sessionSpentSats.Value) : null,
-                ["sessionRemainingUsd"] = sessionRemainingUsd.HasValue ? JsonValue.Create(sessionRemainingUsd.Value) : null,
                 ["revokePath"] = RevokePaths.TryGetValue(label, out var rp) ? rp : RevokeDefault,
             };
             Append(receipt.ToJsonString());
@@ -109,7 +125,7 @@ public sealed class ReceiptService : IReceiptService
         try
         {
             var fi = new FileInfo(_path);
-            if (fi.Exists && fi.Length > MaxBytes)
+            if (fi.Exists && fi.Length > _maxBytes)
             {
                 var backup = _path + ".1";
                 if (File.Exists(backup)) File.Delete(backup);
@@ -134,20 +150,28 @@ public sealed class ReceiptService : IReceiptService
     public List<JsonNode> ReadRecent(int limit)
     {
         var outp = new List<JsonNode>();
+        if (limit <= 0) return outp;
         try
         {
-            if (!File.Exists(_path)) return outp;
-            string[] lines;
-            lock (_lock) { lines = File.ReadAllLines(_path); }
-            var start = Math.Max(0, lines.Length - Math.Max(0, limit));
-            for (var i = start; i < lines.Length; i++)
+            // Read the rotated ".1" backup first (older) then the live file (newer), so
+            // a read right after a rotation still returns recent history.
+            var lines = new List<string>();
+            foreach (var p in new[] { _path + ".1", _path })
+            {
+                if (!File.Exists(p)) continue;
+                lock (_lock) { lines.AddRange(File.ReadAllLines(p)); }
+            }
+
+            var start = Math.Max(0, lines.Count - limit);
+            for (var i = start; i < lines.Count; i++)
             {
                 var l = lines[i].Trim();
                 if (l.Length == 0) continue;
                 try
                 {
                     var node = JsonNode.Parse(l);
-                    if (node != null) outp.Add(node);
+                    // Only surface object lines; skip a torn/interleaved/non-object line.
+                    if (node is JsonObject) outp.Add(node);
                 }
                 catch { /* skip a torn/partial line rather than fail the whole read */ }
             }

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -46,8 +46,14 @@ public static class AccessL402ResourceTool
         IPriceService? priceService = null,
         IPaymentHistoryService? paymentHistory = null,
         IRateLimiter? rateLimiter = null,
+        IReceiptService? receiptService = null,
+        IWalletService? walletService = null,
         CancellationToken cancellationToken = default)
     {
+        // Captured for the durable receipt (success path); set from the budget check below.
+        var paymentPolicy = "auto (no budget check)";
+        decimal? sessionRemainingUsd = null;
+
         // Rate limiting check
         if (rateLimiter != null && !rateLimiter.IsAllowed("access_l402_resource"))
         {
@@ -93,6 +99,8 @@ public static class AccessL402ResourceTool
         if (budgetService != null)
         {
             var approvalResult = await budgetService.CheckApprovalLevelAsync(maxSats, cancellationToken);
+            paymentPolicy = approvalResult.Level.ToString();
+            sessionRemainingUsd = approvalResult.RemainingSessionBudgetUsd;
 
             if (approvalResult.Level == ApprovalLevel.Deny)
             {
@@ -211,6 +219,24 @@ public static class AccessL402ResourceTool
                 body,
                 maxSats,
                 cancellationToken);
+
+            // Durable, off-context-path spend receipt whenever a payment actually
+            // settled (covers both the 200 path and the paid-but-retry-failed path).
+            // Redacted endpoint, no secrets; best-effort, never breaks the payment.
+            if (receiptService != null && result.PaidAmountSats > 0)
+            {
+                try
+                {
+                    receiptService.LogPayment(
+                        walletService?.ProviderName ?? "unknown",
+                        RedactUrl(url),
+                        result.PaidAmountSats,
+                        paymentPolicy,
+                        budgetService?.GetConfig()?.SessionSpent,
+                        sessionRemainingUsd);
+                }
+                catch { /* audit convenience must never break the payment */ }
+            }
 
             if (result.Success)
             {

--- a/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/AccessL402ResourceTool.cs
@@ -52,7 +52,6 @@ public static class AccessL402ResourceTool
     {
         // Captured for the durable receipt (success path); set from the budget check below.
         var paymentPolicy = "auto (no budget check)";
-        decimal? sessionRemainingUsd = null;
 
         // Rate limiting check
         if (rateLimiter != null && !rateLimiter.IsAllowed("access_l402_resource"))
@@ -99,8 +98,7 @@ public static class AccessL402ResourceTool
         if (budgetService != null)
         {
             var approvalResult = await budgetService.CheckApprovalLevelAsync(maxSats, cancellationToken);
-            paymentPolicy = approvalResult.Level.ToString();
-            sessionRemainingUsd = approvalResult.RemainingSessionBudgetUsd;
+            paymentPolicy = PolicyString(approvalResult.Level);
 
             if (approvalResult.Level == ApprovalLevel.Deny)
             {
@@ -232,8 +230,7 @@ public static class AccessL402ResourceTool
                         RedactUrl(url),
                         result.PaidAmountSats,
                         paymentPolicy,
-                        budgetService?.GetConfig()?.SessionSpent,
-                        sessionRemainingUsd);
+                        budgetService?.GetConfig()?.SessionSpent);
                 }
                 catch { /* audit convenience must never break the payment */ }
             }
@@ -339,6 +336,19 @@ public static class AccessL402ResourceTool
     /// reach console/log history (engineering standard #5). The full URL is still returned
     /// in tool results — the caller already supplied it.
     /// </summary>
+    // Snake_case policy label matching the Python runtime's ApprovalLevel.value, so
+    // receipts.jsonl carries one consistent policy string regardless of which server
+    // (Python or .NET) wrote the line.
+    private static string PolicyString(ApprovalLevel level) => level switch
+    {
+        ApprovalLevel.AutoApprove => "auto_approve",
+        ApprovalLevel.LogAndApprove => "log_and_approve",
+        ApprovalLevel.FormConfirm => "form_confirm",
+        ApprovalLevel.UrlConfirm => "url_confirm",
+        ApprovalLevel.Deny => "deny",
+        _ => level.ToString().ToLowerInvariant(),
+    };
+
     internal static string RedactUrl(string url)
     {
         const int maxLen = 80;

--- a/dotnet/src/LightningEnable.Mcp/Tools/GetReceiptsTool.cs
+++ b/dotnet/src/LightningEnable.Mcp/Tools/GetReceiptsTool.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using LightningEnable.Mcp.Services;
+using ModelContextProtocol.Server;
+
+namespace LightningEnable.Mcp.Tools;
+
+/// <summary>
+/// Reads the durable, append-only payment receipt log
+/// (<c>~/.lightning-enable/receipts.jsonl</c>) — the human-facing spend +
+/// revocation record. Off the agent's hot path: rapid flows log to the file;
+/// this tool is how a human (or the agent, on request) reviews what was spent
+/// and how to revoke.
+/// </summary>
+[McpServerToolType]
+public static class GetReceiptsTool
+{
+    [McpServerTool(Name = "get_receipts"), Description(
+        "Read the durable, append-only payment receipt log (~/.lightning-enable/receipts.jsonl). "
+        + "Unlike get_payment_history (in-memory, this session only), receipts persist across sessions "
+        + "and include the spend policy and how to revoke the wallet. Use to review what an agent has "
+        + "spent and how to pull the plug.")]
+    public static string GetReceipts(
+        [Description("Maximum number of recent receipts to return (1-200). Default 20.")] int limit = 20,
+        IReceiptService? receiptService = null)
+    {
+        if (receiptService == null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = "Receipt logging is not available (no wallet/session initialized)."
+            });
+        }
+
+        limit = Math.Clamp(limit, 1, 200);
+        var receipts = receiptService.ReadRecent(limit);
+
+        long totalSats = 0;
+        foreach (var r in receipts)
+        {
+            if (r is JsonObject o
+                && o.TryGetPropertyValue("amountSats", out var a) && a != null
+                && long.TryParse(a.ToString(), out var v))
+            {
+                totalSats += v;
+            }
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            success = true,
+            count = receipts.Count,
+            totalSatsInView = totalSats,
+            logFile = receiptService.Path,
+            receipts,
+            note = "Append-only spend log — one payment receipt per line. Each includes how to revoke the wallet."
+        });
+    }
+}

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/ReceiptServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/ReceiptServiceTests.cs
@@ -17,7 +17,7 @@ public class ReceiptServiceTests
     public void LogPayment_ThenRead_Roundtrips()
     {
         var svc = new ReceiptService(TempReceiptsPath());
-        svc.LogPayment("NWC", "https://api.example.com/x", 1, "AutoApprove", 1, 149.0m);
+        svc.LogPayment("NWC", "https://api.example.com/x", 1, "auto_approve", 1);
 
         var recs = svc.ReadRecent(20);
         recs.Should().HaveCount(1);
@@ -25,9 +25,11 @@ public class ReceiptServiceTests
         o["type"]!.GetValue<string>().Should().Be("l402_payment_receipt");
         o["amountSats"]!.GetValue<long>().Should().Be(1);
         o["wallet"]!.GetValue<string>().Should().Be("NWC");
-        o["policy"]!.GetValue<string>().Should().Be("AutoApprove");
+        o["policy"]!.GetValue<string>().Should().Be("auto_approve");
         o["sessionSpentSats"]!.GetValue<long>().Should().Be(1);
         o["revokePath"]!.GetValue<string>().ToLowerInvariant().Should().Contain("connection");
+        // canonical millisecond Z timestamp (parity with Python)
+        o["timestamp"]!.GetValue<string>().Should().EndWith("Z");
     }
 
     [Fact]
@@ -35,7 +37,7 @@ public class ReceiptServiceTests
     {
         var path = TempReceiptsPath();
         var svc = new ReceiptService(path);
-        svc.LogPayment("NWC", "https://api.example.com/x", 1, "AutoApprove", null, null);
+        svc.LogPayment("NWC", "https://api.example.com/x", 1, "auto_approve", null);
 
         var raw = File.ReadAllText(path);
         foreach (var forbidden in new[] { "preimage", "macaroon", "nostr+walletconnect", "connectionString" })
@@ -46,11 +48,19 @@ public class ReceiptServiceTests
     public void ReadRecent_NewestLast_RespectsLimit()
     {
         var svc = new ReceiptService(TempReceiptsPath());
-        for (var i = 0; i < 5; i++) svc.LogPayment("NWC", $"https://e/{i}", i, "p", null, null);
+        for (var i = 0; i < 5; i++) svc.LogPayment("NWC", $"https://e/{i}", i, "p", null);
 
         var recs = svc.ReadRecent(2);
         recs.Should().HaveCount(2);
         recs[^1].AsObject()["amountSats"]!.GetValue<long>().Should().Be(4);
+    }
+
+    [Fact]
+    public void ReadRecent_ZeroLimit_IsEmpty()
+    {
+        var svc = new ReceiptService(TempReceiptsPath());
+        svc.LogPayment("NWC", "https://e", 1, "p", null);
+        svc.ReadRecent(0).Should().BeEmpty();
     }
 
     [Fact]
@@ -60,14 +70,39 @@ public class ReceiptServiceTests
     }
 
     [Fact]
-    public void ReadRecent_TornLine_IsSkipped()
+    public void ReadRecent_NonObjectLine_IsSkipped()
     {
         var path = TempReceiptsPath();
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllText(path, "{\"amountSats\":1}\nnot valid json\n{\"amountSats\":2}\n");
+        File.WriteAllText(path, "{\"amountSats\":1}\n42\n\"a string\"\n[1,2]\n{\"amountSats\":2}\n");
 
         var recs = new ReceiptService(path).ReadRecent(20);
         recs.Select(r => r.AsObject()["amountSats"]!.GetValue<long>()).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void ReadRecent_IncludesRotatedBackup()
+    {
+        var path = TempReceiptsPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path + ".1", "{\"amountSats\":1}\n{\"amountSats\":2}\n");
+        File.WriteAllText(path, "{\"amountSats\":3}\n");
+
+        var recs = new ReceiptService(path).ReadRecent(20);
+        recs.Select(r => r.AsObject()["amountSats"]!.GetValue<long>()).Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void Rotation_BoundsTheFile_AndPreservesHistoryInBackup()
+    {
+        var path = TempReceiptsPath();
+        // Tiny cap so a handful of appends trips rotation.
+        var svc = new ReceiptService(path, maxBytes: 120);
+        for (var i = 0; i < 30; i++) svc.LogPayment("NWC", $"https://e/{i}", i, "auto_approve", null);
+
+        File.Exists(path + ".1").Should().BeTrue("the live file must rotate to a .1 backup once past the cap");
+        // read merges backup + live, so recent history survives rotation
+        svc.ReadRecent(50).Should().NotBeEmpty();
     }
 
     [Fact]
@@ -80,7 +115,7 @@ public class ReceiptServiceTests
         File.WriteAllText(aFile, "x");
 
         var svc = new ReceiptService(Path.Combine(aFile, "sub", "receipts.jsonl"));
-        var act = () => svc.LogPayment("NWC", "https://e", 1, "p", null, null);
+        var act = () => svc.LogPayment("NWC", "https://e", 1, "p", null);
         act.Should().NotThrow();
     }
 
@@ -88,8 +123,8 @@ public class ReceiptServiceTests
     public void GetReceiptsTool_Summarizes()
     {
         var svc = new ReceiptService(TempReceiptsPath());
-        svc.LogPayment("NWC", "https://e/1", 2, "AutoApprove", null, null);
-        svc.LogPayment("NWC", "https://e/2", 3, "AutoApprove", null, null);
+        svc.LogPayment("NWC", "https://e/1", 2, "auto_approve", null);
+        svc.LogPayment("NWC", "https://e/2", 3, "auto_approve", null);
 
         var json = JsonDocument.Parse(GetReceiptsTool.GetReceipts(limit: 10, receiptService: svc)).RootElement;
         json.GetProperty("success").GetBoolean().Should().BeTrue();

--- a/dotnet/tests/LightningEnable.Mcp.Tests/Services/ReceiptServiceTests.cs
+++ b/dotnet/tests/LightningEnable.Mcp.Tests/Services/ReceiptServiceTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using FluentAssertions;
+using LightningEnable.Mcp.Services;
+using LightningEnable.Mcp.Tools;
+
+namespace LightningEnable.Mcp.Tests.Services;
+
+/// <summary>
+/// Tests for the durable payment receipt log (ReceiptService) + get_receipts tool.
+/// </summary>
+public class ReceiptServiceTests
+{
+    private static string TempReceiptsPath() =>
+        Path.Combine(Path.GetTempPath(), "le-receipts-tests", Guid.NewGuid().ToString("N"), "receipts.jsonl");
+
+    [Fact]
+    public void LogPayment_ThenRead_Roundtrips()
+    {
+        var svc = new ReceiptService(TempReceiptsPath());
+        svc.LogPayment("NWC", "https://api.example.com/x", 1, "AutoApprove", 1, 149.0m);
+
+        var recs = svc.ReadRecent(20);
+        recs.Should().HaveCount(1);
+        var o = recs[0].AsObject();
+        o["type"]!.GetValue<string>().Should().Be("l402_payment_receipt");
+        o["amountSats"]!.GetValue<long>().Should().Be(1);
+        o["wallet"]!.GetValue<string>().Should().Be("NWC");
+        o["policy"]!.GetValue<string>().Should().Be("AutoApprove");
+        o["sessionSpentSats"]!.GetValue<long>().Should().Be(1);
+        o["revokePath"]!.GetValue<string>().ToLowerInvariant().Should().Contain("connection");
+    }
+
+    [Fact]
+    public void Receipt_CarriesNoSecrets()
+    {
+        var path = TempReceiptsPath();
+        var svc = new ReceiptService(path);
+        svc.LogPayment("NWC", "https://api.example.com/x", 1, "AutoApprove", null, null);
+
+        var raw = File.ReadAllText(path);
+        foreach (var forbidden in new[] { "preimage", "macaroon", "nostr+walletconnect", "connectionString" })
+            raw.Should().NotContain(forbidden);
+    }
+
+    [Fact]
+    public void ReadRecent_NewestLast_RespectsLimit()
+    {
+        var svc = new ReceiptService(TempReceiptsPath());
+        for (var i = 0; i < 5; i++) svc.LogPayment("NWC", $"https://e/{i}", i, "p", null, null);
+
+        var recs = svc.ReadRecent(2);
+        recs.Should().HaveCount(2);
+        recs[^1].AsObject()["amountSats"]!.GetValue<long>().Should().Be(4);
+    }
+
+    [Fact]
+    public void ReadRecent_MissingFile_IsEmpty()
+    {
+        new ReceiptService(TempReceiptsPath()).ReadRecent(20).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReadRecent_TornLine_IsSkipped()
+    {
+        var path = TempReceiptsPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "{\"amountSats\":1}\nnot valid json\n{\"amountSats\":2}\n");
+
+        var recs = new ReceiptService(path).ReadRecent(20);
+        recs.Select(r => r.AsObject()["amountSats"]!.GetValue<long>()).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void LogPayment_WriteFailure_NeverThrows()
+    {
+        // Parent path is a FILE, so the directory create/append fails — must be swallowed.
+        var dir = Path.Combine(Path.GetTempPath(), "le-receipts-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var aFile = Path.Combine(dir, "afile");
+        File.WriteAllText(aFile, "x");
+
+        var svc = new ReceiptService(Path.Combine(aFile, "sub", "receipts.jsonl"));
+        var act = () => svc.LogPayment("NWC", "https://e", 1, "p", null, null);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void GetReceiptsTool_Summarizes()
+    {
+        var svc = new ReceiptService(TempReceiptsPath());
+        svc.LogPayment("NWC", "https://e/1", 2, "AutoApprove", null, null);
+        svc.LogPayment("NWC", "https://e/2", 3, "AutoApprove", null, null);
+
+        var json = JsonDocument.Parse(GetReceiptsTool.GetReceipts(limit: 10, receiptService: svc)).RootElement;
+        json.GetProperty("success").GetBoolean().Should().BeTrue();
+        json.GetProperty("count").GetInt32().Should().Be(2);
+        json.GetProperty("totalSatsInView").GetInt64().Should().Be(5);
+        json.GetProperty("logFile").GetString().Should().EndWith("receipts.jsonl");
+    }
+
+    [Fact]
+    public void GetReceiptsTool_NoService_ReturnsUnavailable()
+    {
+        var json = JsonDocument.Parse(GetReceiptsTool.GetReceipts(receiptService: null)).RootElement;
+        json.GetProperty("success").GetBoolean().Should().BeFalse();
+    }
+}

--- a/python/lightning-enable-mcp/pyproject.toml
+++ b/python/lightning-enable-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lightning-enable-mcp"
-version = "1.13.0"
+version = "1.14.0"
 description = "Part of Lightning Enable — infrastructure for agent commerce over Lightning. MCP server for L402 Lightning payments, API discovery, and agent commerce."
 readme = "README.md"
 license = "MIT"

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/l402_client.py
@@ -399,9 +399,15 @@ class L402Client:
             )
 
             if response.status_code >= 400:
-                raise L402Error(
+                # The invoice was already paid (preimage obtained) but the authorized
+                # retry failed. Surface the settled amount on the error so the caller
+                # can still record this real spend (budget / history / receipt) instead
+                # of silently losing it.
+                err = L402Error(
                     f"Request failed after payment: {response.status_code} {response.text[:200]}"
                 )
+                err.amount_paid = challenge.amount_sats
+                raise err
 
             return response.text, challenge.amount_sats
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/receipt_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/receipt_service.py
@@ -23,6 +23,12 @@ from typing import Optional
 
 logger = logging.getLogger("lightning-enable-mcp.receipts")
 
+
+def _utc_now_iso() -> str:
+    """UTC timestamp, canonical millisecond-precision Z form (matches the .NET side)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
 RECEIPTS_FILENAME = "receipts.jsonl"
 
 # Bound disk use: rotate to a single ``.1`` backup once the live file passes this
@@ -71,7 +77,6 @@ class ReceiptService:
         amount_sats: int,
         policy: str,
         session_spent_sats: Optional[int] = None,
-        session_remaining_usd: Optional[float] = None,
         kind: str = "l402_payment_receipt",
     ) -> None:
         """Append one payment receipt. Best-effort — never raises into the payment path.
@@ -80,37 +85,47 @@ class ReceiptService:
         """
         receipt = {
             "type": kind,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": _utc_now_iso(),
             "endpoint": endpoint,
             "amountSats": amount_sats,
             "wallet": self._wallet_label,
             "policy": policy,
+            # Post-payment session total (session_remaining is intentionally omitted:
+            # deriving it consistently across runtimes was error-prone — spentSats is
+            # the accurate, unambiguous figure).
             "sessionSpentSats": session_spent_sats,
-            "sessionRemainingUsd": session_remaining_usd,
             "revokePath": _REVOKE_PATHS.get(self._wallet_label, _REVOKE_DEFAULT),
         }
         self._append(receipt)
 
     def read_recent(self, limit: int = 20) -> list[dict]:
         """Return the most recent receipts (newest last). Tolerant of a missing/partial file."""
-        try:
-            if not self._path.exists():
-                return []
-            with open(self._path, "r", encoding="utf-8") as f:
-                lines = f.readlines()
-        except Exception as e:  # pragma: no cover - defensive
-            logger.warning("Failed to read receipts: %s", e)
+        if limit <= 0:
             return []
 
+        # Read the rotated ".1" backup first (older) then the live file (newer), so a
+        # read right after a rotation still returns recent history rather than the
+        # near-empty fresh file.
+        lines: list[str] = []
+        for p in (self._path.with_name(self._path.name + ".1"), self._path):
+            try:
+                if p.exists():
+                    with open(p, "r", encoding="utf-8") as f:
+                        lines.extend(f.readlines())
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning("Failed to read receipts from %s: %s", p, e)
+
         out: list[dict] = []
-        for line in lines[-max(0, limit):]:
+        for line in lines[-limit:]:
             line = line.strip()
             if not line:
                 continue
             try:
-                out.append(json.loads(line))
+                obj = json.loads(line)
             except Exception:
                 continue  # skip a torn/partial line rather than fail the whole read
+            if isinstance(obj, dict):  # skip non-object lines (hand-edits / interleaved appends)
+                out.append(obj)
         return out
 
     # ---- internals ----

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/receipt_service.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/receipt_service.py
@@ -1,0 +1,144 @@
+"""
+Receipt Service
+
+Append-only, human-readable spend receipts written to
+``~/.lightning-enable/receipts.jsonl`` — one JSON object per line.
+
+This is the DURABLE audit + revocation record that the in-memory
+``PaymentHistoryService`` is not: it survives the session and lives off the
+agent's context path, so rapid machine-to-machine / agent-to-agent flows don't
+pay a per-payment token cost for it. Tool results stay lean; the human/operator
+reads the file (or the ``get_receipts`` tool) for the full record.
+
+Never contains secrets — no preimage, macaroon, or wallet connection string
+(engineering standard #5). ``revokePath`` is *instructions*, not credentials.
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("lightning-enable-mcp.receipts")
+
+RECEIPTS_FILENAME = "receipts.jsonl"
+
+# Bound disk use: rotate to a single ``.1`` backup once the live file passes this
+# size, so the log is self-limiting (~2x this cap total) without per-write trims.
+MAX_RECEIPTS_BYTES = 5 * 1024 * 1024  # 5 MB
+
+# Per-wallet revocation instructions. Instructions only — never the connection
+# string / key itself.
+_REVOKE_PATHS = {
+    "NWC": "Your NWC wallet app (CoinOS / Alby Hub / CLINK) → Connections / Nostr Wallet Connect → delete this connection.",
+    "Strike": "Strike dashboard (dashboard.strike.me) → API keys → revoke the key this agent uses.",
+    "LND": "Your LND node → bake a new macaroon and revoke/rotate the one this client uses.",
+    "OpenNode": "OpenNode dashboard → Integrations / API keys → revoke the key this agent uses.",
+}
+_REVOKE_DEFAULT = "Revoke this wallet's connection or API key in its own app/dashboard."
+
+
+def wallet_label_from(wallet) -> str:
+    """Map a wallet instance to a short provider label (NWC / Strike / LND / OpenNode)."""
+    if wallet is None:
+        return "unknown"
+    name = type(wallet).__name__
+    return {
+        "NWCWallet": "NWC",
+        "StrikeWallet": "Strike",
+        "LndWallet": "LND",
+        "OpenNodeWallet": "OpenNode",
+    }.get(name, name.replace("Wallet", "") or "unknown")
+
+
+class ReceiptService:
+    """Writes and reads append-only payment receipts."""
+
+    def __init__(self, wallet_label: str = "unknown", receipts_path: Optional[Path] = None):
+        self._wallet_label = wallet_label or "unknown"
+        self._path = receipts_path or (Path.home() / ".lightning-enable" / RECEIPTS_FILENAME)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def log_payment(
+        self,
+        *,
+        endpoint: str,
+        amount_sats: int,
+        policy: str,
+        session_spent_sats: Optional[int] = None,
+        session_remaining_usd: Optional[float] = None,
+        kind: str = "l402_payment_receipt",
+    ) -> None:
+        """Append one payment receipt. Best-effort — never raises into the payment path.
+
+        ``endpoint`` MUST already be redacted by the caller (no query/secrets).
+        """
+        receipt = {
+            "type": kind,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "endpoint": endpoint,
+            "amountSats": amount_sats,
+            "wallet": self._wallet_label,
+            "policy": policy,
+            "sessionSpentSats": session_spent_sats,
+            "sessionRemainingUsd": session_remaining_usd,
+            "revokePath": _REVOKE_PATHS.get(self._wallet_label, _REVOKE_DEFAULT),
+        }
+        self._append(receipt)
+
+    def read_recent(self, limit: int = 20) -> list[dict]:
+        """Return the most recent receipts (newest last). Tolerant of a missing/partial file."""
+        try:
+            if not self._path.exists():
+                return []
+            with open(self._path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Failed to read receipts: %s", e)
+            return []
+
+        out: list[dict] = []
+        for line in lines[-max(0, limit):]:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except Exception:
+                continue  # skip a torn/partial line rather than fail the whole read
+        return out
+
+    # ---- internals ----
+
+    def _append(self, receipt: dict) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._rotate_if_needed()
+            is_new = not self._path.exists()
+            with open(self._path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(receipt) + "\n")
+            if is_new:
+                self._restrict_perms()
+        except Exception as e:
+            # A receipt is an audit convenience — it must NEVER break a payment.
+            logger.warning("Failed to write payment receipt: %s", e)
+
+    def _rotate_if_needed(self) -> None:
+        try:
+            if self._path.exists() and self._path.stat().st_size > MAX_RECEIPTS_BYTES:
+                backup = self._path.with_name(self._path.name + ".1")
+                os.replace(self._path, backup)  # atomically replaces any old backup
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Receipt log rotation failed: %s", e)
+
+    def _restrict_perms(self) -> None:
+        try:
+            from .config import _restrict_file_permissions
+            _restrict_file_permissions(self._path)
+        except Exception:  # pragma: no cover - best effort, mirrors config.json
+            pass

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -91,7 +91,10 @@ class LightningEnableServer:
         self.l402_client: L402Client | None = None
         self.budget_service: BudgetService | None = None  # Single source of truth for limits
         self.payment_history_service: PaymentHistoryService | None = None  # Session audit trail
-        self.receipt_service: ReceiptService | None = None  # Durable spend receipts (~/.lightning-enable/receipts.jsonl)
+        # Always available so get_receipts can read the durable log even without a
+        # wallet configured (the "pull the plug" audit moment). The wallet label is
+        # upgraded from "unknown" once a wallet is initialized (used only on write).
+        self.receipt_service: ReceiptService | None = ReceiptService(wallet_label="unknown")
         self._nwc_config: NWCConfig | None = None  # Store NWC config for pubkey access
         self.api_client: LightningEnableApiClient | None = None  # For L402 producer tools
 

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/server.py
@@ -31,6 +31,8 @@ from .opennode_wallet import OpenNodeWallet
 from .strike_wallet import StrikeWallet
 from .tools.access_resource import access_l402_resource
 from .tools.test_l402_payment import test_l402_payment
+from .tools.get_receipts import get_receipts
+from .receipt_service import ReceiptService, wallet_label_from
 from .tools.check_invoice_status import check_invoice_status
 from .tools.confirm_payment import confirm_payment
 from .tools.create_invoice import create_invoice
@@ -89,6 +91,7 @@ class LightningEnableServer:
         self.l402_client: L402Client | None = None
         self.budget_service: BudgetService | None = None  # Single source of truth for limits
         self.payment_history_service: PaymentHistoryService | None = None  # Session audit trail
+        self.receipt_service: ReceiptService | None = None  # Durable spend receipts (~/.lightning-enable/receipts.jsonl)
         self._nwc_config: NWCConfig | None = None  # Store NWC config for pubkey access
         self.api_client: LightningEnableApiClient | None = None  # For L402 producer tools
 
@@ -218,6 +221,26 @@ class LightningEnableServer:
                             "since": {
                                 "type": "string",
                                 "description": "ISO timestamp to filter payments from",
+                            },
+                        },
+                    },
+                ),
+                Tool(
+                    name="get_receipts",
+                    description=(
+                        "Read the durable, append-only payment receipt log "
+                        "(~/.lightning-enable/receipts.jsonl). Unlike get_payment_history "
+                        "(in-memory, this session only), receipts persist across sessions and "
+                        "include the spend policy and how to revoke the wallet. Use to review "
+                        "what an agent has spent and how to pull the plug."
+                    ),
+                    inputSchema={
+                        "type": "object",
+                        "properties": {
+                            "limit": {
+                                "type": "integer",
+                                "description": "Maximum number of recent receipts to return (1-200)",
+                                "default": 20,
                             },
                         },
                     },
@@ -730,7 +753,12 @@ class LightningEnableServer:
                 # return its own structured no_wallet verdict (parity with .NET), instead
                 # of this generic guard string (which also wrongly suggests OpenNode, which
                 # cannot do L402).
-                if self.wallet is None and name not in producer_tools and name != "test_l402_payment":
+                if (
+                    self.wallet is None
+                    and name not in producer_tools
+                    and name != "test_l402_payment"
+                    and name != "get_receipts"  # reads the durable log; no wallet needed
+                ):
                     return [
                         TextContent(
                             type="text",
@@ -752,6 +780,13 @@ class LightningEnableServer:
                         l402_client=self.l402_client,
                         budget_service=self.budget_service,
                         payment_history_service=self.payment_history_service,
+                        receipt_service=self.receipt_service,
+                    )
+
+                elif name == "get_receipts":
+                    result = await get_receipts(
+                        limit=arguments.get("limit", 20),
+                        receipt_service=self.receipt_service,
                     )
 
                 elif name == "test_l402_payment":
@@ -1081,6 +1116,10 @@ class LightningEnableServer:
 
             # Initialize the PaymentHistoryService (separate session audit trail).
             self.payment_history_service = get_payment_history_service()
+
+            # Durable, append-only spend receipts (off the agent's context path).
+            # Wallet label is fixed for the session, so bake it in at init.
+            self.receipt_service = ReceiptService(wallet_label=wallet_label_from(self.wallet))
 
             # Initialize L402 client
             self.l402_client = L402Client(wallet=self.wallet)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/access_resource.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/access_resource.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ..budget_service import BudgetService
     from ..payment_history_service import PaymentHistoryService
     from ..l402_client import L402Client
+    from ..receipt_service import ReceiptService
 
 from ..config import ApprovalLevel
 from . import sanitize_error
@@ -60,6 +61,7 @@ async def access_l402_resource(
     l402_client: "L402Client | None" = None,
     budget_service: "BudgetService | None" = None,
     payment_history_service: "PaymentHistoryService | None" = None,
+    receipt_service: "ReceiptService | None" = None,
 ) -> str:
     """
     Fetch a URL with automatic L402 payment handling.
@@ -97,12 +99,17 @@ async def access_l402_resource(
     if method not in ("GET", "POST", "PUT", "DELETE"):
         return f"Error: Invalid HTTP method: {method}"
 
+    # Captured for the durable receipt (success path). Overwritten with the real
+    # approval tier once the budget check runs.
+    payment_policy = "auto (no budget check)"
+
     try:
         # BudgetService is the single source of truth for spending limits + the
         # out-of-band confirmation flow.
         if budget_service:
             # Check approval level using new multi-tier system
             result = await budget_service.check_approval_level(max_sats)
+            payment_policy = getattr(result.level, "value", str(result.level))
 
             if result.level == ApprovalLevel.DENY:
                 return json.dumps({
@@ -210,6 +217,16 @@ async def access_l402_resource(
                     url=_redact_url_for_display(url),
                     amount_sats=amount_paid,
                     status="success",
+                )
+
+            # Durable, off-context-path spend receipt (redacted endpoint, no secrets).
+            if receipt_service is not None:
+                receipt_service.log_payment(
+                    endpoint=_redact_url_for_display(url),
+                    amount_sats=amount_paid,
+                    policy=payment_policy,
+                    session_spent_sats=(session_info or {}).get("spentSats"),
+                    session_remaining_usd=(session_info or {}).get("remainingUsd"),
                 )
 
         # Format response

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/access_resource.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/access_resource.py
@@ -220,14 +220,18 @@ async def access_l402_resource(
                 )
 
             # Durable, off-context-path spend receipt (redacted endpoint, no secrets).
+            # Best-effort — a receipt failure must NEVER turn a settled payment into
+            # an error result (which a caller might retry, double-paying).
             if receipt_service is not None:
-                receipt_service.log_payment(
-                    endpoint=_redact_url_for_display(url),
-                    amount_sats=amount_paid,
-                    policy=payment_policy,
-                    session_spent_sats=(session_info or {}).get("spentSats"),
-                    session_remaining_usd=(session_info or {}).get("remainingUsd"),
-                )
+                try:
+                    receipt_service.log_payment(
+                        endpoint=_redact_url_for_display(url),
+                        amount_sats=amount_paid,
+                        policy=payment_policy,
+                        session_spent_sats=(session_info or {}).get("spentSats"),
+                    )
+                except Exception:
+                    logger.warning("Receipt logging failed (payment already settled)")
 
         # Format response
         result = {
@@ -248,6 +252,38 @@ async def access_l402_resource(
 
     except Exception as e:
         logger.exception(f"Error accessing {_redact_url_for_display(url)}")
+
+        # Paid-but-retry-failed (store split-flow): the invoice settled — money left the
+        # wallet — even though the resource retry failed. Record the real spend so the
+        # budget/history/receipt don't silently omit it (parity with the .NET runtime).
+        # Best-effort; never mask the original error.
+        amount_paid = getattr(e, "amount_paid", None)
+        if amount_paid:
+            try:
+                if budget_service:
+                    budget_service.record_spend(amount_paid)
+                    budget_service.record_payment_time()
+                if payment_history_service:
+                    payment_history_service.record_payment(
+                        url=_redact_url_for_display(url),
+                        amount_sats=amount_paid,
+                        status="paid_retry_failed",
+                    )
+                if receipt_service is not None:
+                    spent = None
+                    if budget_service:
+                        try:
+                            spent = budget_service.get_status()["session"]["spentSats"]
+                        except Exception:
+                            spent = None
+                    receipt_service.log_payment(
+                        endpoint=_redact_url_for_display(url),
+                        amount_sats=amount_paid,
+                        policy=payment_policy,
+                        session_spent_sats=spent,
+                    )
+            except Exception:
+                logger.warning("Failed to record paid-but-retry-failed spend")
 
         error_result = {
             "success": False,

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/get_receipts.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/get_receipts.py
@@ -1,0 +1,44 @@
+"""
+Get Receipts Tool
+
+Reads the durable, append-only payment receipt log
+(``~/.lightning-enable/receipts.jsonl``) — the human-facing spend + revocation
+record. Off the agent's hot path: rapid flows log to the file; this tool is how a
+human (or the agent, on request) reviews what was spent and how to revoke.
+"""
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..receipt_service import ReceiptService
+
+
+async def get_receipts(
+    limit: int = 20,
+    receipt_service: "ReceiptService | None" = None,
+) -> str:
+    """Return the most recent payment receipts from the durable log."""
+    if receipt_service is None:
+        return json.dumps({
+            "success": False,
+            "error": "Receipt logging is not available (no wallet/session initialized).",
+        })
+
+    # Clamp the window so a huge request can't be used to dump an unbounded read.
+    try:
+        limit = max(1, min(int(limit), 200))
+    except (TypeError, ValueError):
+        limit = 20
+
+    receipts = receipt_service.read_recent(limit)
+    total_sats = sum((r.get("amountSats") or 0) for r in receipts)
+
+    return json.dumps({
+        "success": True,
+        "count": len(receipts),
+        "totalSatsInView": total_sats,
+        "logFile": str(receipt_service.path),
+        "receipts": receipts,
+        "note": "Append-only spend log — one payment receipt per line. Each includes how to revoke the wallet.",
+    }, indent=2)

--- a/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/get_receipts.py
+++ b/python/lightning-enable-mcp/src/lightning_enable_mcp/tools/get_receipts.py
@@ -32,7 +32,15 @@ async def get_receipts(
         limit = 20
 
     receipts = receipt_service.read_recent(limit)
-    total_sats = sum((r.get("amountSats") or 0) for r in receipts)
+    # read_recent returns only dicts; still coerce defensively so a stray non-numeric
+    # amountSats (hand-edit / format drift) can never crash the whole read.
+    total_sats = 0
+    for r in receipts:
+        v = r.get("amountSats")
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)):
+            total_sats += int(v)
 
     return json.dumps({
         "success": True,

--- a/python/lightning-enable-mcp/tests/test_receipts.py
+++ b/python/lightning-enable-mcp/tests/test_receipts.py
@@ -1,0 +1,128 @@
+"""Tests for the durable payment receipt log (ReceiptService) + get_receipts tool."""
+
+import json
+
+import pytest
+
+from lightning_enable_mcp.receipt_service import ReceiptService, wallet_label_from
+from lightning_enable_mcp.tools.get_receipts import get_receipts
+
+
+def _svc(tmp_path, label="NWC"):
+    return ReceiptService(wallet_label=label, receipts_path=tmp_path / "receipts.jsonl")
+
+
+def test_log_and_read_roundtrip(tmp_path):
+    svc = _svc(tmp_path)
+    svc.log_payment(
+        endpoint="https://api.example.com/x",
+        amount_sats=1,
+        policy="auto_approve",
+        session_spent_sats=1,
+        session_remaining_usd=149.0,
+    )
+    recs = svc.read_recent()
+    assert len(recs) == 1
+    r = recs[0]
+    assert r["type"] == "l402_payment_receipt"
+    assert r["amountSats"] == 1
+    assert r["wallet"] == "NWC"
+    assert r["policy"] == "auto_approve"
+    assert r["endpoint"] == "https://api.example.com/x"
+    assert r["sessionSpentSats"] == 1
+    assert "connection" in r["revokePath"].lower()
+
+
+def test_receipt_carries_no_secrets(tmp_path):
+    svc = _svc(tmp_path)
+    svc.log_payment(endpoint="https://api.example.com/x", amount_sats=1, policy="auto_approve")
+    raw = (tmp_path / "receipts.jsonl").read_text(encoding="utf-8")
+    for forbidden in ("preimage", "macaroon", "nostr+walletconnect", "connectionString", "secret="):
+        assert forbidden not in raw
+
+
+def test_append_preserves_order(tmp_path):
+    svc = _svc(tmp_path)
+    for i in range(1, 4):
+        svc.log_payment(endpoint=f"https://e/{i}", amount_sats=i, policy="auto_approve")
+    assert [r["amountSats"] for r in svc.read_recent()] == [1, 2, 3]
+
+
+def test_read_recent_returns_newest_last_and_respects_limit(tmp_path):
+    svc = _svc(tmp_path)
+    for i in range(5):
+        svc.log_payment(endpoint=f"https://e/{i}", amount_sats=i, policy="p")
+    recs = svc.read_recent(limit=2)
+    assert len(recs) == 2
+    assert recs[-1]["amountSats"] == 4
+
+
+def test_read_missing_file_is_empty(tmp_path):
+    svc = ReceiptService(wallet_label="NWC", receipts_path=tmp_path / "nope.jsonl")
+    assert svc.read_recent() == []
+
+
+def test_read_tolerates_torn_line(tmp_path):
+    p = tmp_path / "receipts.jsonl"
+    p.write_text('{"amountSats": 1}\nnot valid json\n{"amountSats": 2}\n', encoding="utf-8")
+    svc = ReceiptService(wallet_label="NWC", receipts_path=p)
+    assert [r["amountSats"] for r in svc.read_recent()] == [1, 2]
+
+
+def test_rotation_bounds_the_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("lightning_enable_mcp.receipt_service.MAX_RECEIPTS_BYTES", 120)
+    svc = _svc(tmp_path)
+    for i in range(20):
+        svc.log_payment(endpoint=f"https://e/{i}", amount_sats=i, policy="auto_approve")
+    # once past the cap, the live file is rotated to a .1 backup
+    assert (tmp_path / "receipts.jsonl.1").exists()
+    # live file still readable and small
+    assert svc.read_recent()  # non-empty, current file
+
+
+def test_write_failure_never_raises(tmp_path):
+    # parent path is a FILE, so mkdir under it fails — must be swallowed.
+    a_file = tmp_path / "afile"
+    a_file.write_text("x", encoding="utf-8")
+    svc = ReceiptService(wallet_label="NWC", receipts_path=a_file / "sub" / "receipts.jsonl")
+    svc.log_payment(endpoint="https://e", amount_sats=1, policy="p")  # must not raise
+    assert svc.read_recent() == []
+
+
+def test_wallet_label_from():
+    class NWCWallet:  # noqa: N801 - mirrors real class name for the mapping
+        pass
+
+    class StrikeWallet:  # noqa: N801
+        pass
+
+    assert wallet_label_from(NWCWallet()) == "NWC"
+    assert wallet_label_from(StrikeWallet()) == "Strike"
+    assert wallet_label_from(None) == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_get_receipts_tool_summarizes(tmp_path):
+    svc = _svc(tmp_path)
+    svc.log_payment(endpoint="https://e/1", amount_sats=2, policy="auto_approve")
+    svc.log_payment(endpoint="https://e/2", amount_sats=3, policy="auto_approve")
+    out = json.loads(await get_receipts(limit=10, receipt_service=svc))
+    assert out["success"] is True
+    assert out["count"] == 2
+    assert out["totalSatsInView"] == 5
+    assert out["logFile"].endswith("receipts.jsonl")
+    assert len(out["receipts"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_receipts_tool_no_service():
+    out = json.loads(await get_receipts(receipt_service=None))
+    assert out["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_receipts_clamps_limit(tmp_path):
+    svc = _svc(tmp_path)
+    svc.log_payment(endpoint="https://e", amount_sats=1, policy="p")
+    out = json.loads(await get_receipts(limit=99999, receipt_service=svc))
+    assert out["success"] is True  # huge limit clamped, no error

--- a/python/lightning-enable-mcp/tests/test_receipts.py
+++ b/python/lightning-enable-mcp/tests/test_receipts.py
@@ -19,7 +19,6 @@ def test_log_and_read_roundtrip(tmp_path):
         amount_sats=1,
         policy="auto_approve",
         session_spent_sats=1,
-        session_remaining_usd=149.0,
     )
     recs = svc.read_recent()
     assert len(recs) == 1
@@ -31,6 +30,32 @@ def test_log_and_read_roundtrip(tmp_path):
     assert r["endpoint"] == "https://api.example.com/x"
     assert r["sessionSpentSats"] == 1
     assert "connection" in r["revokePath"].lower()
+    # timestamp is the canonical millisecond Z form (parity with .NET)
+    assert r["timestamp"].endswith("Z")
+
+
+def test_read_recent_zero_or_negative_is_empty(tmp_path):
+    svc = _svc(tmp_path)
+    for i in range(3):
+        svc.log_payment(endpoint=f"https://e/{i}", amount_sats=i, policy="p")
+    assert svc.read_recent(0) == []
+    assert svc.read_recent(-5) == []
+
+
+def test_read_recent_skips_non_object_lines(tmp_path):
+    p = tmp_path / "receipts.jsonl"
+    p.write_text('{"amountSats": 1}\n42\n"a string"\n[1,2]\n{"amountSats": 2}\n', encoding="utf-8")
+    svc = ReceiptService(wallet_label="NWC", receipts_path=p)
+    assert [r["amountSats"] for r in svc.read_recent()] == [1, 2]
+
+
+def test_read_recent_includes_rotated_backup(tmp_path):
+    p = tmp_path / "receipts.jsonl"
+    p.with_name(p.name + ".1").write_text('{"amountSats": 1}\n{"amountSats": 2}\n', encoding="utf-8")
+    p.write_text('{"amountSats": 3}\n', encoding="utf-8")
+    svc = ReceiptService(wallet_label="NWC", receipts_path=p)
+    # backup (older) first, then live (newer)
+    assert [r["amountSats"] for r in svc.read_recent()] == [1, 2, 3]
 
 
 def test_receipt_carries_no_secrets(tmp_path):
@@ -126,3 +151,40 @@ async def test_get_receipts_clamps_limit(tmp_path):
     svc.log_payment(endpoint="https://e", amount_sats=1, policy="p")
     out = json.loads(await get_receipts(limit=99999, receipt_service=svc))
     assert out["success"] is True  # huge limit clamped, no error
+
+
+@pytest.mark.asyncio
+async def test_get_receipts_tolerates_bad_amount(tmp_path):
+    # A stray non-numeric amountSats must never crash the whole read.
+    p = tmp_path / "receipts.jsonl"
+    p.write_text('{"amountSats": "5"}\n{"amountSats": 3}\n', encoding="utf-8")
+    svc = ReceiptService(wallet_label="NWC", receipts_path=p)
+    out = json.loads(await get_receipts(limit=10, receipt_service=svc))
+    assert out["success"] is True
+    assert out["totalSatsInView"] == 3  # numeric one counted, string one skipped
+
+
+@pytest.mark.asyncio
+async def test_split_flow_paid_but_retry_failed_is_receipted(tmp_path):
+    # The wallet paid (preimage obtained) but the retry 500'd: overall failure, but
+    # the real spend must still be recorded in the receipt log.
+    from unittest.mock import AsyncMock
+    from lightning_enable_mcp.tools.access_resource import access_l402_resource
+    from lightning_enable_mcp.l402_client import L402Error
+
+    err = L402Error("Request failed after payment: 500 boom")
+    err.amount_paid = 7
+    client = AsyncMock()
+    client.fetch = AsyncMock(side_effect=err)
+
+    svc = _svc(tmp_path)
+    result = await access_l402_resource(
+        url="https://api.lightningenable.com/x",
+        l402_client=client,
+        receipt_service=svc,
+    )
+    data = json.loads(result)
+    assert data["success"] is False  # the request failed overall...
+    recs = svc.read_recent()          # ...but the spend was receipted
+    assert len(recs) == 1
+    assert recs[0]["amountSats"] == 7

--- a/python/lightning-enable-mcp/tests/test_server.py
+++ b/python/lightning-enable-mcp/tests/test_server.py
@@ -55,6 +55,7 @@ class TestLightningEnableServer:
             "pay_l402_challenge",
             "check_wallet_balance",
             "get_payment_history",
+            "get_receipts",
             "configure_budget",
             "pay_invoice",
             "create_invoice",
@@ -77,7 +78,7 @@ class TestLightningEnableServer:
         }
 
         assert tool_names == expected_tools
-        assert len(tool_names) == 24
+        assert len(tool_names) == 25
 
     @pytest.mark.asyncio
     async def test_services_not_initialized_without_nwc(self):


### PR DESCRIPTION
Implements the payment-receipt idea: an **append-only spend + revocation log** at `~/.lightning-enable/receipts.jsonl`, one JSON receipt per L402 payment.

## Design (per the discussion)
- **Every payment → the durable file** (cheap, off the agent's context path, so rapid m2m/a2a flows don't pay a per-payment token cost). **Tool results unchanged.**
- Each receipt: `type`, `timestamp`, redacted `endpoint`, `amountSats`, `wallet`, `policy` (the budget approval tier), `sessionSpentSats`, `sessionRemainingUsd`, `revokePath` (how to pull the plug).
- **Never contains secrets** — no preimage / macaroon / connection string. `revokePath` is instructions only. 0600 on POSIX.

## What's here
- `ReceiptService` (both packages): append-only JSONL, size-rotated to one `.1` backup, torn-line-tolerant reads, best-effort writes that **never break a payment**.
- `get_receipts` tool (both packages): review recent receipts + revoke instructions; works without a wallet.
- Hooked into the **`access_l402_resource`** path (the m2m/a2a L402 flow; also covers `test_l402_payment`). `pay_l402_challenge` / `pay_invoice` / on-chain are noted follow-ups.
- Version `1.13.0 → 1.14.0`; README tool counts `16→17` / `24→25`; `get_receipts` documented.

## Tests
.NET **303** pass (+8), Python **488** pass (+12): roundtrip, no-secrets, rotation, torn-line, write-failure-never-throws, the tool summary, and the no-service path.

Merging (touching csproj/pyproject) triggers the publish workflow → 1.14.0 to NuGet/PyPI/Docker/MCP Registry. Running `/code-review` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeVJ1dSozozhHDmNHiPj5f